### PR TITLE
docs: correct typo in get started guide

### DIFF
--- a/docs/get-started-dapr-actor.md
+++ b/docs/get-started-dapr-actor.md
@@ -158,7 +158,7 @@ namespace MyActorService
         {
             // Data is saved to configured state store implicitly after each method execution by Actor's runtime.
             // Data can also be saved explicitly by calling this.StateManager.SaveStateAsync();
-            // State to be saved must be DataContract serialziable.
+            // State to be saved must be DataContract serializable.
             await this.StateManager.SetStateAsync<MyData>(
                 "my_data",  // state name
                 data);      // data saved for the named state "my_data"


### PR DESCRIPTION
# Description

`serialziable` -> `serializable` in `docs/get-started-dapr-actor.md`.

## Issue reference

This PR will close: #330

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
