### PR TITLE
Revert the workaround added to work with mTLS enabled grpc endpoint.

### DIFF
--- a/src/Dapr.Client/DaprClientBuilder.cs
+++ b/src/Dapr.Client/DaprClientBuilder.cs
@@ -71,12 +71,11 @@ namespace Dapr.Client
         }
 
         /// <summary>
-        ///  Usees options for configuring a Grpc.Net.Client.GrpcChannel.
-        ///  Used by UnitTests to provide a HttpClient for testing.
+        /// Usees options for configuring a Grpc.Net.Client.GrpcChannel.
         /// </summary>
         /// <param name="gRPCChannelOptions"></param>
         /// <returns></returns>
-        internal DaprClientBuilder UseGrpcChannelOptions(GrpcChannelOptions gRPCChannelOptions)
+        public DaprClientBuilder UseGrpcChannelOptions(GrpcChannelOptions gRPCChannelOptions)
         {
             this.gRPCChannelOptions = gRPCChannelOptions;
             return this;

--- a/src/Dapr.Client/DaprClientBuilder.cs
+++ b/src/Dapr.Client/DaprClientBuilder.cs
@@ -6,10 +6,7 @@
 namespace Dapr.Client
 {
     using System;
-    using System.Net.Http;
     using System.Text.Json;
-    using System.Threading.Tasks;
-    using Grpc.Core;
     using Grpc.Net.Client;
 
     /// <summary>
@@ -68,29 +65,8 @@ namespace Dapr.Client
                 // Set correct switch to make insecure gRPC service calls. This switch must be set before creating the GrpcChannel.
                 AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             }
-            else
-            {
-                // Workaround to allow with mTLS enabled Dapr grpc endpoint. The behavior will be fixed in 0.6.0 Dapr runtime.
-                if (this.gRPCChannelOptions == null)
-                {
-                    var httpClientHandler = new HttpClientHandler();
-                 
-                    // validate server cert.
-                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) =>
-                    {
-                        return true;
-                    };
 
-                    var httpClient = new HttpClient(httpClientHandler);
-                    this.gRPCChannelOptions = new GrpcChannelOptions
-                    {
-                        HttpClient = httpClient,
-                        DisposeHttpClient = true
-                    };
-                }
-            }
-            
-            var channel = GrpcChannel.ForAddress(this.daprEndpoint, this.gRPCChannelOptions ?? new GrpcChannelOptions());
+            var channel = GrpcChannel.ForAddress(this.daprEndpoint, this.gRPCChannelOptions ?? new GrpcChannelOptions());            
             return new DaprClientGrpc(channel, this.jsonSerializerOptions);
         }
 

--- a/src/Dapr.Client/DaprClientBuilder.cs
+++ b/src/Dapr.Client/DaprClientBuilder.cs
@@ -66,7 +66,7 @@ namespace Dapr.Client
                 AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             }
 
-            var channel = GrpcChannel.ForAddress(this.daprEndpoint, this.gRPCChannelOptions ?? new GrpcChannelOptions());            
+            var channel = GrpcChannel.ForAddress(this.daprEndpoint, this.gRPCChannelOptions ?? new GrpcChannelOptions());
             return new DaprClientGrpc(channel, this.jsonSerializerOptions);
         }
 


### PR DESCRIPTION
Summary of changes:
- This reverts the workaroung which was added to handle mtls on dapr endpoints. With 0.6.0 release, there will be a separate endpoint for app->dapr  which will not use tls. This was the original issue: https://github.com/dapr/dotnet-sdk/issues/261
- Also exposes option to provide GrpcChannelOptions to allow more customizations by users
