### PR TITLE
Changing the application port to 5000 in launch settings

### DIFF
--- a/samples/Actor/DemoActor/Properties/launchSettings.json
+++ b/samples/Actor/DemoActor/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5001/"
+      "applicationUrl": "http://localhost:5000/"
     }
   }
 }

--- a/samples/Actor/Readme.md
+++ b/samples/Actor/Readme.md
@@ -29,10 +29,10 @@ Actor --- IDemoActor
 
  To run the actor service locally run this comment in DemoActor directory:
  ```sh
- dapr run --port 3500 --app-id demo_actor --app-port 5001 dotnet run
+ dapr run --port 3500 --app-id demo_actor --app-port 5000 dotnet run
  ```
 
- The actor service will listen on port 5001 for HTTP.
+ The actor service will listen on port 5000 for HTTP.
 
  ### Making Client calls.
  Actor Client project shows how to make client calls for actor using Remoting which provides a strongly typed invocation experience.


### PR DESCRIPTION
# Description

Changing the application port to 5000 in launch settings

## Issue reference

This change will always run the application on port 5000 be in development or production environment.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Updated the documentation
