### PR TITLE
Pass serializer options to InvokeMethodAsync<TRequest,TResponse> #234

### DIFF
--- a/src/Dapr.Client/InvokeHttpClient.cs
+++ b/src/Dapr.Client/InvokeHttpClient.cs
@@ -66,7 +66,7 @@ namespace Dapr
                 throw new ArgumentNullException("The value cannot be null", nameof(data));
             }
 
-            var response = await this.MakeInvokeHttpRequest(serviceName, methodName, JsonSerializer.Serialize(data), cancellationToken).ConfigureAwait(false);
+            var response = await this.MakeInvokeHttpRequest(serviceName, methodName, JsonSerializer.Serialize(data, this.serializerOptions), cancellationToken).ConfigureAwait(false);
 
             if (response.Content == null || response.Content.Headers?.ContentLength == 0)
             {

--- a/src/Dapr.Client/InvokeHttpClient.cs
+++ b/src/Dapr.Client/InvokeHttpClient.cs
@@ -140,7 +140,7 @@ namespace Dapr
                 throw new ArgumentNullException("The value cannot be null", nameof(data));
             }
 
-            await this.MakeInvokeHttpRequest(serviceName, methodName, JsonSerializer.Serialize(data), cancellationToken).ConfigureAwait(false);
+            await this.MakeInvokeHttpRequest(serviceName, methodName, JsonSerializer.Serialize(data, this.serializerOptions), cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<HttpResponseMessage> MakeInvokeHttpRequest(string serviceName, string methodName, string data, CancellationToken cancellationToken)

--- a/test/Dapr.Client.Test/InvokeHttpClientTest.cs
+++ b/test/Dapr.Client.Test/InvokeHttpClientTest.cs
@@ -158,7 +158,7 @@ namespace Dapr.Client.Test
 
             var invokeClient = new InvokeHttpClient(httpClient, jsonOptions);
             var invokeRequest = new InvokeRequest() { RequestParameter = "Hello " };
-            var invokeResponse = new InvokedResponse { Name = "Look, I was invoked!" };
+            var invokedResponse = new InvokedResponse { Name = "Look, I was invoked!" };
 
             var task = invokeClient.InvokeMethodAsync<InvokeRequest, InvokedResponse>("test", "test", invokeRequest);
 
@@ -166,11 +166,11 @@ namespace Dapr.Client.Test
 
             (await entry.Request.Content.ReadAsStringAsync()).Should().Be(JsonSerializer.Serialize(invokeRequest, jsonOptions));
 
-            entry.RespondWithJson(invokeResponse, jsonOptions);
+            entry.RespondWithJson(invokedResponse, jsonOptions);
 
-            var invokedResponse = await task;
+            var response = await task;
 
-            invokedResponse.Name.Should().Be("Look, I was invoked!");
+            response.Name.Should().Be(invokedResponse.Name);
         }
 
 


### PR DESCRIPTION
# Description

InvokeMethodAsync<TRequest,TResponse> is not considering json serialization. Is not possible to serialize C# PascalCase properties to Camelse

## Issue reference

#234 


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
