### PR TITLE
Updating sample which shows more calls with remoting.

### DIFF
--- a/samples/Actor/ActorClient/Program.cs
+++ b/samples/Actor/ActorClient/Program.cs
@@ -6,6 +6,7 @@
 namespace ActorClient
 {
     using System;
+    using System.Threading.Tasks;
     using Dapr.Actors;
     using Dapr.Actors.Client;
     using IDemoActorInterface;
@@ -21,6 +22,15 @@ namespace ActorClient
         /// <param name="args">Arguments.</param>
         public static void Main(string[] args)
         {
+            MakeActorCalls().GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// A wrapper method which make actual calls.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous save operation.</returns>
+        public static async Task MakeActorCalls()
+        {
             var data = new MyData()
             {
                 PropertyA = "ValueA",
@@ -34,10 +44,37 @@ namespace ActorClient
             // DemoACtor is the type registered with Dapr runtime in the service.
             var proxy = ActorProxy.Create<IDemoActor>(actorId, "DemoActor");
             Console.WriteLine("Making call using actor proxy to save data.");
-            proxy.SaveData(data).GetAwaiter().GetResult();
+            await proxy.SaveData(data);
             Console.WriteLine("Making call using actor proxy to get data.");
-            var receivedData = proxy.GetData().GetAwaiter().GetResult();
+            var receivedData = await proxy.GetData();
             Console.WriteLine($"Received data is {receivedData.ToString()}");
+
+            // Making some more calls to test methods.
+            try
+            {
+                Console.WriteLine("Making calls to an actor method which has no argument and no return type.");
+                await proxy.TestNoArgumentNoReturnType();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"ERROR: Got exception while making call to method with No Argument & No Return Type. Exception: {ex.ToString()}");
+            }
+
+            try
+            {
+                await proxy.TestThrowException();
+            }
+            catch (ActorMethodInvocationException ex)
+            {
+                if (ex.InnerException is NotImplementedException)
+                {
+                    Console.WriteLine($"Got Correct Exception from actor method invocation.");
+                }
+                else
+                {
+                    Console.WriteLine($"Got Incorrect Exception from actor method invocation. Exception {ex.InnerException.ToString()}");
+                }
+            }
         }
     }
 }

--- a/samples/Actor/DemoActor/DemoActor.cs
+++ b/samples/Actor/DemoActor/DemoActor.cs
@@ -33,13 +33,12 @@ namespace DaprDemoActor
         }
 
         /// <inheritdoc/>
-        public async Task<string> SaveData(MyData data)
+        public async Task SaveData(MyData data)
         {
             Console.WriteLine($"This is Actor id {this.Id}  with data {data.ToString()}");
 
             // Set State using StateManager, state is saved after the method execution.
             await this.StateManager.SetStateAsync<MyData>(StateName, data);
-            return "Success";
         }
 
         /// <inheritdoc/>
@@ -47,6 +46,18 @@ namespace DaprDemoActor
         {
             // Get state using StateManager.
             return this.StateManager.GetStateAsync<MyData>(StateName);
+        }
+
+        /// <inheritdoc/>
+        public Task TestThrowException()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public Task TestNoArgumentNoReturnType()
+        {
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc/>

--- a/samples/Actor/IDemoActor/IDemoActor.cs
+++ b/samples/Actor/IDemoActor/IDemoActor.cs
@@ -18,13 +18,25 @@ namespace IDemoActorInterface
         /// </summary>
         /// <param name="data">DAta to save.</param>
         /// <returns>A task that represents the asynchronous save operation.</returns>
-        Task<string> SaveData(MyData data);
+        Task SaveData(MyData data);
 
         /// <summary>
         /// Method to get data.
         /// </summary>
         /// <returns>A task that represents the asynchronous save operation.</returns>
         Task<MyData> GetData();
+
+        /// <summary>
+        /// A test method which throws exception.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous save operation.</returns>
+        Task TestThrowException();
+
+        /// <summary>
+        /// A test method which validates calls for methods with no arguments and no return types.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous save operation.</returns>
+        Task TestNoArgumentNoReturnType();
 
         /// <summary>
         /// Registers a reminder.


### PR DESCRIPTION
Updating sample which shows more calls with remoting for methods which throw exception & call to method with no return and arg.

This also covers the calls for methods with no return type as pointed in this issue: https://github.com/dapr/dotnet-sdk/issues/129