### PR TITLE
Serializing actor state as json by default.

### DIFF
--- a/src/Dapr.Actors/Runtime/ActorService.cs
+++ b/src/Dapr.Actors/Runtime/ActorService.cs
@@ -25,7 +25,7 @@ namespace Dapr.Actors.Runtime
         {
             this.ActorTypeInfo = actorTypeInfo;
             this.actorFactory = actorFactory ?? this.DefaultActorFactory;
-            this.StateProvider = new DaprStateProvider(new ActorStateProviderSerializer());
+            this.StateProvider = new DaprStateProvider();
         }
 
         /// <summary>

--- a/src/Dapr.Actors/Runtime/DataContractStateSerializer.cs
+++ b/src/Dapr.Actors/Runtime/DataContractStateSerializer.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------
+﻿// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // ------------------------------------------------------------
@@ -11,16 +11,22 @@ namespace Dapr.Actors.Runtime
     using System.Runtime.Serialization;
     using System.Xml;
 
-    internal class ActorStateProviderSerializer
+    /// <summary>
+    /// DataContract serializer for Actor state serialization/deserialziation.
+    /// This is the default state serializer used with Service Fabric Reliable Actors.
+    /// If there is user ask for the compatibility, this can be exposed by adding a compatibility option as an attribute on Actor type so that Service Fabric Reliable Actors state serialization behavior
+    /// can also be used using Dapr.
+    /// </summary>
+    internal class DataContractStateSerializer : IActorStateSerializer
     {
         private readonly ConcurrentDictionary<Type, DataContractSerializer> actorStateSerializerCache;
 
-        internal ActorStateProviderSerializer()
+        internal DataContractStateSerializer()
         {
             this.actorStateSerializerCache = new ConcurrentDictionary<Type, DataContractSerializer>();
         }
 
-        internal byte[] Serialize<T>(Type stateType, T state)
+        public byte[] Serialize<T>(Type stateType, T state)
         {
             var serializer = this.actorStateSerializerCache.GetOrAdd(
                 stateType,
@@ -33,7 +39,7 @@ namespace Dapr.Actors.Runtime
             return stream.ToArray();
         }
 
-        internal T Deserialize<T>(byte[] buffer)
+        public T Deserialize<T>(byte[] buffer)
         {
             if ((buffer == null) || (buffer.Length == 0))
             {

--- a/src/Dapr.Actors/Runtime/IActorStateSerializer.cs
+++ b/src/Dapr.Actors/Runtime/IActorStateSerializer.cs
@@ -1,0 +1,29 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+namespace Dapr.Actors.Runtime
+{
+    using System;
+
+    /// <summary>
+    /// Represents a custom serializer for actor state.
+    /// </summary>
+    internal interface IActorStateSerializer
+    {
+        /// <summary>
+        /// Deserializes from the given byte array to <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="buffer">The byte array to deserialize from.</param>
+        /// <returns>The deserialized value.</returns>
+        T Deserialize<T>(byte[] buffer);
+
+        /// <summary>
+        /// Serializes an object into a byte array.
+        /// </summary>
+        /// <param name="stateType">Type of the state.</param>
+        /// <param name="state">The state value to serialize.</param>
+        byte[] Serialize<T>(Type stateType, T state);
+    }
+}


### PR DESCRIPTION
Summary of changes:
- Serializing Actor state as json
- Moving older DataContract serializer into its own class so that it can exposed later as a Service Fabric compatibility mode
- Adding an interface for serialization/deserialization so that it can be exposed to users.



Fixes https://github.com/dapr/dotnet-sdk/issues/58