### PR TITLE
Initializing ActorId with an empty string should throw an exception

### DIFF
--- a/src/Dapr.Actors/ActorId.cs
+++ b/src/Dapr.Actors/ActorId.cs
@@ -24,9 +24,9 @@ namespace Dapr.Actors
         /// <param name="id">Value for actor id.</param>
         public ActorId(string id)
         {
-            if (string.IsNullOrEmpty(id))
+            if (string.IsNullOrWhiteSpace(id))
             {
-                throw new ArgumentException("The value cannot be null or empty", nameof(id));
+                throw new ArgumentException("The value cannot be null, empty or white spaces.", nameof(id));
             }
             this.stringId = id;
         }

--- a/src/Dapr.Actors/ActorId.cs
+++ b/src/Dapr.Actors/ActorId.cs
@@ -24,7 +24,11 @@ namespace Dapr.Actors
         /// <param name="id">Value for actor id.</param>
         public ActorId(string id)
         {
-            this.stringId = id ?? throw new ArgumentNullException(nameof(id));
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException("The value cannot be null or empty", nameof(id));
+            }
+            this.stringId = id;
         }
 
         /// <summary>

--- a/test/Dapr.Actors.Test/ActorIdTests.cs
+++ b/test/Dapr.Actors.Test/ActorIdTests.cs
@@ -101,16 +101,19 @@ namespace Dapr.Actors.Test
         /// <summary>
         /// Throw exception if id is null.
         /// </summary>
-        [Fact]
-        public void Initialize_New_ActorId_Object_With_Null_Id()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Initialize_New_ActorId_Object_With_Null_Id(string id)
         {
-            Assert.Throws<ArgumentNullException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
-                ActorId actorId = new ActorId(null);
+                ActorId actorId = new ActorId(id);
             });
         }
 
         [Theory]
+        [InlineData("   ")]
         [InlineData("one")]
         [InlineData("123")]
         public void Get_Id(string id)
@@ -120,6 +123,7 @@ namespace Dapr.Actors.Test
         }
 
         [Theory]
+        [InlineData("   ")]
         [InlineData("one")]
         [InlineData("123")]
         public void Verify_ToString(string id)

--- a/test/Dapr.Actors.Test/ActorIdTests.cs
+++ b/test/Dapr.Actors.Test/ActorIdTests.cs
@@ -104,7 +104,8 @@ namespace Dapr.Actors.Test
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void Initialize_New_ActorId_Object_With_Null_Id(string id)
+        [InlineData("   ")]
+        public void Initialize_New_ActorId_Object_With_Null_Or_Whitespace_Id(string id)
         {
             Assert.Throws<ArgumentException>(() =>
             {
@@ -113,7 +114,6 @@ namespace Dapr.Actors.Test
         }
 
         [Theory]
-        [InlineData("   ")]
         [InlineData("one")]
         [InlineData("123")]
         public void Get_Id(string id)
@@ -123,7 +123,6 @@ namespace Dapr.Actors.Test
         }
 
         [Theory]
-        [InlineData("   ")]
         [InlineData("one")]
         [InlineData("123")]
         public void Verify_ToString(string id)


### PR DESCRIPTION
# Description
Fixes https://github.com/dapr/dotnet-sdk/issues/277
Add an empty string check in the ActorId constructor.

The tests have been modified by adding :
1) When Id is an empty string test => Check Exception
2) When Id is white spaces test => Check OK

## Issue reference

Please reference the issue this PR will close: #_277_

## Checklist

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
