### PR TITLE
Determine assembly, nuget versions based on git tags.

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -61,11 +61,6 @@ jobs:
             --prerelease true \
             ${RELEASE_ARTIFACT[*]}
       - name: Publish nuget packages to nuget.org
-        if: startswith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '-rc'
+        if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-beta') || endsWith(github.ref, '-alpha'))
         run: |
           dotnet nuget push ${{ env.NUPKG_OUTDIR }}/Dapr*.nupkg --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json
-      - name: Publish nuget packages to github feed.
-        if: startswith(github.ref, 'refs/tags/v')
-        run: |
-          # publish to github nuget repository
-          dotnet nuget push ${{ env.NUPKG_OUTDIR }}/Dapr*.nupkg --skip-duplicate --api-key ${{ secrets.DAPR_BOT_TOKEN }} --source https://nuget.pkg.github.com/dapr/index.json

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -61,6 +61,11 @@ jobs:
             --prerelease true \
             ${RELEASE_ARTIFACT[*]}
       - name: Publish nuget packages to nuget.org
+        if: startswith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '-rc'
+        run: |
+          dotnet nuget push ${{ env.NUPKG_OUTDIR }}/Dapr*.nupkg --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json
+      - name: Publish nuget packages to github feed.
         if: startswith(github.ref, 'refs/tags/v')
         run: |
-          dotnet nuget push ${{ env.NUPKG_OUTDIR }}/DApr*.nupkg --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json
+          # publish to github nuget repository
+          dotnet nuget push ${{ env.NUPKG_OUTDIR }}/Dapr*.nupkg --skip-duplicate --api-key ${{ secrets.DAPR_BOT_TOKEN }} --source https://nuget.pkg.github.com/dapr/index.json

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -61,6 +61,6 @@ jobs:
             --prerelease true \
             ${RELEASE_ARTIFACT[*]}
       - name: Publish nuget packages to nuget.org
-        if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-beta') || endsWith(github.ref, '-alpha'))
+        if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
         run: |
           dotnet nuget push ${{ env.NUPKG_OUTDIR }}/Dapr*.nupkg --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/properties/dapr_common.props
+++ b/properties/dapr_common.props
@@ -4,23 +4,5 @@
   <PropertyGroup>
     <RepoRoot>$(MSBuildThisFileDirectory)..\</RepoRoot>
     <RequestedVerbosity Condition=" '$(RequestedVerbosity)' == '' ">minimal</RequestedVerbosity>
-    
-    <!-- Version for binaries, nuget packages generated from this repo. -->
-    <MajorVersion>1</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <BuildVersion>0</BuildVersion>
-    <Revision>0</Revision>
-    <Version>$(MajorVersion).$(MinorVersion).$(BuildVersion).$(Revision)</Version>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
-    <AssemblyFileVersion>$(Version)</AssemblyFileVersion>
-    <FileVersion>$(Version)</FileVersion>
-
-    <!-- Nuget package versions -->
-    <NupkgMajorVersion>0</NupkgMajorVersion>
-    <NupkgMinorVersion>9</NupkgMinorVersion>
-    <NupkgPatchVersion>0</NupkgPatchVersion>
-    <NupkgPreviewTag>-preview01</NupkgPreviewTag>
-    <NupkgVersion>$(NupkgMajorVersion).$(NupkgMinorVersion).$(NupkgPatchVersion)$(NupkgPreviewTag)</NupkgVersion>
   </PropertyGroup>
-  
 </Project>

--- a/properties/dapr_managed_netcore.props
+++ b/properties/dapr_managed_netcore.props
@@ -48,4 +48,18 @@
     <DefineConstants>$(DefineConstants);DotNetCoreClr</DefineConstants>
   </PropertyGroup>
 
+  <!-- Use MinVer for versioning based on git tags -->
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="2.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Configure properties for MinVer -->
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+    <MinVerVerbosity>detailed</MinVerVerbosity>
+  </PropertyGroup>
 </Project>

--- a/properties/dapr_managed_netcore.props
+++ b/properties/dapr_managed_netcore.props
@@ -48,7 +48,7 @@
     <DefineConstants>$(DefineConstants);DotNetCoreClr</DefineConstants>
   </PropertyGroup>
 
-  <!-- Use MinVer for versioning based on git tags -->
+  <!-- Use MinVer for assembly, nuget versioning based on git tags -->
   <ItemGroup>
     <PackageReference Include="MinVer" Version="2.3.0">
       <PrivateAssets>all</PrivateAssets>
@@ -60,6 +60,6 @@
   <PropertyGroup>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
-    <MinVerVerbosity>detailed</MinVerVerbosity>
+    <!-- <MinVerVerbosity>detailed</MinVerVerbosity>-->
   </PropertyGroup>
 </Project>

--- a/properties/dapr_nuget.props
+++ b/properties/dapr_nuget.props
@@ -1,7 +1,6 @@
 <Project>
   <!-- Nuget package properties when packed using dotnet pack. -->
   <PropertyGroup>
-    <PackageVersion>$(NupkgVersion)</PackageVersion>
     <Authors>dapr.io</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Summary of changes:
- With these changes, no need to update versions manually, they will be determined using the git tags
- Version for assembly and nuget package is derived form tag which are created at release time. MinVer is used for it