### PR TITLE
Fix URL generation when BaseAddress is used

### DIFF
--- a/src/Dapr.Client/StateHttpClient.cs
+++ b/src/Dapr.Client/StateHttpClient.cs
@@ -54,7 +54,7 @@ namespace Dapr
                 throw new ArgumentException("The value cannot be null or empty.", nameof(key));
             }
 
-            var url = this.client.BaseAddress == null ? $"http://localhost:{DefaultHttpPort}{StatePath}/{key}" : $"{StatePath}{key}";
+            var url = this.client.BaseAddress == null ? $"http://localhost:{DefaultHttpPort}{StatePath}/{key}" : $"{StatePath}/{key}";
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var response = await this.client.SendAsync(request, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
We were missing tests for the case where the HttpClient has a
BaseAddress set. In these case we'd generate an incorrect URL.

Fixes: #192

# Description

Fixed #192 (add missing slash) and added unit tests

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #192

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation **N/A** this was a functional bug
