### PR TITLE
Make Stylecop.Analyzers a private dependency

### DIFF
--- a/properties/dapr_managed_stylecop.props
+++ b/properties/dapr_managed_stylecop.props
@@ -5,7 +5,7 @@
     <StylecopSuppressionsFile>$(MSBuildThisFileDirectory)stylecop\GlobalStylecopSuppressions.cs</StylecopSuppressionsFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="$(StylecopSettingsFile)" />


### PR DESCRIPTION
Fixes: #155

# Description

This will prevent Stylecop.Analyzers from being pulled in as a
dependency transitively.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #155

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests (n/a build-only change)
* [x] Extended the documentation (n/a build-only change)

Verified the generated nuspec:

**Before**

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Dapr.Client</id>
    <version>0.2.0-preview01</version>
    <authors>dapr.io</authors>
    <owners>dapr.io</owners>
    <requireLicenseAcceptance>true</requireLicenseAcceptance>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>images\logo-transparent.png</icon>
    <projectUrl>https://dapr.io/</projectUrl>
    <description>This package contains the reference assemblies for developing services using Dapr.</description>
    <copyright>Copyright (c) Microsoft Corporation.  All rights reserved.</copyright>
    <tags>Dapr</tags>
    <repository type="git" url="https://github.com/dapr/dotnet-sdk" />
    <dependencies>
      <group targetFramework=".NETCoreApp3.0">
        <dependency id="StyleCop.Analyzers" version="1.1.118" include="All" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="/Users/ryan/github.com/dapr/dotnet-sdk/bin/Debug/prod/Dapr.Client/Dapr.Client.dll" target="lib/netcoreapp3.0/Dapr.Client.dll" />
    <file src="/Users/ryan/github.com/dapr/dotnet-sdk/bin/Debug/prod/Dapr.Client/Dapr.Client.xml" target="lib/netcoreapp3.0/Dapr.Client.xml" />
    <file src="/Users/ryan/github.com/dapr/dotnet-sdk/properties/logo-transparent.png" target="images/logo-transparent.png" />
  </files>
</package>
```

**After**

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Dapr.Client</id>
    <version>0.2.0-preview01</version>
    <authors>dapr.io</authors>
    <owners>dapr.io</owners>
    <requireLicenseAcceptance>true</requireLicenseAcceptance>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <icon>images\logo-transparent.png</icon>
    <projectUrl>https://dapr.io/</projectUrl>
    <description>This package contains the reference assemblies for developing services using Dapr.</description>
    <copyright>Copyright (c) Microsoft Corporation.  All rights reserved.</copyright>
    <tags>Dapr</tags>
    <repository type="git" url="https://github.com/dapr/dotnet-sdk" />
    <dependencies>
      <group targetFramework=".NETCoreApp3.0" />
    </dependencies>
  </metadata>
  <files>
    <file src="/Users/ryan/github.com/dapr/dotnet-sdk/bin/Debug/prod/Dapr.Client/Dapr.Client.dll" target="lib/netcoreapp3.0/Dapr.Client.dll" />
    <file src="/Users/ryan/github.com/dapr/dotnet-sdk/bin/Debug/prod/Dapr.Client/Dapr.Client.xml" target="lib/netcoreapp3.0/Dapr.Client.xml" />
    <file src="/Users/ryan/github.com/dapr/dotnet-sdk/properties/logo-transparent.png" target="images/logo-transparent.png" />
  </files>
</package>
```
