### PR TITLE
Fixing null reference exception when no model binder provided

### DIFF
--- a/src/Dapr.AspNetCore/StateEntryModelBinderProvider.cs
+++ b/src/Dapr.AspNetCore/StateEntryModelBinderProvider.cs
@@ -29,7 +29,7 @@ namespace Dapr.AspNetCore
 
         private static bool CanBind(ModelBinderProviderContext context, out Type type)
         {
-            if (context.BindingInfo.BindingSource.Id == "state")
+            if (context.BindingInfo.BindingSource?.Id == "state")
             {
                 // [FromState]
                 type = Unwrap(context.Metadata.ModelType);

--- a/test/Dapr.AspNetCore.IntegrationTest.App/DaprController.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/DaprController.cs
@@ -46,5 +46,12 @@ namespace Dapr.AspNetCore.IntegrationTest.App
             state.Value.Count++;
             await state.SaveAsync();
         }
+
+        [HttpPost("/echo-user")]
+        public ActionResult<UserInfo> EchoUser([FromQuery]UserInfo user)
+        {
+            // To simulate an action where there's no Dapr attribute, yet MVC still checks the list of available model binder providers.
+            return user;
+        }
     }
 }

--- a/test/Dapr.AspNetCore.IntegrationTest/ControllerIntegrationTest.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest/ControllerIntegrationTest.cs
@@ -69,5 +69,19 @@ namespace Dapr.AspNetCore.IntegrationTest
                 widget.Count.Should().Be(18);
             }
         }
+
+        [Fact]
+        public async Task ModelBinder_CanGetOutOfTheWayWhenTheresNoBinding()
+        {
+            using (var factory = new AppWebApplicationFactory())
+            {
+                var httpClient = factory.CreateClient();
+                var daprClient = factory.DaprClient;
+
+                var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/echo-user?name=jimmy");
+                var response = await httpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description

Even when there's no Dapr attribute used on an Action, all model binders are checked by ASP.NET from the top against a parameter when needed. StateEntryModelBinderProvider does not handle a null reference when called in this context. This PR fixes that.

## Issue reference

#368 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
