### PR TITLE
Add build tag for release-* branch build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,7 +169,7 @@ stages:
           publishLocation: 'Container'
       - task: CmdLine@2
         displayName: 'Add release tag for release branch'
-        condition: and(eq(variables['Configuration'], 'release'), contains(variables['Build.SourceBranch'], 'refs/heads/release-')))
+        condition: and(eq(variables['Configuration'], 'release'), contains(variables['Build.SourceBranch'], 'refs/heads/release-'))
         inputs:
           script: 'echo "##vso[build.addbuildtag]release"'
           workingDirectory: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
* Remove useless ESRP signing result because the result is showing in esrp signing task
* Add build tag for release-* branch build
* `release` tag will allow preview kit automation build definition to pick the binaries from release-* branch