### PR TITLE
Update Version to 0.6.0-preview01

### DIFF
--- a/properties/dapr_common.props
+++ b/properties/dapr_common.props
@@ -20,7 +20,7 @@
 
     <!-- Nuget package versions -->
     <NupkgMajorVersion>0</NupkgMajorVersion>
-    <NupkgMinorVersion>4</NupkgMinorVersion>
+    <NupkgMinorVersion>6</NupkgMinorVersion>
     <NupkgPatchVersion>0</NupkgPatchVersion>
     <NupkgPreviewTag>-preview01</NupkgPreviewTag>
     <NupkgVersion>$(NupkgMajorVersion).$(NupkgMinorVersion).$(NupkgPatchVersion)$(NupkgPreviewTag)</NupkgVersion>


### PR DESCRIPTION
* Update Version to 0.6.0-preview01

We missed the step to update the version to 0.5.0 on the last Friday when we released 0.5.0. Therefore, 0.6.0-preview01 is correct for the next version of sdk.
