### PR TITLE
Workaround .NET SDK bug with pipelines package

### DIFF
--- a/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
+++ b/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
@@ -4,6 +4,13 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <!--
+      This is a workaround for https://github.com/dotnet/sdk/issues/14019
+      The extra reference is harmless but is needed due to a bug in the 5.0 RC dotnet SDK.
+      It can be removed when the issue is fixed (likely 5.0 GA).
+    -->
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
   </ItemGroup>
 
   <!-- Additional Nuget package properties. -->
@@ -28,5 +35,4 @@
       <LastGenOutput>SR.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
 </Project>

--- a/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
+++ b/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
@@ -11,6 +11,13 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <!--
+      This is a workaround for https://github.com/dotnet/sdk/issues/14019
+      The extra reference is harmless but is needed due to a bug in the 5.0 RC dotnet SDK.
+      It can be removed when the issue is fixed (likely 5.0 GA).
+    -->
+    <PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

This is a workaround for https://github.com/dotnet/sdk/issues/14019
which prevents the current prerelease dotnet SDK
`5.0.100-rc.1.20452.10` from successfully building the repo.

Users attempting to build with the bugged release will see a compiler
error related to the `System.IO.Pipelines` assembly.

The explicit reference to `System.IO.Pipelines` is harmless long term,
but can be removed when the underlying bug is fixed and shipped in a GA
release (likely 5.0.100 GA).

## Issue reference

Underlying issue is a dotnet SDK bug  - https://github.com/dotnet/sdk/issues/14019

We should make sure that the repo is buildable by wide audience of contributors 😉 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests (n/a)
* [x] Extended the documentation (n/a)
