### PR TITLE
#312 - make changes corresponding to change in dapr runtime.  The run…

### DIFF
--- a/src/Dapr.Actors.AspNetCore/DaprActorSetupFilter.cs
+++ b/src/Dapr.Actors.AspNetCore/DaprActorSetupFilter.cs
@@ -26,8 +26,7 @@ namespace Dapr.Actors.AspNetCore
                 app.UseEndpoints(endpoints =>
                 {
                     endpoints.MapHealthChecks("/healthz");
-                    endpoints.AddDaprConfigRoute();
-                    endpoints.AddActorActivationRoute();
+                    endpoints.AddDaprConfigRoute();                    
                     endpoints.AddActorDeactivationRoute();
                     endpoints.AddActorMethodRoute();
                     endpoints.AddReminderRoute();

--- a/src/Dapr.Actors.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -20,18 +20,7 @@ namespace Dapr.Actors.AspNetCore
                 context.Response.ContentType = "application/json";
                 await ActorRuntime.Instance.SerializeSettingsAndRegisteredTypes(context.Response.BodyWriter);
             });
-        }
-
-        public static IEndpointConventionBuilder AddActorActivationRoute(this IEndpointRouteBuilder endpoints)
-        {
-            return endpoints.MapPost("actors/{actorTypeName}/{actorId}", async context =>
-            {
-                var routeValues = context.Request.RouteValues;
-                var actorTypeName = (string)routeValues["actorTypeName"];
-                var actorId = (string)routeValues["actorId"];
-                await ActorRuntime.ActivateAsync(actorTypeName, actorId);
-            });
-        }
+        }     
 
         public static IEndpointConventionBuilder AddActorDeactivationRoute(this IEndpointRouteBuilder endpoints)
         {

--- a/src/Dapr.Actors/Runtime/ActorManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorManager.cs
@@ -55,7 +55,7 @@ namespace Dapr.Actors.Runtime
         internal ActorTypeInformation ActorTypeInfo => this.actorService.ActorTypeInfo;
 
         internal async Task<Tuple<string, byte[]>> DispatchWithRemotingAsync(ActorId actorId, string actorMethodName, string daprActorheader, Stream data, CancellationToken cancellationToken)
-        {
+        {          
             var actorMethodContext = ActorMethodContext.CreateForActor(actorMethodName);
 
             // Get the serialized header
@@ -104,7 +104,7 @@ namespace Dapr.Actors.Runtime
         }
 
         internal async Task DispatchWithoutRemotingAsync(ActorId actorId, string actorMethodName, Stream requestBodyStream, Stream responseBodyStream, CancellationToken cancellationToken)
-        {
+        {                       
             var actorMethodContext = ActorMethodContext.CreateForActor(actorMethodName);
 
             // Create a Func to be invoked by common method.
@@ -120,7 +120,7 @@ namespace Dapr.Actors.Runtime
                     awaitable = methodInfo.Invoke(actor, null);
                 }
                 else if (parameters.Length == 1)
-                {
+                {                    
                     // deserialize using stream.
                     var type = parameters[0].ParameterType;
                     var deserializedType = await JsonSerializer.DeserializeAsync(requestBodyStream, type);
@@ -159,7 +159,7 @@ namespace Dapr.Actors.Runtime
         }
 
         internal async Task FireReminderAsync(ActorId actorId, string reminderName, Stream requestBodyStream, CancellationToken cancellationToken = default)
-        {
+        {            
             // Only FireReminder if its IRemindable, else ignore it.
             if (this.ActorTypeInfo.IsRemindable)
             {
@@ -225,7 +225,12 @@ namespace Dapr.Actors.Runtime
         }
 
         private async Task<T> DispatchInternalAsync<T>(ActorId actorId, ActorMethodContext actorMethodContext, Func<Actor, CancellationToken, Task<T>> actorFunc, CancellationToken cancellationToken)
-        {
+        {            
+            if (!this.activeActors.ContainsKey(actorId))
+            {
+                await this.ActivateActor(actorId);
+            }
+
             if (!this.activeActors.TryGetValue(actorId, out var actor))
             {
                 // This should never happen, as "Dapr" runtime activates the actor first. if it ever it would mean a bug in "Dapr" runtime.

--- a/src/Dapr.Actors/Runtime/ActorManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorManager.cs
@@ -232,8 +232,7 @@ namespace Dapr.Actors.Runtime
             }
 
             if (!this.activeActors.TryGetValue(actorId, out var actor))
-            {
-                // This should never happen, as "Dapr" runtime activates the actor first. if it ever it would mean a bug in "Dapr" runtime.
+            {             
                 var errorMsg = $"Actor {actorId} is not yet activated.";
                 ActorTrace.Instance.WriteError(TraceType, errorMsg);
                 throw new InvalidOperationException(errorMsg);

--- a/src/Dapr.Actors/Runtime/ActorManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorManager.cs
@@ -55,7 +55,7 @@ namespace Dapr.Actors.Runtime
         internal ActorTypeInformation ActorTypeInfo => this.actorService.ActorTypeInfo;
 
         internal async Task<Tuple<string, byte[]>> DispatchWithRemotingAsync(ActorId actorId, string actorMethodName, string daprActorheader, Stream data, CancellationToken cancellationToken)
-        {          
+        {
             var actorMethodContext = ActorMethodContext.CreateForActor(actorMethodName);
 
             // Get the serialized header
@@ -104,7 +104,7 @@ namespace Dapr.Actors.Runtime
         }
 
         internal async Task DispatchWithoutRemotingAsync(ActorId actorId, string actorMethodName, Stream requestBodyStream, Stream responseBodyStream, CancellationToken cancellationToken)
-        {                       
+        {
             var actorMethodContext = ActorMethodContext.CreateForActor(actorMethodName);
 
             // Create a Func to be invoked by common method.
@@ -120,7 +120,7 @@ namespace Dapr.Actors.Runtime
                     awaitable = methodInfo.Invoke(actor, null);
                 }
                 else if (parameters.Length == 1)
-                {                    
+                {
                     // deserialize using stream.
                     var type = parameters[0].ParameterType;
                     var deserializedType = await JsonSerializer.DeserializeAsync(requestBodyStream, type);
@@ -159,7 +159,7 @@ namespace Dapr.Actors.Runtime
         }
 
         internal async Task FireReminderAsync(ActorId actorId, string reminderName, Stream requestBodyStream, CancellationToken cancellationToken = default)
-        {            
+        {
             // Only FireReminder if its IRemindable, else ignore it.
             if (this.ActorTypeInfo.IsRemindable)
             {
@@ -225,7 +225,7 @@ namespace Dapr.Actors.Runtime
         }
 
         private async Task<T> DispatchInternalAsync<T>(ActorId actorId, ActorMethodContext actorMethodContext, Func<Actor, CancellationToken, Task<T>> actorFunc, CancellationToken cancellationToken)
-        {            
+        {
             if (!this.activeActors.ContainsKey(actorId))
             {
                 await this.ActivateActor(actorId);

--- a/src/Dapr.Actors/Runtime/ActorRuntime.cs
+++ b/src/Dapr.Actors/Runtime/ActorRuntime.cs
@@ -119,17 +119,6 @@ namespace Dapr.Actors.Runtime
         }
 
         /// <summary>
-        /// Activates an actor for an actor type with given actor id.
-        /// </summary>
-        /// <param name="actorTypeName">Actor type name to activate the actor for.</param>
-        /// <param name="actorId">Actor id for the actor to be activated.</param>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        internal static async Task ActivateAsync(string actorTypeName, string actorId)
-        {
-            await Instance.GetActorManager(actorTypeName).ActivateActor(new ActorId(actorId));
-        }
-
-        /// <summary>
         /// Deactivates an actor for an actor type with given actor id.
         /// </summary>
         /// <param name="actorTypeName">Actor type name to deactivate the actor for.</param>
@@ -201,7 +190,7 @@ namespace Dapr.Actors.Runtime
         {
             if (!this.actorManagers.TryGetValue(actorTypeName, out var actorManager))
             {
-                var errorMsg = $"Actor type {actorTypeName} is not registerd with Actor runtime.";
+                var errorMsg = $"Actor type {actorTypeName} is not registered with Actor runtime.";
                 ActorTrace.Instance.WriteError(TraceType, errorMsg);
                 throw new InvalidOperationException(errorMsg);
             }


### PR DESCRIPTION
# Description

The runtime will no longer send an activate message, so the SDK should 'activate' an actor anytime it receives an actor method call.  See proposal in https://github.com/dapr/dapr/issues/1038 for longer description.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #312

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
