### PR TITLE
Updated dotnet sdk in github actions

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.300
+          dotnet-version: 3.1.301
       - name: Build solution - release
         run: dotnet build all.sln --configuration release
       - name: Test solution - release

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.102
+          dotnet-version: 3.1.301
       - name: Build solution - release
         run: dotnet build all.sln --configuration release
       - name: Test solution - release
         run: dotnet test test/test.sln --configuration release
       - name: Generate Nuget Packages - release
-        run: dotnet pack src/prod.sln --configuration release --include-symbols --no-build
+        run: dotnet pack src/prod.sln --configuration release
       - name: upload artifacts
         uses: actions/upload-artifact@master
         with:
@@ -60,3 +60,7 @@ jobs:
             --name "Dapr dotnet SDK v${REL_VERSION}" \
             --prerelease true \
             ${RELEASE_ARTIFACT[*]}
+      - name: Publish nuget packages to nuget.org
+        if: startswith(github.ref, 'refs/tags/v')
+        run: |
+          dotnet nuget push ${{ env.NUPKG_OUTDIR }}/DApr*.nupkg --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.301
+          dotnet-version: 3.1.300
       - name: Build solution - release
         run: dotnet build all.sln --configuration release
       - name: Test solution - release

--- a/properties/dapr_nuget.props
+++ b/properties/dapr_nuget.props
@@ -17,4 +17,10 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\properties\logo-transparent.png" Pack="true" Visible="false" PackagePath="images" />
   </ItemGroup>
+
+  <!-- Enable symbols package generation. https://docs.microsoft.com/nuget/create-packages/symbol-packages-snupkg -->
+  <PropertyGroup>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
 </Project>

--- a/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
+++ b/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
@@ -11,6 +11,12 @@
     <Description>This package contains the reference assemblies for developing Actor services using Dapr and AspNetCore.</Description>
     <PackageTags>$(PackageTags);Actors</PackageTags>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- Adding ref. to System.IO.Pipelines explicitly to work around build issue with .netcore sdk 3.1.102
+    https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-known-issues.md#net-core-312
+    This should be reverted when the fix will be available in future .net core sdk. -->
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Dapr.Actors\Dapr.Actors.csproj" />

--- a/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
+++ b/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
@@ -11,12 +11,6 @@
     <Description>This package contains the reference assemblies for developing Actor services using Dapr and AspNetCore.</Description>
     <PackageTags>$(PackageTags);Actors</PackageTags>
   </PropertyGroup>
-  <ItemGroup>
-    <!-- Adding ref. to System.IO.Pipelines explicitly to work around build issue with .netcore sdk 3.1.102
-    https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-known-issues.md#net-core-312
-    This should be reverted when the fix will be available in future .net core sdk. -->
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Dapr.Actors\Dapr.Actors.csproj" />

--- a/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
+++ b/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
@@ -10,11 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <!-- Adding ref. to System.IO.Pipelines explicitly to work around build issue with .netcore sdk 3.1.102
-    https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-known-issues.md#net-core-312
-    This should be reverted when the fix will be available in future .net core sdk. -->
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
+++ b/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
@@ -11,10 +11,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <!-- Adding ref. to System.IO.Pipelines explicitly to work around build issue with .netcore sdk 3.1.102
-    https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-known-issues.md#net-core-312
-    This should be reverted when the fix will be available in future .net core sdk. -->
-    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
+++ b/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
@@ -10,7 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />    
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <!-- Adding ref. to System.IO.Pipelines explicitly to work around build issue with .netcore sdk 3.1.102
+    https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-known-issues.md#net-core-312
+    This should be reverted when the fix will be available in future .net core sdk. -->
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,4 +8,18 @@
     <!-- Stylecop needs the documentation file to exist -->
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
   </PropertyGroup>
+
+  <!-- Enable sourcelink https://docs.microsoft.com/dotnet/standard/library-guidance/sourcelink -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <!-- Enable Deterministic Builds for github actions -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #251 #339 #340
Updated dotnet sdk
Generate .snupkg
Upload packages for tags to nuget.org
Enable sourcelink
Enable Deterministic build for github actions

