### PR TITLE
Specify pipeline artifact name explicitly for each build configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,9 @@ stages:
           SourceFolder: 'bin/$(Configuration)'
           Contents: '**'
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
-      - task: PublishPipelineArtifact@1
+      - task: PublishBuildArtifacts@1
         condition: ne(variables['Build.Reason'], 'PullRequest')
         inputs:
-          targetPath: '$(Build.ArtifactStagingDirectory)'
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: '$(Configuration)_drop'
+          publishLocation: 'Container'


### PR DESCRIPTION
* Add displayname to each build step
* Specify pipeline artifact name because DownloadBuildArtifact task cannot find artifact name of cs-sdk build