### PR TITLE
pub/sub - rename refs to 'content' to 'data'

### DIFF
--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -19,11 +19,11 @@ namespace Dapr.Client
         /// Publishes an event to the specified topic.
         /// </summary>
         /// <param name="topicName">The name of the topic the request should be published to.</param>
-        /// <param name="content">The contents of the event.</param>
+        /// <param name="data">The  event data.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> that can be used to cancel the operation.</param>
-        /// <typeparam name="TContent">The data type of the object that will be serialized.</typeparam>
+        /// <typeparam name="TData">The data type of the object that will be serialized.</typeparam>
         /// <returns>A <see cref="Task" /> that will complete when the operation has completed.</returns>
-        public abstract Task PublishEventAsync<TContent>(string topicName, TContent content, CancellationToken cancellationToken = default);
+        public abstract Task PublishEventAsync<TData>(string topicName, TData data, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Publishes an event to the specified topic.

--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -40,11 +40,11 @@ namespace Dapr.Client
 
         #region Publish Apis
         /// <inheritdoc/>
-        public override Task PublishEventAsync<TContent>(string topicName, TContent content, CancellationToken cancellationToken = default)
+        public override Task PublishEventAsync<TData>(string topicName, TData data, CancellationToken cancellationToken = default)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(topicName, nameof(topicName));
-            ArgumentVerifier.ThrowIfNull(content, nameof(content));
-            return MakePublishRequest(topicName, content, cancellationToken);
+            ArgumentVerifier.ThrowIfNull(data, nameof(data));
+            return MakePublishRequest(topicName, data, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/test/Dapr.Client.Test/PublishEventApiTest.cs
+++ b/test/Dapr.Client.Test/PublishEventApiTest.cs
@@ -15,22 +15,22 @@ namespace Dapr.Client.Test
     public class PublishEventApiTest
     {
         [Fact]
-        public async Task PublishEventAsync_CanPublishTopicWithContent()
+        public async Task PublishEventAsync_CanPublishTopicWithData()
         {
             var httpClient = new TestHttpClient();
             var daprClient = new DaprClientBuilder()
                 .UseGrpcChannelOptions(new GrpcChannelOptions{ HttpClient = httpClient })
                 .Build();
           
-            var publishContent = new PublishContent() { PublishObjectParameter = "testparam" };
-            var task = daprClient.PublishEventAsync<PublishContent>("test", publishContent);
+            var publishData = new PublishData() { PublishObjectParameter = "testparam" };
+            var task = daprClient.PublishEventAsync<PublishData>("test", publishData);
 
             httpClient.Requests.TryDequeue(out var entry).Should().BeTrue();
             var envelope = await GrpcUtils.GetEnvelopeFromRequestMessageAsync<PublishEventEnvelope>(entry.Request);
             var jsonFromRequest = envelope.Data.Value.ToStringUtf8();
 
             envelope.Topic.Should().Be("test");
-            jsonFromRequest.Should().Be(JsonSerializer.Serialize(publishContent));
+            jsonFromRequest.Should().Be(JsonSerializer.Serialize(publishData));
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Dapr.Client.Test
             jsonFromRequest.Should().Be("\"\"");
         }
         
-        private class PublishContent
+        private class PublishData
         {
             public string PublishObjectParameter { get; set; }
         }


### PR DESCRIPTION
# Description

pub/sub - rename refs to 'content' to 'data'

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

https://github.com/dapr/dapr/issues/1370

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
