### PR TITLE
Workaround for mTLS enabled Dapr endpoint.

### DIFF
--- a/src/Dapr.Client/DaprClientBuilder.cs
+++ b/src/Dapr.Client/DaprClientBuilder.cs
@@ -6,7 +6,10 @@
 namespace Dapr.Client
 {
     using System;
+    using System.Net.Http;
     using System.Text.Json;
+    using System.Threading.Tasks;
+    using Grpc.Core;
     using Grpc.Net.Client;
 
     /// <summary>
@@ -65,8 +68,29 @@ namespace Dapr.Client
                 // Set correct switch to make insecure gRPC service calls. This switch must be set before creating the GrpcChannel.
                 AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             }
+            else
+            {
+                // Workaround to allow with mTLS enabled Dapr grpc endpoint. The behavior will be fixed in 0.6.0 Dapr runtime.
+                if (this.gRPCChannelOptions == null)
+                {
+                    var httpClientHandler = new HttpClientHandler();
+                 
+                    // validate server cert.
+                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) =>
+                    {
+                        return true;
+                    };
 
-            var channel = GrpcChannel.ForAddress(this.daprEndpoint, this.gRPCChannelOptions ?? new GrpcChannelOptions());            
+                    var httpClient = new HttpClient(httpClientHandler);
+                    this.gRPCChannelOptions = new GrpcChannelOptions
+                    {
+                        HttpClient = httpClient,
+                        DisposeHttpClient = true
+                    };
+                }
+            }
+            
+            var channel = GrpcChannel.ForAddress(this.daprEndpoint, this.gRPCChannelOptions ?? new GrpcChannelOptions());
             return new DaprClientGrpc(channel, this.jsonSerializerOptions);
         }
 


### PR DESCRIPTION
Allows the DaprClient to work with mTLS enabled grpc endpoint when https endpoint is provided with DaprClientBuilder.UseEndpoint
It will be cherry-picked into 0.5.0 branch to realse a new nuget package.
The change will be reverted from master branch for 0.6.0 when the issue is fixed in Dapr runtime.

Fixes https://github.com/dapr/dotnet-sdk/issues/261