### PR TITLE
First approach adding Dependency Injection to Actor activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ bld/
 
 # coverlet code coverage results
 coverage.json
+/.ionide

--- a/src/Dapr.Actors.AspNetCore/WebHostBuilderExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/WebHostBuilderExtensions.cs
@@ -59,7 +59,7 @@ namespace Dapr.Actors.AspNetCore
 
                 services.AddSingleton<ActorRuntime>(s =>
                 {
-                    return new ActorRuntime(s.GetRequiredService<IOptions<ActorRuntimeOptions>>().Value, s.GetRequiredService<ILoggerFactory>());
+                    return new ActorRuntime(s);
                 });
             });
 

--- a/src/Dapr.Actors/Dapr.Actors.csproj
+++ b/src/Dapr.Actors/Dapr.Actors.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.10" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapr.Actors/Runtime/ActorService.cs
+++ b/src/Dapr.Actors/Runtime/ActorService.cs
@@ -6,6 +6,7 @@
 namespace Dapr.Actors.Runtime
 {
     using System;
+    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -13,6 +14,7 @@ namespace Dapr.Actors.Runtime
     /// </summary>
     public class ActorService : IActorService
     {
+        private readonly IServiceProvider serviceProvider;
         private readonly Func<ActorService, ActorId, Actor> actorFactory;
 
         /// <summary>
@@ -33,11 +35,36 @@ namespace Dapr.Actors.Runtime
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="ActorService"/> class.
+        /// </summary>
+        /// <param name="actorTypeInfo">The type information of the Actor.</param>
+        /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="serviceProvider">The service container required to activate new Actor's instances.</param>
+        /// <param name="actorFactory">The factory method to create Actor objects.</param>
+        public ActorService(
+            ActorTypeInformation actorTypeInfo,
+            ILoggerFactory loggerFactory,
+            IServiceProvider serviceProvider,
+            Func<ActorService, ActorId, Actor> actorFactory = null) :
+            this(
+                actorTypeInfo, 
+                loggerFactory, 
+                actorFactory ?? ServiceProviderBasedFactory(actorTypeInfo, serviceProvider))
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
+        /// <summary>
         /// Gets the ActorTypeInformation for actor service.
         /// </summary>
         public ActorTypeInformation ActorTypeInfo { get; }
 
         internal DaprStateProvider StateProvider { get; }
+
+        /// <summary>
+        /// Returns the instance of <see cref="IServiceProvider"/> used to activate new Actor's instances
+        /// </summary>
+        public IServiceProvider ServiceProvider => serviceProvider;
 
         /// <summary>
         /// Gets the LoggerFactory for actor service
@@ -55,6 +82,18 @@ namespace Dapr.Actors.Runtime
                 this.ActorTypeInfo.ImplementationType,
                 actorService,
                 actorId);
+        }
+
+        private static Func<ActorService, ActorId, Actor> ServiceProviderBasedFactory(
+            ActorTypeInformation actorTypeInfo,
+            IServiceProvider serviceProvider)
+        {
+            return (actorService, actorId) =>
+                (Actor)ActivatorUtilities.CreateInstance(
+                    serviceProvider,
+                    actorTypeInfo.ImplementationType,
+                    actorService,
+                    actorId);
         }
     }
 }


### PR DESCRIPTION
# Description

This is a first approach on adding dependency injection to `Dapr.Actors`. I just what to put a solution I came up today to discuss it, after that some code cleanup would be necessary and some unit tests would be required to validate this approach.

There are two API changes that are additive, hence backward compatible:
- Actor constructors MUST have parameters `ActorService service` and `ActorId actorId`, as before, but also MAY have any other parameters as long as their types are registered as services in the implicit `IServiceProvider` used to create the `ActorRuntime` (during the call to `services.UseActors(...)`)
- `ActorService` have a reference to the `IServiceProvider` instance, so that an actor type can have a factory function with access to the service provider through the `ActorService`, when using the method `RegisterActor`.

This propositions MUST be tested yet, but the changes are actual and backward compatible with existing test sets.

I modified existing tests (4) to check that my proposed changes do not affect existing code.

There are some changes that can be avoided, like adding a dependency to package `Microsoft.Extensions.Options` from `Dapr.Actors` project, I just wanted to have a tested solution and an approval to move this PR forward, to do the rest of the work.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #171

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
