### PR TITLE
Making stylecopanalyzers private dependency and updating version.

### DIFF
--- a/properties/dapr_common.props
+++ b/properties/dapr_common.props
@@ -19,7 +19,7 @@
     <NupkgMajorVersion>0</NupkgMajorVersion>
     <NupkgMinorVersion>2</NupkgMinorVersion>
     <NupkgPatchVersion>0</NupkgPatchVersion>
-    <NupkgPreviewTag>-preview01</NupkgPreviewTag>
+    <NupkgPreviewTag>-preview02</NupkgPreviewTag>
     <NupkgVersion>$(NupkgMajorVersion).$(NupkgMinorVersion).$(NupkgPatchVersion)$(NupkgPreviewTag)</NupkgVersion>
   </PropertyGroup>
   

--- a/properties/dapr_managed_stylecop.props
+++ b/properties/dapr_managed_stylecop.props
@@ -5,7 +5,7 @@
     <StylecopSuppressionsFile>$(MSBuildThisFileDirectory)stylecop\GlobalStylecopSuppressions.cs</StylecopSuppressionsFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="$(StylecopSettingsFile)" />


### PR DESCRIPTION
cherry-pick  fedfd4a50ae73bfa1f3ac5ffe6057cb65cb3a4aa (PR https://github.com/dapr/dotnet-sdk/pull/156) to release new nuget package for 0.2.0