### PR TITLE
Enable ESRP signing for dll and nupkg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,7 @@ stages:
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
       - task: CmdLine@2
         displayName: "Show ESRP signing result"
-        condition: eq(variables['Configuration'], 'release')
+        condition: and(eq(variables['Configuration'], 'release'), or(contains(variables['Build.SourceBranch'], 'refs/heads/master'), contains(variables['Build.SourceBranch'], 'refs/heads/release')))
         inputs:
           script: 'type *.md'
           workingDirectory: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
* Sign *.dll and *.nupkg files only for `master` and `release-*` branches