### PR TITLE
Add coverlet output to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ bld/
 
 # VS Code
 .vscode/
+
+# coverlet code coverage results
+coverage.json


### PR DESCRIPTION
# Description

Makes sure we exclude the generated `coverage.json` files from git. We
don't want these to get accidentally committed if someone is running
coverage on their own machine.


## Issue reference

Follow up from #443 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
