### PR TITLE
Get the integration tests to calm down

### DIFF
--- a/test/Dapr.AspNetCore.IntegrationTest/AppWebApplicationFactory.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest/AppWebApplicationFactory.cs
@@ -9,6 +9,7 @@ namespace Dapr.AspNetCore.IntegrationTest
     using Microsoft.AspNetCore.Mvc.Testing;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
 
     public class AppWebApplicationFactory : WebApplicationFactory<Startup>
     {
@@ -17,6 +18,10 @@ namespace Dapr.AspNetCore.IntegrationTest
         protected override IHostBuilder CreateHostBuilder()
         {
             var builder = base.CreateHostBuilder();
+            builder.ConfigureLogging(b =>
+            {
+                b.SetMinimumLevel(LogLevel.None);
+            });
             return builder.ConfigureServices((context, services) =>
             {
                 services.AddSingleton<StateClient>(this.StateClient);


### PR DESCRIPTION
Removes console spew when running the integration tests at the command
line

Fixes: #193

# Description

Disables logging for the test host created by integration tests. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #193

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests **N/A** no change to product
* [x] Extended the documentation **N/A** no change to product
