### PR TITLE
Add .NET 5 testing

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -26,11 +26,15 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.301
+          dotnet-version: 3.1.x
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
       - name: Test solution - release
         run: |
-          unset GITHUB_ACTIONS #disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
-          dotnet test test/test.sln --configuration release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+          # disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
+          dotnet test test/test.sln --configuration release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:GITHUB_ACTIONS=false
           dotnet clean # remove the artifacts so they can be rebuild with deterministic builds enabled
       - name: Build solution - release
         run: dotnet build all.sln --configuration release

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repo builds the following packages:
 
 ### Prerequesites
 
-Each project is a normal C# project. At minimum, you need [.NET Core SDK 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1) to build, test, and generate NuGet packages.
+Each project is a normal C# project. At minimum, you need [.NET Core SDK 5.0](https://dotnet.microsoft.com/download/dotnet-core/5.0) to build, test, and generate NuGet packages.
 
 **macOS/Linux:**
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,12 +22,9 @@ stages:
         release:
           configuration: release
     steps:
-      - task: UseDotNet@2
-        displayName: 'Install dotnet SDK 3.0'
-        inputs:
-          packageType: sdk
-          version: 3.0.100
-          installationPath: $(Agent.ToolsDirectory)/dotnet
+      - uses: actions/setup-dotnet@v1
+        with:
+        dotnet-version: '3.1.x' # SDK Version to use; x will use the latest version of the 3.1 channel
       - task: DotNetCoreCLI@2
         displayName: 'Build solution - $(Configuration)'
         inputs:

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
-  "_comment": "This policy allows the 3.1.100 SDK (latest LTS) or anything newer.",
+  "_comment": "This policy allows the 5.0.100 SDK or patches in that family.",
   "sdk": {
-    "version": "3.1.100",
+    "version": "5.0.100",
     "rollForward": "latestMajor"
   }
 }

--- a/properties/dapr_managed_netcore.props
+++ b/properties/dapr_managed_netcore.props
@@ -5,9 +5,6 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
-    <NoWarn></NoWarn>
-    <!-- Don't append TargetFramework to output path. -->
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
    </PropertyGroup>
 
   <!-- Cls Compliant -->

--- a/test/Dapr.Actors.AspNetCore.IntegrationTest.App/Dapr.Actors.AspNetCore.IntegrationTest.App.csproj
+++ b/test/Dapr.Actors.AspNetCore.IntegrationTest.App/Dapr.Actors.AspNetCore.IntegrationTest.App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.Actors.AspNetCore.Test/Dapr.Actors.AspNetCore.Test.csproj
+++ b/test/Dapr.Actors.AspNetCore.Test/Dapr.Actors.AspNetCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
     <BaseNamespace>Dapr.Actors.AspNetCore</BaseNamespace>
   </PropertyGroup>
 

--- a/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
+++ b/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
     <RootNamespace>Dapr.Actors</RootNamespace>
   </PropertyGroup>
 

--- a/test/Dapr.AspNetCore.IntegrationTest.App/Dapr.AspNetCore.IntegrationTest.App.csproj
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/Dapr.AspNetCore.IntegrationTest.App.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.AspNetCore.Test/Dapr.AspNetCore.Test.csproj
+++ b/test/Dapr.AspNetCore.Test/Dapr.AspNetCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.Client.Test/Dapr.Client.Test.csproj
+++ b/test/Dapr.Client.Test/Dapr.Client.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
+++ b/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

Update the repo to run tests against .NET 5. There's no change in the support matrix or how the dotnet-sdk libraries build - the difference is that both 3.1 and 5.0 are tested now.

We'll require the .NET 5 SDK for contributing the repo from now on. 


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #429

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
