### PR TITLE
Change the http app channel port env var to DAPR_HTTP_PORT

### DIFF
--- a/docs/get-started-dapr-actor.md
+++ b/docs/get-started-dapr-actor.md
@@ -389,7 +389,7 @@ In order to validate and debug actor service and client, we need to run actor se
 
    MyActorClient will console out if it calls actor hosted in MyActorService successfully.
 
-   > If you specify the different dapr runtime http port (default port: 3500), you need to set DAPR_PORT environment variable before running the client.
+   > If you specify the different dapr runtime http port (default port: 3500), you need to set DAPR_HTTP_PORT environment variable before running the client.
 
    ```bash
    Success

--- a/src/Microsoft.Dapr.Actors/Constants.cs
+++ b/src/Microsoft.Dapr.Actors/Constants.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Dapr.Actors
         public const string RequestIdHeaderName = "X-DaprRequestId";
         public const string RequestHeaderName = "X-DaprRequestHeader";
         public const string ErrorResponseHeaderName = "X-DaprErrorResponseHeader";
-        public const string DaprPortEnvironmentVariable = "DAPR_PORT";
+        public const string DaprHttpPortEnvironmentVariable = "DAPR_HTTP_PORT";
         public const string Dapr = "dapr";
         public const string Config = "config";
         public const string State = "state";

--- a/src/Microsoft.Dapr.Actors/DaprHttpInteractor.cs
+++ b/src/Microsoft.Dapr.Actors/DaprHttpInteractor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Dapr.Actors
             params DelegatingHandler[] delegateHandlers)
         {
             // Get Dapr port from Environment Variable if it has been overridden.
-            var daprPort = Environment.GetEnvironmentVariable(Constants.DaprPortEnvironmentVariable);
+            var daprPort = Environment.GetEnvironmentVariable(Constants.DaprHttpPortEnvironmentVariable);
             if (daprPort != null)
             {
                 this.daprPort = daprPort;

--- a/src/Microsoft.Dapr.Client/DaprUris.cs
+++ b/src/Microsoft.Dapr.Client/DaprUris.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Dapr
     {
         public const string StatePath = "/v1.0/state";
 
-        public static string DefaultPort => Environment.GetEnvironmentVariable("DAPR_PORT") ?? "3500";
+        public static string DefaultPort => Environment.GetEnvironmentVariable("DAPR_HTTP_PORT") ?? "3500";
     }
 }


### PR DESCRIPTION
With the grpc client support, we changed the environment variable from DAPR_PORT to DAPR_HTTP_PORT.