### PR TITLE
Remove GetAllStateNamesAsync

### DIFF
--- a/src/Dapr.Actors/Runtime/ActorStateManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateManager.cs
@@ -238,31 +238,6 @@ namespace Dapr.Actors.Runtime
             return addValue;
         }
 
-        public async Task<IEnumerable<string>> GetStateNamesAsync(CancellationToken cancellationToken = default)
-        {
-            // TODO: Get all state names from Dapr once implemented.
-            // var namesFromStateProvider = await this.stateProvider.EnumerateStateNamesAsync(this.actor.Id, cancellationToken);
-            await Task.CompletedTask;
-            var stateNameList = new List<string>();
-
-            var kvPairEnumerator = this.stateChangeTracker.GetEnumerator();
-
-            while (kvPairEnumerator.MoveNext())
-            {
-                switch (kvPairEnumerator.Current.Value.ChangeKind)
-                {
-                    case StateChangeKind.Add:
-                        stateNameList.Add(kvPairEnumerator.Current.Key);
-                        break;
-                    case StateChangeKind.Remove:
-                        stateNameList.Remove(kvPairEnumerator.Current.Key);
-                        break;
-                }
-            }
-
-            return stateNameList;
-        }
-
         public Task ClearCacheAsync(CancellationToken cancellationToken)
         {
             this.stateChangeTracker.Clear();
@@ -326,7 +301,7 @@ namespace Dapr.Actors.Runtime
 
         private sealed class StateMetadata
         {
-            private StateMetadata(object value,     Type type, StateChangeKind changeKind)
+            private StateMetadata(object value, Type type, StateChangeKind changeKind)
             {
                 this.Value = value;
                 this.Type = type;

--- a/src/Dapr.Actors/Runtime/IActorStateManager.cs
+++ b/src/Dapr.Actors/Runtime/IActorStateManager.cs
@@ -202,17 +202,6 @@ namespace Dapr.Actors.Runtime
         Task<T> AddOrUpdateStateAsync<T>(string stateName, T addValue, Func<string, T, T> updateValueFactory, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates an enumerable of all actor state names for current actor.
-        /// </summary>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <returns>
-        /// A task that represents the asynchronous enumeration operation. The value of TResult
-        /// parameter is an enumerable of all actor state names.
-        /// </returns>
-        /// <exception cref="OperationCanceledException">The operation was canceled.</exception>
-        Task<IEnumerable<string>> GetStateNamesAsync(CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Clears all the cached actor states and any operation(s) performed on <see cref="IActorStateManager"/>
         /// since last state save operation.
         /// </summary>


### PR DESCRIPTION
# Description

This API was intended to query the state store for all existing state
entries for the actor. However support for this in the dapr runtime has
not be implemented. We're removing this API to avoid confusion since
it does not behave as expected. We can revisit this in the future based
on feedback.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Fixes: #53

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
