### PR TITLE
Add HttpClient support for Dapr service invocation

### DIFF
--- a/docs/cancellation-tokens.md
+++ b/docs/cancellation-tokens.md
@@ -1,0 +1,9 @@
+## Working with cancellation tokens
+
+Asynchronous APIs exposed by `DaprClient` accept a cancellation token and by default, if the operation is canceled, you will get an OperationCanceledException. However, if you choose to initialize and pass in your own GrpcChannelOptions to the client builder, then unless you enable the [ThrowOperationCanceledOnCancellation setting](https://grpc.github.io/grpc/csharp-dotnet/api/Grpc.Net.Client.GrpcChannelOptions.html#Grpc_Net_Client_GrpcChannelOptions_ThrowOperationCanceledOnCancellation), the exception thrown would be an RpcException with StatusCode as Cancelled. To get an OperationCanceledException instead, refer to the code below:-
+```c#
+var httpClient = new HttpClient();
+var daprClient = new DaprClientBuilder()
+    .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient, ThrowOperationCanceledOnCancellation = true })
+    .Build();
+```

--- a/samples/Client/DaprClient/DaprClient.csproj
+++ b/samples/Client/DaprClient/DaprClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.13.0" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
   </ItemGroup>

--- a/samples/Client/DaprClient/DaprClient.csproj
+++ b/samples/Client/DaprClient/DaprClient.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
+    <RootNamespace>Samples.Client</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Client/DaprClient/Example.cs
+++ b/samples/Client/DaprClient/Example.cs
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Samples.Client
+{
+    public abstract class Example 
+    {
+        public abstract string DisplayName { get; }
+
+        public abstract Task RunAsync(CancellationToken cancellationToken);
+    }
+}

--- a/samples/Client/DaprClient/InvokeServiceGrpcExample.cs
+++ b/samples/Client/DaprClient/InvokeServiceGrpcExample.cs
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+
+namespace Samples.Client
+{
+    public class InvokeServiceGrpcExample : Example
+    {
+        public override string DisplayName => "Invoking a gRPC service with DaprClient";
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            var client = new DaprClientBuilder().Build();
+
+            Console.WriteLine("Invoking grpc balance");
+            var res = await client.InvokeMethodAsync<object, Account>("grpcsample", "getaccount", new { Id = "17" });
+            Console.WriteLine($"Received grpc balance {res.Balance}");
+
+            Console.WriteLine("Invoking grpc deposit");
+            var data = new Transaction() { Id = "17", Amount = 99m };
+            var result = await client.InvokeMethodAsync<Transaction, Account>("grpcsample", "deposit", data);
+            Console.WriteLine("Returned: id:{0} | Balance:{1}", result.Id, result.Balance);
+            Console.WriteLine("Completed grpc deposit");
+
+            Console.WriteLine("Invoking grpc withdraw");
+            var withdraw = new Transaction() { Id = "17", Amount = 10m, };
+            await client.InvokeMethodAsync("grpcsample", "withdraw", data);
+            Console.WriteLine("Completed grpc withdraw");
+        }
+
+        internal class Transaction
+        {
+            public string? Id { get; set; }
+
+            public decimal? Amount { get; set; }
+        }
+
+        internal class Account
+        {
+            public string? Id { get; set; }
+
+            public decimal? Balance { get; set; }
+        }
+    }
+}

--- a/samples/Client/DaprClient/InvokeServiceGrpcExample.cs
+++ b/samples/Client/DaprClient/InvokeServiceGrpcExample.cs
@@ -19,18 +19,18 @@ namespace Samples.Client
             var client = new DaprClientBuilder().Build();
 
             Console.WriteLine("Invoking grpc balance");
-            var res = await client.InvokeMethodAsync<object, Account>("grpcsample", "getaccount", new { Id = "17" });
-            Console.WriteLine($"Received grpc balance {res.Balance}");
+            var account = await client.InvokeMethodAsync<object, Account>("grpcsample", "getaccount", new { Id = "17" }, cancellationToken: cancellationToken);
+            Console.WriteLine($"Received grpc balance {account.Balance}");
 
             Console.WriteLine("Invoking grpc deposit");
             var data = new Transaction() { Id = "17", Amount = 99m };
-            var result = await client.InvokeMethodAsync<Transaction, Account>("grpcsample", "deposit", data);
-            Console.WriteLine("Returned: id:{0} | Balance:{1}", result.Id, result.Balance);
+            account = await client.InvokeMethodAsync<Transaction, Account>("grpcsample", "deposit", data, cancellationToken: cancellationToken);
+            Console.WriteLine("Returned: id:{0} | Balance:{1}", account.Id, account.Balance);
             Console.WriteLine("Completed grpc deposit");
 
             Console.WriteLine("Invoking grpc withdraw");
             var withdraw = new Transaction() { Id = "17", Amount = 10m, };
-            await client.InvokeMethodAsync("grpcsample", "withdraw", data);
+            await client.InvokeMethodAsync("grpcsample", "withdraw", data, cancellationToken: cancellationToken);
             Console.WriteLine("Completed grpc withdraw");
         }
 

--- a/samples/Client/DaprClient/InvokeServiceHttpClientExample.cs
+++ b/samples/Client/DaprClient/InvokeServiceHttpClientExample.cs
@@ -18,7 +18,7 @@ namespace Samples.Client
 
         public override async Task RunAsync(CancellationToken cancellationToken)
         {
-            var client = DaprClient.CreateInvokeClient(appId: "routing");
+            var client = DaprClient.CreateInvokeHttpClient(appId: "routing");
 
             var deposit = new Transaction  { Id = "17", Amount = 99m };
             var response = await client.PostAsJsonAsync("/deposit", deposit, cancellationToken);

--- a/samples/Client/DaprClient/InvokeServiceHttpClientExample.cs
+++ b/samples/Client/DaprClient/InvokeServiceHttpClientExample.cs
@@ -1,0 +1,50 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+
+namespace Samples.Client
+{
+    public class InvokeServiceHttpClientExample : Example
+    {
+        public override string DisplayName => "Invoking an HTTP service with HttpClient";
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            var client = DaprClient.CreateInvokeClient(appId: "routing");
+
+            var deposit = new Transaction  { Id = "17", Amount = 99m };
+            var response = await client.PostAsJsonAsync("/deposit", deposit, cancellationToken);
+            var account = await response.Content.ReadFromJsonAsync<Account>(cancellationToken: cancellationToken);
+            Console.WriteLine("Returned: id:{0} | Balance:{1}", account?.Id, account?.Balance);
+
+            var withdraw = new Transaction { Id = "17", Amount = 10m, };
+            response = await client.PostAsJsonAsync("/withdraw", withdraw, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            account = await client.GetFromJsonAsync<Account>("/17", cancellationToken);
+            Console.WriteLine($"Received balance {account?.Balance}");
+        }
+
+        internal class Transaction
+        {
+            public string? Id { get; set; }
+
+            public decimal? Amount { get; set; }
+        }
+
+        internal class Account
+        {
+            public string? Id { get; set; }
+
+            public decimal? Balance { get; set; }
+        }
+    }
+}

--- a/samples/Client/DaprClient/InvokeServiceHttpExample.cs
+++ b/samples/Client/DaprClient/InvokeServiceHttpExample.cs
@@ -1,0 +1,53 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+
+namespace Samples.Client
+{
+    public class InvokeServiceHttpExample : Example
+    {
+        public override string DisplayName => "Invoking an HTTP service with DaprClient";
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            var client = new DaprClientBuilder().Build();
+
+            // Invokes a POST method named "deposit" that takes input of type "Transaction" as define in the RoutingSample.
+            Console.WriteLine("Invoking deposit");
+            var data = new { id = "17", amount = 99m };
+            var account = await client.InvokeMethodAsync<object, Account>("routing", "deposit", data, HttpInvocationOptions.UsingPost());
+            Console.WriteLine("Returned: id:{0} | Balance:{1}", account.Id, account.Balance);
+
+            // Invokes a POST method named "Withdraw" that takes input of type "Transaction" as define in the RoutingSample.
+            Console.WriteLine("Invoking withdraw");
+            data = new { id = "17", amount = 10m, };
+            await client.InvokeMethodAsync<object>("routing", "Withdraw", data, HttpInvocationOptions.UsingPost());
+            Console.WriteLine("Completed");
+
+            // Invokes a GET method named "hello" that takes input of type "MyData" and returns a string.
+            Console.WriteLine("Invoking balance");
+            account = await client.InvokeMethodAsync<Account>("routing", "17", HttpInvocationOptions.UsingGet());
+            Console.WriteLine($"Received balance {account.Balance}");
+        }
+
+        internal class Transaction
+        {
+            public string? Id { get; set; }
+
+            public decimal? Amount { get; set; }
+        }
+
+        internal class Account
+        {
+            public string? Id { get; set; }
+
+            public decimal? Balance { get; set; }
+        }
+    }
+}

--- a/samples/Client/DaprClient/InvokeServiceHttpExample.cs
+++ b/samples/Client/DaprClient/InvokeServiceHttpExample.cs
@@ -21,18 +21,18 @@ namespace Samples.Client
             // Invokes a POST method named "deposit" that takes input of type "Transaction" as define in the RoutingSample.
             Console.WriteLine("Invoking deposit");
             var data = new { id = "17", amount = 99m };
-            var account = await client.InvokeMethodAsync<object, Account>("routing", "deposit", data, HttpInvocationOptions.UsingPost());
+            var account = await client.InvokeMethodAsync<object, Account>("routing", "deposit", data, HttpInvocationOptions.UsingPost(), cancellationToken);
             Console.WriteLine("Returned: id:{0} | Balance:{1}", account.Id, account.Balance);
 
             // Invokes a POST method named "Withdraw" that takes input of type "Transaction" as define in the RoutingSample.
             Console.WriteLine("Invoking withdraw");
             data = new { id = "17", amount = 10m, };
-            await client.InvokeMethodAsync<object>("routing", "Withdraw", data, HttpInvocationOptions.UsingPost());
+            await client.InvokeMethodAsync<object>("routing", "Withdraw", data, HttpInvocationOptions.UsingPost(), cancellationToken);
             Console.WriteLine("Completed");
 
             // Invokes a GET method named "hello" that takes input of type "MyData" and returns a string.
             Console.WriteLine("Invoking balance");
-            account = await client.InvokeMethodAsync<Account>("routing", "17", HttpInvocationOptions.UsingGet());
+            account = await client.InvokeMethodAsync<Account>("routing", "17", HttpInvocationOptions.UsingGet(), cancellationToken);
             Console.WriteLine($"Received balance {account.Balance}");
         }
 

--- a/samples/Client/DaprClient/Program.cs
+++ b/samples/Client/DaprClient/Program.cs
@@ -15,6 +15,7 @@ namespace Samples.Client
         {
             new InvokeServiceGrpcExample(),
             new InvokeServiceHttpExample(),
+            new InvokeServiceHttpClientExample(),
             new PublishEventExample(),
             new StateStoreExample(),
             new StateStoreTransactionsExample(),

--- a/samples/Client/DaprClient/Program.cs
+++ b/samples/Client/DaprClient/Program.cs
@@ -3,353 +3,42 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-namespace DaprClient
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Samples.Client
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text.Json;
-    using System.Threading.Tasks;
-    using Dapr;
-    using Dapr.Client;
-    using Grpc.Core;
-    using Microsoft.Extensions.Configuration;
-
-    /// <summary>
-    /// Shows Dapr client calls.
-    /// </summary>
-    public static class Program
+    class Program
     {
-        private static readonly string stateKeyName = "mykey";
-        private static readonly string storeName = "statestore";
-        private static readonly string pubsubName = "pubsub";
-        private static readonly string daprErrorInfoHTTPCodeMetadata  = "http.code";
-        private static readonly string daprErrorInfoHTTPErrorMetadata = "http.error_message";
-        private static readonly string grpcStatusDetails = "grpc-status-details-bin";
-        private static readonly string grpcErrorInfoDetail = "google.rpc.ErrorInfo";
-
-        /// <summary>
-        /// Main entry point.
-        /// </summary>
-        /// <param name="args">
-        /// set parameter "useRouting" true to use routing service;
-        /// set parameter "useGrpcsample" true to use grpcsample service
-        /// </param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task Main(string[] args)
+        private static readonly Example[] Examples = new Example[]
         {
-            var builder = new ConfigurationBuilder();
-            builder.AddCommandLine(args);
+            new InvokeServiceGrpcExample(),
+            new InvokeServiceHttpExample(),
+            new PublishEventExample(),
+            new StateStoreExample(),
+            new StateStoreTransactionsExample(),
+            new StateStoreETagsExample(),
+        };
 
-            var config = builder.Build();
-
-            var jsonOptions = new JsonSerializerOptions()
+        static async Task<int> Main(string[] args)
+        {
+            if (args.Length > 0 && int.TryParse(args[0], out var index) && index >= 0 && index < Examples.Length)
             {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true,
-            };
+                var cts = new CancellationTokenSource();
+                Console.CancelKeyPress += (object? sender, ConsoleCancelEventArgs e) => cts.Cancel();
 
-            var client = new DaprClientBuilder()
-                .UseJsonSerializationOptions(jsonOptions)
-                .Build();
-
-            await PublishEventAsync(client);
-
-            // Save State
-            await SaveStateAsync(client);
-
-            // Read State
-            await GetStateAsync(client);
-
-            // Delete State
-            await DeleteStateAsync(client);
-
-            // State Transaction
-            await ExecuteStateTransactionAsync(client);
-
-            // Read State
-            await GetStateAfterTransactionAsync(client);
-
-            // Read and save state with etags
-            await ReadAndSaveStateWithEtagsAsync(client);
-
-            if (config.GetValue("rpc-exception", false))
-            {
-                // Invoke /throwException route on the Controller sample server
-                await InvokeThrowExceptionOperationAsync(client);
+                await Examples[index].RunAsync(cts.Token);
+                return 0;
             }
 
-            // Invoke deposit operation on ControllerSample or RoutingSample or GrpcServiceSample service by publishing event.
-            await PublishDepositeEventAsync(client);
-
-            await Task.Delay(TimeSpan.FromSeconds(1));
-
-            #region Service Invoke - Required RoutingService
-            // This provides an example of how to invoke a method on another REST service that is listening on http.
-            // To use it run RoutingService in this solution.
-
-            if (config.GetValue("useRouting", false))
+            Console.WriteLine("Hello, please choose a sample to run:");
+            for (var i = 0; i < Examples.Length; i++)
             {
-                //Invoke deposit operation on RoutingSample service by POST.
-                await InvokeDepositServiceOperationAsync(client);
-
-                //Invoke withdraw operation on RoutingSample service by POST.
-                await InvokeWithdrawServiceOperationAsync(client);
-
-                //Invoke balance operation on RoutingSample service by GET.
-                await InvokeBalanceServiceOperationAsync(client);
+                Console.WriteLine($"{i}: {Examples[i].DisplayName}");
             }
-            #endregion
-
-            #region Service Invoke via GRPC - Required GrpcServiceSample
-
-            if (config.GetValue("useGrpcsample", false))
-            {
-                //Invoke deposit operation on GrpcServiceSample service by GRPC.
-                await InvokeGrpcDepositServiceOperationAsync(client);
-
-                //Invoke withdraw operation on GrpcServiceSample service by GRPC.
-                await InvokeGrpcWithdrawServiceOperationAsync(client);
-
-                //Invoke balance operation on GrpcServiceSample service by GRPC.
-                await InvokeGrpcBalanceServiceOperationAsync(client);
-            }
-
-            #endregion
-
-            Console.WriteLine("Done");
-        }
-
-        internal static async Task PublishDepositeEventAsync(DaprClient client)
-        {
-            var eventData = new { Id = "17", Amount = (decimal)10, };
-            await client.PublishEventAsync(pubsubName, "deposit", eventData);
-            Console.WriteLine("Published deposit event!");
-        }
-
-        internal static async Task PublishEventAsync(DaprClient client)
-        {
-            var eventData = new Widget() { Size = "small", Color = "yellow", };
-            await client.PublishEventAsync(pubsubName, "TopicA", eventData);
-            Console.WriteLine("Published Event!");
-        }
-
-        internal static async Task SaveStateAsync(DaprClient client)
-        {
-            var state = new Widget() { Size = "small", Color = "yellow", };
-            await client.SaveStateAsync(storeName, stateKeyName, state);
-            Console.WriteLine("Saved State!");
-        }
-
-        internal static async Task GetStateAsync(DaprClient client)
-        {
-            var state = await client.GetStateAsync<Widget>(storeName, stateKeyName);
-            if (state == null)
-            {
-                Console.WriteLine("State not found in store");
-            }
-            else
-            {
-                Console.WriteLine($"Got State: {state.Size}  {state.Color}");
-            }
-        }
-
-        internal static async Task DeleteStateAsync(DaprClient client)
-        {
-            await client.DeleteStateAsync(storeName, stateKeyName);
-            Console.WriteLine("Deleted State!");
-        }
-
-        internal static async Task ExecuteStateTransactionAsync(DaprClient client)
-        {
-            var value = new Widget() { Size = "small", Color = "yellow", }; 
-            var request1 = new StateTransactionRequest("mystate", JsonSerializer.SerializeToUtf8Bytes(value), StateOperationType.Upsert);
-            var request2 = new StateTransactionRequest("mystate", null, StateOperationType.Delete);
-            var requests = new List<StateTransactionRequest>
-            {
-                request1,
-                request2
-            };
-            
-            Console.WriteLine("Executing transaction - save state and delete state");
-            await client.ExecuteStateTransactionAsync(storeName, requests);
-            Console.WriteLine("Executed State Transaction!");
-        }
-
-        // This code demonstrates the use of ETags with State APIs.
-        internal static async Task ReadAndSaveStateWithEtagsAsync(DaprClient client)
-        {
-            // Save state which will create an etag for the state entry
-            var origState = new Widget() { Size = "small", Color = "yellow", };
-            await client.SaveStateAsync(storeName, stateKeyName, origState);
-
-            // Read the state and etag
-            var (origRetrievedState, origEtag) = await client.GetStateAndETagAsync<Widget>(storeName, stateKeyName);
-            Console.WriteLine($"Retrieved state: {origRetrievedState.Size}  {origRetrievedState.Color} with etag: {origEtag}");
-
-            // Modify the state which will update the etag
-            origRetrievedState.Color = "orange";
-            await client.SaveStateAsync<Widget>(storeName, stateKeyName, origRetrievedState);
-            Console.WriteLine($"Saved modified state : {origRetrievedState.Size}  {origRetrievedState.Color}");
-
-            // Read the updated state and etag
-            var (updatedRetrievedState, updatedEtag) = await client.GetStateAndETagAsync<Widget>(storeName, stateKeyName);
-            Console.WriteLine($"Retrieved state: {updatedRetrievedState.Size}  {updatedRetrievedState.Color} with etag: {updatedEtag}");
-
-            // Modify the state and try saving it with the old etag. This will fail
-            updatedRetrievedState.Color = "purple";
-            var isSaveStateSuccess = await client.TrySaveStateAsync<Widget>(storeName, stateKeyName, updatedRetrievedState, origEtag);
-            Console.WriteLine($"Saved state with old etag: {origEtag} successfully? {isSaveStateSuccess}");
-
-            // Modify the state and try saving it with the updated etag. This will succeed
-            isSaveStateSuccess = await client.TrySaveStateAsync<Widget>(storeName, stateKeyName, updatedRetrievedState, updatedEtag);
-            Console.WriteLine($"Saved state with latest etag: {updatedEtag} successfully? {isSaveStateSuccess}");
-        }
-
-        internal static async Task GetStateAfterTransactionAsync(DaprClient client)
-        {
-            var state = await client.GetStateAsync<Widget>(storeName, "mystate");
-            if (state == null)
-            {
-                Console.WriteLine("State not found in store");
-            }
-            else
-            {
-                Console.WriteLine($"Got Transaction State: {state.Size} {state.Color}");
-            }
-        }
-        internal static async Task InvokeDepositServiceOperationAsync(DaprClient client)
-        {
-            Console.WriteLine("Invoking deposit");
-            var data = new { id = "17", amount = (decimal)99 };
-
-            // Invokes a POST method named "depoit" that takes input of type "Transaction" as define in the RoutingSample.
-            Console.WriteLine("invoking");
-
-            var a = await client.InvokeMethodAsync<object, Account>("routing", "deposit", data, HttpInvocationOptions.UsingPost());
-            Console.WriteLine("Returned: id:{0} | Balance:{1}", a.Id, a.Balance);
-
-            Console.WriteLine("Completed");
-        }
-
-        /// <summary>
-        /// This example shows how to invoke a POST method on a service listening on http.
-        /// Example:  curl -X POST http://127.0.0.1:5000/deposit -H "Content-Type: application/json" -d "{ \"id\": \"17\", \"amount\": 120 }"
-        /// </summary>
-        /// <param name="client"></param>
-        /// <remarks>
-        /// Before invoking this method, please first run RoutingSample.
-        /// </remarks>
-        /// <returns></returns>
-        internal static async Task InvokeWithdrawServiceOperationAsync(DaprClient client)
-        {
-            Console.WriteLine("Invoking withdraw");
-            var data = new { id = "17", amount = (decimal)10, };
-
-            // Invokes a POST method named "Withdraw" that takes input of type "Transaction" as define in the RoutingSample.            
-            await client.InvokeMethodAsync<object>("routing", "Withdraw", data, HttpInvocationOptions.UsingPost());
-
-            Console.WriteLine("Completed");
-        }
-
-        /// <summary>
-        /// This example shows how to invoke a GET method on a service listening on http.
-        /// Example:  curl -X GET http://127.0.0.1:5000/17
-        /// </summary>
-        /// <param name="client"></param>
-        /// <remarks>
-        /// Before invoking this method, please first run RoutingSample.
-        /// </remarks>
-        /// <returns></returns>
-        internal static async Task InvokeBalanceServiceOperationAsync(DaprClient client)
-        {
-            Console.WriteLine("Invoking balance");
-
-            // Invokes a GET method named "hello" that takes input of type "MyData" and returns a string.
-            var res = await client.InvokeMethodAsync<Account>("routing", "17", HttpInvocationOptions.UsingGet());
-
-            Console.WriteLine($"Received balance {res.Balance}");
-        }
-
-        internal static async Task InvokeThrowExceptionOperationAsync(DaprClient client)
-        {
-            Console.WriteLine("Invoking ThrowException");
-            var data = new { id = "17", amount = (decimal)10, };
-
-            try
-            {
-                // Invokes a POST method named "throwException" that takes input of type "Transaction" as defined in the ControllerSample.            
-                await client.InvokeMethodAsync("controller", "throwException", data, HttpInvocationOptions.UsingPost());
-            }
-            catch (RpcException ex)
-            {
-                var entry = ex.Trailers.Get(grpcStatusDetails);
-                var status = Google.Rpc.Status.Parser.ParseFrom(entry.ValueBytes);
-                Console.WriteLine("Grpc Exception Message: " + status.Message);
-                Console.WriteLine("Grpc Statuscode: " + status.Code);
-                foreach(var detail in status.Details)
-                {
-                    if(Google.Protobuf.WellKnownTypes.Any.GetTypeName(detail.TypeUrl) == grpcErrorInfoDetail)
-                    {
-                        var rpcError = detail.Unpack<Google.Rpc.ErrorInfo>();
-                        Console.WriteLine("Grpc Exception: Http Error Message: " + rpcError.Metadata[daprErrorInfoHTTPErrorMetadata]);
-                        Console.WriteLine("Grpc Exception: Http Status Code: " + rpcError.Metadata[daprErrorInfoHTTPCodeMetadata]);
-                    }
-                }
-            }
-        }
-
-        internal static async Task InvokeGrpcBalanceServiceOperationAsync(DaprClient client)
-        {
-            Console.WriteLine("Invoking grpc balance");
-
-            var res = await client.InvokeMethodAsync<object, Account>("grpcsample", "getaccount", new { Id = "17" }, new HttpInvocationOptions());
-
-            Console.WriteLine($"Received grpc balance {res.Balance}");
-        }
-
-        internal static async Task InvokeGrpcDepositServiceOperationAsync(DaprClient client)
-        {
-            Console.WriteLine("Invoking grpc deposit");
-            var data = new { id = "17", amount = (decimal)99 };
-
-            Console.WriteLine("invoking");
-
-            var a = await client.InvokeMethodAsync<object, Account>("grpcsample", "deposit", data, new HttpInvocationOptions());
-            Console.WriteLine("Returned: id:{0} | Balance:{1}", a.Id, a.Balance);
-
-            Console.WriteLine("Completed grpc deposit");
-        }
-
-        internal static async Task InvokeGrpcWithdrawServiceOperationAsync(DaprClient client)
-        {
-            Console.WriteLine("Invoking grpc withdraw");
-            var data = new { id = "17", amount = (decimal)10, };
-
-            await client.InvokeMethodAsync<object>("grpcsample", "withdraw", data, new HttpInvocationOptions());
-
-            Console.WriteLine("Completed grpc withdraw");
-        }
-
-        private class Widget
-        {
-            public string Size { get; set; }
-            public string Color { get; set; }
-        }
-
-        class MyData
-        {
-            public MyData()
-            { }
-
-            public String Message { get; set; }
-        }
-
-
-        internal class Account
-        {
-            public string Id { get; set; }
-
-            public decimal Balance { get; set; }
+            Console.WriteLine();
+            return 1;
         }
     }
 }

--- a/samples/Client/DaprClient/PublishEventExample.cs
+++ b/samples/Client/DaprClient/PublishEventExample.cs
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+
+namespace Samples.Client
+{
+    public class PublishEventExample : Example
+    {
+        private static readonly string pubsubName = "pubsub";
+
+        public override string DisplayName => "Publishing Events";
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            var client = new DaprClientBuilder().Build();
+
+            var eventData = new { Id = "17", Amount = 10m, };
+            await client.PublishEventAsync(pubsubName, "deposit", eventData);
+            Console.WriteLine("Published deposit event!");
+        }
+
+        private class Widget
+        {
+            public string? Size { get; set; }
+            public string? Color { get; set; }
+        }
+    }
+}

--- a/samples/Client/DaprClient/PublishEventExample.cs
+++ b/samples/Client/DaprClient/PublishEventExample.cs
@@ -21,7 +21,7 @@ namespace Samples.Client
             var client = new DaprClientBuilder().Build();
 
             var eventData = new { Id = "17", Amount = 10m, };
-            await client.PublishEventAsync(pubsubName, "deposit", eventData);
+            await client.PublishEventAsync(pubsubName, "deposit", eventData, cancellationToken);
             Console.WriteLine("Published deposit event!");
         }
 

--- a/samples/Client/DaprClient/Readme.md
+++ b/samples/Client/DaprClient/Readme.md
@@ -1,4 +1,5 @@
 # Dapr Client Sample
+
 The client sample shows how to use the Dapr Client to:
 
 - Invoke services
@@ -11,54 +12,45 @@ The client sample shows how to use the Dapr Client to:
 * [Dapr CLI](https://github.com/dapr/cli)
 * [Dapr DotNet SDK](https://github.com/dapr/dotnet-sdk)
 
- ## Running the Sample
+## Running the Sample
 
- To run the sample locally run this command in DaprClient directory:
- ```sh
- dapr run --app-id DaprClient -- dotnet run <sample number>
- ```
+To run the sample locally run this command in DaprClient directory:
+```sh
+dapr run --app-id DaprClient -- dotnet run <sample number>
+```
 
 Running the following command will output a list of the samples included. 
- ```sh
- dapr run --app-id DaprClient -- dotnet run
- ```
+```sh
+dapr run --app-id DaprClient -- dotnet run
+```
 
- Press Ctrl+C to exit, and then run the command again and provide a sample number to run the samples.
+Press Ctrl+C to exit, and then run the command again and provide a sample number to run the samples.
 
- For example run this command to run the 0th sample from the list produced earlier.
+For example run this command to run the 0th sample from the list produced earlier.
+```sh
+dapr run --app-id DaprClient -- dotnet run 0
+```
 
-  ```sh
- dapr run --app-id DaprClient -- dotnet run 0
- ```
+Samples that use HTTP-based service invocation will require running the [RoutingService](../../AspNetCore/RoutingSample).
 
- Samples that use HTTP-based service invocation will require running the [RoutingService](../../AspNetCore/RoutingSample).
- 
- Samples that use gRPC-based service invocation will require running [GrpcService](../../AspNetCore/GrpcServiceSample).
+Samples that use gRPC-based service invocation will require running [GrpcService](../../AspNetCore/GrpcServiceSample).
 
 ## Invoking Services
 
-This solution contains a sample [RoutingSample service](../../AspNetCore/RoutingSample), which implements a simple banking application in ASP.NET core.
-
-The service provides following operations:
-
-- balance
-- withdraw
-- deposit
-
-The service is a typical HTTP service.
-
-See: [RoutingSample service](../../AspNetCore/RoutingSample/Startup.cs) for the defition of the service.
-
 See: `InvokeServiceHttpClientExample.cs` for an example of using `HttpClient` to invoke another service through Dapr.
 
-See: `InvokeServiceHttpExample.cs` for an example using the `DaprClient` to invoke another service throught Dapr.
+See: `InvokeServiceHttpExample.cs` for an example using the `DaprClient` to invoke another service through Dapr.
 
- ## Working with cancellation tokens
+See: `InvokeServiceGrpcExample.cs` for an example using the `DaprClient` to invoke a service using gRPC through Dapr.
 
-Asynchronous APIs exposed by `DaprClient` accept a cancellation token and by default, if the operation is canceled, you will get an OperationCanceledException. However, if you choose to initialize and pass in your own GrpcChannelOptions to the client builder, then unless you enable the [ThrowOperationCanceledOnCancellation setting](https://grpc.github.io/grpc/csharp-dotnet/api/Grpc.Net.Client.GrpcChannelOptions.html#Grpc_Net_Client_GrpcChannelOptions_ThrowOperationCanceledOnCancellation), the exception thrown would be an RpcException with StatusCode as Cancelled. To get an OperationCanceledException instead, refer to the code below:-
- ```c#
-            var httpClient = new HttpClient();
-            var daprClient = new DaprClientBuilder()
-                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient, ThrowOperationCanceledOnCancellation = true })
-                .Build();
-```
+## Publishing Pub/Sub Events
+
+See: `PublishEventExample.cs` for an example using the `DaprClient` to publish a pub/sub event.
+
+## Working with the State Store
+
+See: `StateStoreExample.cs` for an example of using `DaprClient` for basic state store operations like get, set, and delete.
+
+See: `StateStoreETagsExample.cs` for an example of using `DaprClient` for optimistic concurrency control with the state store.
+
+See: `StateStoreTransactionsExample.cs` for an example of using `DaprClient` for transactional state store operations that affect multiple keys. 

--- a/samples/Client/DaprClient/Readme.md
+++ b/samples/Client/DaprClient/Readme.md
@@ -2,177 +2,54 @@
 The client sample shows how to make Dapr calls to publish events, save state, get state and delete state using a Dapr client apis. 
 
 ## Prerequistes
-* [.Net Core SDK 3.1](https://dotnet.microsoft.com/download)
+
+* [.Net Core SDK](https://dotnet.microsoft.com/download)
 * [Dapr CLI](https://github.com/dapr/cli)
 * [Dapr DotNet SDK](https://github.com/dapr/dotnet-sdk)
-
 
  ## Running the Sample
 
  To run the sample locally run this command in DaprClient directory:
  ```sh
+ dapr run --app-id DaprClient -- dotnet run <sample number>
+ ```
+
+Running the following command will output a list of the samples included. 
+ ```sh
  dapr run --app-id DaprClient -- dotnet run
  ```
 
- Above command will run Dapr runtime and launch the app and will show logs both form Dapr runtime and the application. The client app will make calls to Dapr runtime to publish events, save state, get state and delete state using the gRPC client.
- Logs from application will show following in the command window:
-```sh
-Published Event!
-Saved State!
-Got State: small  yellow
-Deleted State!
-Executing transaction - save state and delete state
-Executed State Transaction!
-State not found in store
-Retrieved state: small  yellow with etag: 1
-Saved modified state : small  orange
-Retrieved state: small  orange with etag: 2
-Saved state with old etag: 1 successfully? False
-Saved state with latest etag: 2 successfully? True
-Published deposit event!
-Done
+ Press Ctrl+C to exit, and then run the command again and provide a sample number to run the samples.
+
+  ```sh
+ dapr run --app-id DaprClient -- dotnet run 0
  ```
 
-To invoke RoutingService via HTTP, run [RoutingService](../../AspNetCore/RoutingSample) or to invoke GrpcService via gRPC, run [GrpcService](../../AspNetCore/GrpcServiceSample) sample first. Then, invoke the client using the corresponding command below:-
-
-``` sh
- dapr run --app-id DaprClient -- dotnet run --useRouting true
-```
-
-or
-
-``` sh
- dapr run --app-id DaprClient -- dotnet run --useGrpcsample true
-```
-
-or to invoke RoutingService via HTTP and GrpcService via gRPC simultaneously:
-
-``` sh
- dapr run --app-id DaprClient -- dotnet run --useRouting true --useGrpcsample true
-```
+ Samples that use HTTP-based service invocation will require running the [RoutingService](../../AspNetCore/RoutingSample).
+ 
+ Samples that use gRPC-based service invocation will require running [GrpcService](../../AspNetCore/GrpcServiceSample).
 
 ## Invoking Services
+
 This solution contains a sample [RoutingSample service](../../AspNetCore/RoutingSample), which implements a simple banking application in ASP.NET core.
+
 The service provides following operations:
+
 - balance
 - withdraw
 - deposit
 
-The service is a typical HTTP service. The following sample demonstrates how to use the Dapr .NET SDK to invoke a service listening on HTTP.
+The service is a typical HTTP service.
 
-Operation *balance* is a GET-operation mapped as (see startup.cs in the *RoutingService*):
- ```c#
- endpoints.MapGet("{id}", Balance);
- ```
+See: [RoutingSample service](../../AspNetCore/RoutingSample/Startup.cs) for the defition of the service.
 
-It can be invoked via HTTP by using following urls.
-On Windows, Linux, MacOS:
- ```sh
-curl -X GET http://127.0.0.1:5000/17
- ```
+See: `InvokeServiceHttpClientExample.cs` for an example of using `HttpClient` to invoke another service through Dapr.
 
-Dapr supports out-of-the-box invocation of the service operation.
-To demonstrate this, take a look at the example inside `InvokeBalanceServiceOperationAsync()`.
-
-The following example invokes another service:
-
-```c#
-
-var res = await client.InvokeMethodAsync<object>(serviceName, methodName);
-```
-
-In this example, the HttpGet method is invoked on the service with name *serviceName*. This argument specifies the name of the service, which was used when in conjunction with *dapr run –app-id serviceName*.The *route* argument specifies the route of the service endpoint.
-For example, if your service listens on HTTP, the route is typically defined by attribute *HttpPost(“route”)* or *HttpGet(“route”)*. Last argument is called metadata and it specifies GET operation in its example.
-
-
-Second service operation *withdraw* can be invoked by HTTP POST request, but also triggered as a *cloud event* by publishing the event to the topic with name 'withdraw'.
-To enable this, the operation is mapped as:
- ```c#
-endpoints.MapPost("withdraw", Withdraw).WithTopic("withdraw");
- ```
-and it can also be invoked (triggered) by following url:
-
-On Linux and MacOS:
- ```sh
-curl -X POST http://127.0.0.1:5000/withdraw \
-        -H 'Content-Type: application/json' \
-        -d '{ "id": "17", "amount": 10 }'
- ```
-On Windows:
- ```sh
-curl -X POST http://127.0.0.1:5000/withdraw -H "Content-Type: application/json" -d "{ \"id\": \"17\", \"amount\": 1 }"
- ```
-
-
-The method *InvokeWithdrawServiceOperationAsync* demonstrates how to use DAPR .NET SDK to invoke a POST operation on another service.
-
- ```c#        
-            ...
-
-            var data = new { id = "17", amount = (decimal)10, };
-            
-            // The HttpInvocationOptions object is needed to specify additional information such as the HTTP method and an optional query string, because the receiving service is listening on HTTP.  If it were listening on gRPC, it is not needed.
-            var httpOptions = new HttpInvocationOptions()
-            {
-                Method = HttpMethod.Post
-            };
-
-            await client.InvokeMethodAsync<object>("routing", "Withdraw", data, httpOptions);
- ```
-
-Because, the same operation subscribes events on the *withdraw* topic, it can be invoked by event:
-``` 
-dapr publish -t withdraw -p '{"id": "17", "amount": 15 }'
-``` 
-
-Operation *deposit* can be invoked by HTTP POST request and also triggered as a *cloud event* by publishing the event to the topic with name 'deposit'.
-It is mapped as:
- ```c#
-endpoints.MapPost("deposit", Withdraw).WithTopic("deposit");
- ```
-You can also use a **dapr** cli to publish the event to invoke te operation *deposit*: 
-``` 
-dapr publish -t deposit -p '{"id": "17", "deposit": 15 }'
- ``` 
-
-The method *PublishDepositeEventToRoutingSampleAsync* demonstrates how to publish an event to the dapr runtime, which triggers the operation 'deposit'.
- ```c#
-            await client.PublishEventAsync("deposit", new  { id = "17", amount = (decimal)10, });          
- ```
-
-
-## Handling RpcException
-
-Run the controller sample as follows from samples/AspNetCore/ControllerSample directory:
-```
-dapr run --app-id controller --app-port 5000 dotnet run
-```
-
-Run the client sample as follows from samples/Client/DaprClient directory. Setting the "--rpc-exception" argument to true will invoke a route on the server side that causes it to throw an RpcException:
-```
-dapr run --app-id DaprClient dotnet run --rpc-exception true
-```
-
-The controller sample has a route "/throwException" that returns a BadRequest result which causes the Dapr sidecar to throw an RpcException. The method *InvokeThrowExceptionOperationAsync* on the client side demonstrates how to extract the error message from RpcException.
-```c#
-            var entry = ex.Trailers.Get(grpcStatusDetails);
-            var status = Google.Rpc.Status.Parser.ParseFrom(entry.ValueBytes);
-            Console.WriteLine("Grpc Exception Message: " + status.Message);
-            Console.WriteLine("Grpc Statuscode: " + status.Code);
-            foreach(var detail in status.Details)
-            {
-                if(Google.Protobuf.WellKnownTypes.Any.GetTypeName(detail.TypeUrl) == grpcErrorInfoDetail)
-                {
-                    var rpcError = detail.Unpack<Google.Rpc.ErrorInfo>();
-                    Console.WriteLine("Grpc Exception: Http Error Message: " + rpcError.Metadata[daprErrorInfoHTTPErrorMetadata]);
-                    Console.WriteLine("Grpc Exception: Http Status Code: " + rpcError.Metadata[daprErrorInfoHTTPCodeMetadata]);
-                }
-            }
- ```
+See: `InvokeServiceHttpExample.cs` for an example using the `DaprClient` to invoke another service throught Dapr.
 
  ## Working with cancellation tokens
 
- InvokeMethodAsync and other APIs exposed by Dapr client accept a cancellation token and by default, if the operation is canceled, you will get an OperationCanceledException. However, if you choose to initialize and pass in your own GrpcChannelOptions to the client builder, then unless you enable the [ThrowOperationCanceledOnCancellation setting](https://grpc.github.io/grpc/csharp-dotnet/api/Grpc.Net.Client.GrpcChannelOptions.html#Grpc_Net_Client_GrpcChannelOptions_ThrowOperationCanceledOnCancellation), the exception thrown would be an RpcException with StatusCode as Cancelled. To get an OperationCanceledException instead, refer to the code below:-
+Asynchronous APIs exposed by `DaprClient` accept a cancellation token and by default, if the operation is canceled, you will get an OperationCanceledException. However, if you choose to initialize and pass in your own GrpcChannelOptions to the client builder, then unless you enable the [ThrowOperationCanceledOnCancellation setting](https://grpc.github.io/grpc/csharp-dotnet/api/Grpc.Net.Client.GrpcChannelOptions.html#Grpc_Net_Client_GrpcChannelOptions_ThrowOperationCanceledOnCancellation), the exception thrown would be an RpcException with StatusCode as Cancelled. To get an OperationCanceledException instead, refer to the code below:-
  ```c#
             var httpClient = new HttpClient();
             var daprClient = new DaprClientBuilder()

--- a/samples/Client/DaprClient/Readme.md
+++ b/samples/Client/DaprClient/Readme.md
@@ -1,5 +1,9 @@
 # Dapr Client Sample
-The client sample shows how to make Dapr calls to publish events, save state, get state and delete state using a Dapr client apis. 
+The client sample shows how to use the Dapr Client to:
+
+- Invoke services
+- Publish events
+- Use the state store to get, set, and delete data
 
 ## Prerequistes
 
@@ -20,6 +24,8 @@ Running the following command will output a list of the samples included.
  ```
 
  Press Ctrl+C to exit, and then run the command again and provide a sample number to run the samples.
+
+ For example run this command to run the 0th sample from the list produced earlier.
 
   ```sh
  dapr run --app-id DaprClient -- dotnet run 0

--- a/samples/Client/DaprClient/StateStoreETagsExample.cs
+++ b/samples/Client/DaprClient/StateStoreETagsExample.cs
@@ -1,0 +1,56 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+
+namespace Samples.Client
+{
+    public class StateStoreETagsExample : Example
+    {
+        private static readonly string stateKeyName = "widget";
+        private static readonly string storeName = "statestore";
+
+        public override string DisplayName => "Using the State Store with ETags";
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            var client = new DaprClientBuilder().Build();
+
+            // Save state which will create an etag for the state entry
+            await client.SaveStateAsync(storeName, stateKeyName, new Widget() { Size = "small", Color = "yellow", });
+
+            // Read the state and etag
+            var (original, originalETag) = await client.GetStateAndETagAsync<Widget>(storeName, stateKeyName);
+            Console.WriteLine($"Retrieved state: {original.Size}  {original.Color} with etag: {originalETag}");
+
+            // Modify the state which will update the etag
+            original.Color = "orange";
+            await client.SaveStateAsync<Widget>(storeName, stateKeyName, original);
+            Console.WriteLine($"Saved modified state : {original.Size}  {original.Color}");
+
+            // Read the updated state and etag
+            var (updated, updatedETag) = await client.GetStateAndETagAsync<Widget>(storeName, stateKeyName);
+            Console.WriteLine($"Retrieved state: {updated.Size}  {updated.Color} with etag: {updatedETag}");
+
+            // Modify the state and try saving it with the old etag. This will fail
+            updated.Color = "purple";
+            var isSaveStateSuccess = await client.TrySaveStateAsync<Widget>(storeName, stateKeyName, updated, originalETag);
+            Console.WriteLine($"Saved state with old etag: {originalETag} successfully? {isSaveStateSuccess}");
+
+            // Modify the state and try saving it with the updated etag. This will succeed
+            isSaveStateSuccess = await client.TrySaveStateAsync<Widget>(storeName, stateKeyName, updated, updatedETag);
+            Console.WriteLine($"Saved state with latest etag: {updatedETag} successfully? {isSaveStateSuccess}");
+        }
+
+        private class Widget
+        {
+            public string? Size { get; set; }
+            public string? Color { get; set; }
+        }
+    }
+}

--- a/samples/Client/DaprClient/StateStoreETagsExample.cs
+++ b/samples/Client/DaprClient/StateStoreETagsExample.cs
@@ -22,28 +22,28 @@ namespace Samples.Client
             var client = new DaprClientBuilder().Build();
 
             // Save state which will create an etag for the state entry
-            await client.SaveStateAsync(storeName, stateKeyName, new Widget() { Size = "small", Color = "yellow", });
+            await client.SaveStateAsync(storeName, stateKeyName, new Widget() { Size = "small", Color = "yellow", }, cancellationToken: cancellationToken);
 
             // Read the state and etag
-            var (original, originalETag) = await client.GetStateAndETagAsync<Widget>(storeName, stateKeyName);
+            var (original, originalETag) = await client.GetStateAndETagAsync<Widget>(storeName, stateKeyName, cancellationToken: cancellationToken);
             Console.WriteLine($"Retrieved state: {original.Size}  {original.Color} with etag: {originalETag}");
 
             // Modify the state which will update the etag
             original.Color = "orange";
-            await client.SaveStateAsync<Widget>(storeName, stateKeyName, original);
+            await client.SaveStateAsync<Widget>(storeName, stateKeyName, original, cancellationToken: cancellationToken);
             Console.WriteLine($"Saved modified state : {original.Size}  {original.Color}");
 
             // Read the updated state and etag
-            var (updated, updatedETag) = await client.GetStateAndETagAsync<Widget>(storeName, stateKeyName);
+            var (updated, updatedETag) = await client.GetStateAndETagAsync<Widget>(storeName, stateKeyName, cancellationToken: cancellationToken);
             Console.WriteLine($"Retrieved state: {updated.Size}  {updated.Color} with etag: {updatedETag}");
 
             // Modify the state and try saving it with the old etag. This will fail
             updated.Color = "purple";
-            var isSaveStateSuccess = await client.TrySaveStateAsync<Widget>(storeName, stateKeyName, updated, originalETag);
+            var isSaveStateSuccess = await client.TrySaveStateAsync<Widget>(storeName, stateKeyName, updated, originalETag, cancellationToken: cancellationToken);
             Console.WriteLine($"Saved state with old etag: {originalETag} successfully? {isSaveStateSuccess}");
 
             // Modify the state and try saving it with the updated etag. This will succeed
-            isSaveStateSuccess = await client.TrySaveStateAsync<Widget>(storeName, stateKeyName, updated, updatedETag);
+            isSaveStateSuccess = await client.TrySaveStateAsync<Widget>(storeName, stateKeyName, updated, updatedETag, cancellationToken: cancellationToken);
             Console.WriteLine($"Saved state with latest etag: {updatedETag} successfully? {isSaveStateSuccess}");
         }
 

--- a/samples/Client/DaprClient/StateStoreExample.cs
+++ b/samples/Client/DaprClient/StateStoreExample.cs
@@ -1,0 +1,48 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+
+namespace Samples.Client
+{
+    public class StateStoreExample : Example
+    {
+        private static readonly string stateKeyName = "widget";
+        private static readonly string storeName = "statestore";
+
+        public override string DisplayName => "Using the State Store";
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            var client = new DaprClientBuilder().Build();
+
+            var state = new Widget() { Size = "small", Color = "yellow", };
+            await client.SaveStateAsync(storeName, stateKeyName, state);
+            Console.WriteLine("Saved State!");
+
+            state = await client.GetStateAsync<Widget>(storeName, stateKeyName);
+            if (state == null)
+            {
+                Console.WriteLine("State not found in store");
+            }
+            else
+            {
+                Console.WriteLine($"Got State: {state.Size} {state.Color}");
+            }
+
+            await client.DeleteStateAsync(storeName, stateKeyName);
+            Console.WriteLine("Deleted State!");
+        }
+
+        private class Widget
+        {
+            public string? Size { get; set; }
+            public string? Color { get; set; }
+        }
+    }
+}

--- a/samples/Client/DaprClient/StateStoreExample.cs
+++ b/samples/Client/DaprClient/StateStoreExample.cs
@@ -22,10 +22,10 @@ namespace Samples.Client
             var client = new DaprClientBuilder().Build();
 
             var state = new Widget() { Size = "small", Color = "yellow", };
-            await client.SaveStateAsync(storeName, stateKeyName, state);
+            await client.SaveStateAsync(storeName, stateKeyName, state, cancellationToken: cancellationToken);
             Console.WriteLine("Saved State!");
 
-            state = await client.GetStateAsync<Widget>(storeName, stateKeyName);
+            state = await client.GetStateAsync<Widget>(storeName, stateKeyName, cancellationToken: cancellationToken);
             if (state == null)
             {
                 Console.WriteLine("State not found in store");
@@ -35,7 +35,7 @@ namespace Samples.Client
                 Console.WriteLine($"Got State: {state.Size} {state.Color}");
             }
 
-            await client.DeleteStateAsync(storeName, stateKeyName);
+            await client.DeleteStateAsync(storeName, stateKeyName, cancellationToken: cancellationToken);
             Console.WriteLine("Deleted State!");
         }
 

--- a/samples/Client/DaprClient/StateStoreTransactionsExample.cs
+++ b/samples/Client/DaprClient/StateStoreTransactionsExample.cs
@@ -34,10 +34,10 @@ namespace Samples.Client
             };
             
             Console.WriteLine("Executing transaction - save state and delete state");
-            await client.ExecuteStateTransactionAsync(storeName, requests);
+            await client.ExecuteStateTransactionAsync(storeName, requests, cancellationToken: cancellationToken);
             Console.WriteLine("Executed State Transaction!");
 
-            var state = await client.GetStateAsync<Widget>(storeName, "widget");
+            var state = await client.GetStateAsync<Widget>(storeName, "widget", cancellationToken: cancellationToken);
             if (state == null)
             {
                 Console.WriteLine("State not found in store");

--- a/samples/Client/DaprClient/StateStoreTransactionsExample.cs
+++ b/samples/Client/DaprClient/StateStoreTransactionsExample.cs
@@ -1,0 +1,57 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+
+namespace Samples.Client
+{
+    public class StateStoreTransactionsExample : Example
+    {
+        private static readonly string storeName = "statestore";
+
+        public override string DisplayName => "Using the State Store with Transactions";
+
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            var client = new DaprClientBuilder().Build();
+
+            var value = new Widget() { Size = "small", Color = "yellow", };
+
+            // State transactions operate on raw bytes
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(value);
+
+            var requests = new List<StateTransactionRequest>()
+            {
+                new StateTransactionRequest("widget", bytes, StateOperationType.Upsert),
+                new StateTransactionRequest("oldwidget", null, StateOperationType.Delete)
+            };
+            
+            Console.WriteLine("Executing transaction - save state and delete state");
+            await client.ExecuteStateTransactionAsync(storeName, requests);
+            Console.WriteLine("Executed State Transaction!");
+
+            var state = await client.GetStateAsync<Widget>(storeName, "widget");
+            if (state == null)
+            {
+                Console.WriteLine("State not found in store");
+            }
+            else
+            {
+                Console.WriteLine($"Got State: {state.Size} {state.Color}");
+            }
+        }
+
+        private class Widget
+        {
+            public string? Size { get; set; }
+            public string? Color { get; set; }
+        }
+    }
+}

--- a/src/Dapr.Client/BulkStateItem.cs
+++ b/src/Dapr.Client/BulkStateItem.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-namespace Dapr
+namespace Dapr.Client
 {
     /// <summary>
     /// Represents a state object returned from a bulk get state operation.

--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -48,6 +48,7 @@ namespace Dapr.Client
 
             if (daprEndpoint is string)
             {
+                // DaprEndpoint performs validation.
                 handler.DaprEndpoint = daprEndpoint;
             }
 
@@ -55,7 +56,14 @@ namespace Dapr.Client
             
             if (appId is string)
             {
-                httpClient.BaseAddress = new Uri($"http://{appId}");
+                try
+                {
+                    httpClient.BaseAddress = new Uri($"http://{appId}");
+                }
+                catch (UriFormatException inner)
+                {
+                    throw new ArgumentException("The appId must be a valid hostname.", nameof(appId), inner);
+                }
             }
 
             return httpClient;

--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -42,7 +42,7 @@ namespace Dapr.Client
         /// a single client object can be reused for the life of the application.
         /// </para>
         /// </remarks>
-        public static HttpClient CreateInvokeClient(string appId = null, string daprEndpoint = null)
+        public static HttpClient CreateInvokeHttpClient(string appId = null, string daprEndpoint = null)
         {
             var handler = new InvocationHandler(){ InnerHandler = new HttpClientHandler(), };
 

--- a/src/Dapr.Client/InvocationHandler.cs
+++ b/src/Dapr.Client/InvocationHandler.cs
@@ -39,7 +39,18 @@ namespace Dapr.Client
         private static string GetDefaultDaprEndpoint()
         {
             var port = Environment.GetEnvironmentVariable("DAPR_HTTP_PORT") ?? DefaultDaprHttpPort;
+            
+            // Since we're dealing with environment variables, treat empty the same as null.
+            port = port == string.Empty ? DefaultDaprHttpPort : port;
             return $"http://127.0.0.1:{port}";
+        }
+
+        private static string? GetDaprApiToken()
+        {
+            var token = Environment.GetEnvironmentVariable("DAPR_API_TOKEN");
+
+            // Since we're dealing with environment variables, treat empty the same as null.
+            return token == string.Empty ? null : token;
         }
 
         private Uri parsedEndpoint;
@@ -51,7 +62,7 @@ namespace Dapr.Client
         public InvocationHandler()
         {
             this.parsedEndpoint = new Uri(GetDefaultDaprEndpoint(), UriKind.Absolute);
-            this.apiToken = Environment.GetEnvironmentVariable("DAPR_API_TOKEN");
+            this.apiToken = GetDaprApiToken();
         }
 
         /// <summary>

--- a/src/Dapr.Client/InvocationHandler.cs
+++ b/src/Dapr.Client/InvocationHandler.cs
@@ -1,0 +1,137 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Dapr.Client
+{
+    /// <summary>
+    /// <para>
+    /// A <see cref="DelegatingHandler" /> implementation that rewrites URIs of outgoing requests
+    /// to use the Dapr service invocation protocol. This handle allows code using <see cref="HttpClient" />
+    /// to use the client as-if it were communciating with the destination application directly.
+    /// </para>
+    /// <para>
+    /// The handler will read the <see cref="HttpRequestMessage.RequestUri" /> property, and 
+    /// interpret the hostname as the destination <c>app-id</c>. The <see cref="HttpRequestMessage.RequestUri" /> 
+    /// property will be replaced with a new URI with the authority section replaced by <see cref="DaprEndpoint" />
+    /// and the path portion of the URI rewitten to follow the format of a Dapr service invocation request.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// This message handler does not distinguish between requests destined for Dapr service invocation and general
+    /// HTTP traffic, and will attempt to forward all traffic to the Dapr endpoint. Do not attempt to set
+    /// <see cref="DaprEndpoint" /> to a publicly routable URI, this will result in leaking of traffic and the Dapr
+    /// security token.
+    /// </remarks>
+    public class InvocationHandler : DelegatingHandler
+    {
+        private const string DefaultDaprHttpPort = "3500";
+
+        private static string GetDefaultDaprEndpoint()
+        {
+            var port = Environment.GetEnvironmentVariable("DAPR_HTTP_PORT") ?? DefaultDaprHttpPort;
+            return $"http://127.0.0.1:{port}";
+        }
+
+        private Uri parsedEndpoint;
+        private string? apiToken;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="InvocationHandler" />.
+        /// </summary>
+        public InvocationHandler()
+        {
+            this.parsedEndpoint = new Uri(GetDefaultDaprEndpoint(), UriKind.Absolute);
+            this.apiToken = Environment.GetEnvironmentVariable("DAPR_API_TOKEN");
+        }
+
+        /// <summary>
+        /// Gets or the sets the URI of the Dapr HTTP endpoint used for service invocation.
+        /// </summary>
+        /// <returns>The URI of the Dapr HTTP endpoint used for service invocation.</returns>
+        public string DaprEndpoint
+        {
+            get
+            {
+                return this.parsedEndpoint.OriginalString;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                // This will throw a reasonable exception if the URI is invalid.
+                this.parsedEndpoint = new Uri(value, UriKind.Absolute);
+            }
+        }
+
+        // Internal for testing
+        internal string? DaprApiToken
+        {
+            get => this.apiToken;
+            set => this.apiToken = value;
+        }
+
+        /// <inheritdoc />
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var original = request.RequestUri;
+            if (!this.TryRewriteUri(request.RequestUri, out var rewritten))
+            {
+                throw new ArgumentException($"The request URI '{original}' is not a valid Dapr service invocation destination.", nameof(request));
+            }
+
+            try
+            {
+                if (this.apiToken is string)
+                {
+                    request.Headers.Add("dapr-api-token", this.apiToken);
+                }
+                request.RequestUri = rewritten;
+
+                return await base.SendAsync(request, cancellationToken);
+            }
+            finally
+            {
+                request.RequestUri = original;
+                request.Headers.Remove("dapr-api-token");
+            }
+        }
+
+        // Internal for testing
+        internal bool TryRewriteUri(Uri uri, [NotNullWhen(true)] out Uri? rewritten)
+        {
+            // For now the only invalid cases are when the request URI is missing or just silly.
+            // We may support additional cases for validation in the future (like an allow-list of App-Ids).
+            if (uri is null || !uri.IsAbsoluteUri || (uri.Scheme != "http" && uri.Scheme != "https"))
+            {
+                // do nothing
+                rewritten = null;
+                return false;
+            }
+
+
+            var builder = new UriBuilder(uri)
+            {
+                Scheme = this.parsedEndpoint.Scheme,
+                Host = this.parsedEndpoint.Host,
+                Port = this.parsedEndpoint.Port,
+                Path = $"/v1.0/invoke/{uri.Host}/method" + uri.AbsolutePath,
+            };
+
+            rewritten = builder.Uri;
+            return true;
+        }
+    }
+}

--- a/src/Dapr.Client/InvocationHandler.cs
+++ b/src/Dapr.Client/InvocationHandler.cs
@@ -83,7 +83,13 @@ namespace Dapr.Client
                 }
 
                 // This will throw a reasonable exception if the URI is invalid.
-                this.parsedEndpoint = new Uri(value, UriKind.Absolute);
+                var uri = new Uri(value, UriKind.Absolute);
+                if (uri.Scheme != "http" && uri.Scheme != "https")
+                {
+                    throw new ArgumentException("The URI scheme of the Dapr endpoint must be http or https.", "value");
+                }
+
+                this.parsedEndpoint = uri;
             }
         }
 

--- a/src/Dapr.Client/StateTransactionRequest.cs
+++ b/src/Dapr.Client/StateTransactionRequest.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-namespace Dapr
+namespace Dapr.Client
 {
     using System.Collections.Generic;
     using System.Threading;

--- a/test/Dapr.AspNetCore.IntegrationTest/StateTestClient.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest/StateTestClient.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-namespace Dapr
+namespace Dapr.Client
 {
     using System;
     using System.Collections.Generic;

--- a/test/Dapr.Client.Test/DaprClientTest.cs
+++ b/test/Dapr.Client.Test/DaprClientTest.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
+using System;
 using Xunit;
 
 namespace Dapr.Client
@@ -17,10 +18,45 @@ namespace Dapr.Client
         }
 
         [Fact]
+        public void CreateInvokeHttpClient_InvalidAppId()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => 
+            { 
+                // The appId needs to be something that can be used as hostname in a URI.
+                _ = DaprClient.CreateInvokeHttpClient(appId: "");
+            });
+
+            Assert.Contains("The appId must be a valid hostname.", ex.Message);
+            Assert.IsType<UriFormatException>(ex.InnerException);
+        }
+
+        [Fact]
         public void CreateInvokeHttpClient_WithoutAppId()
         {
             var client = DaprClient.CreateInvokeHttpClient(daprEndpoint: "http://localhost:3500");
             Assert.Null(client.BaseAddress);
+        }
+
+        [Fact]
+        public void CreateInvokeHttpClient_InvalidDaprEndpoint_InvalidFormat()
+        {
+            Assert.Throws<UriFormatException>(() => 
+            { 
+                _ = DaprClient.CreateInvokeHttpClient(daprEndpoint: "");
+            });
+
+            // Exception message comes from the runtime, not validating it here.
+        }
+
+        [Fact]
+        public void CreateInvokeHttpClient_InvalidDaprEndpoint_InvalidScheme()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => 
+            { 
+                _ = DaprClient.CreateInvokeHttpClient(daprEndpoint: "ftp://localhost:3500");
+            });
+
+            Assert.Contains("The URI scheme of the Dapr endpoint must be http or https.", ex.Message);
         }
     }
 }

--- a/test/Dapr.Client.Test/DaprClientTest.cs
+++ b/test/Dapr.Client.Test/DaprClientTest.cs
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using Xunit;
+
+namespace Dapr.Client
+{
+    public class DaprClientTest
+    {
+        [Fact]
+        public void CreateInvokeClient_WithAppId()
+        {
+            var client = DaprClient.CreateInvokeClient(appId: "bank", daprEndpoint: "http://localhost:3500");
+            Assert.Equal("http://bank/", client.BaseAddress.AbsoluteUri);
+        }
+
+        [Fact]
+        public void CreateInvokeClient_WithoutAppId()
+        {
+            var client = DaprClient.CreateInvokeClient(daprEndpoint: "http://localhost:3500");
+            Assert.Null(client.BaseAddress);
+        }
+    }
+}

--- a/test/Dapr.Client.Test/DaprClientTest.cs
+++ b/test/Dapr.Client.Test/DaprClientTest.cs
@@ -10,16 +10,16 @@ namespace Dapr.Client
     public class DaprClientTest
     {
         [Fact]
-        public void CreateInvokeClient_WithAppId()
+        public void CreateInvokeHttpClient_WithAppId()
         {
-            var client = DaprClient.CreateInvokeClient(appId: "bank", daprEndpoint: "http://localhost:3500");
+            var client = DaprClient.CreateInvokeHttpClient(appId: "bank", daprEndpoint: "http://localhost:3500");
             Assert.Equal("http://bank/", client.BaseAddress.AbsoluteUri);
         }
 
         [Fact]
-        public void CreateInvokeClient_WithoutAppId()
+        public void CreateInvokeHttpClient_WithoutAppId()
         {
-            var client = DaprClient.CreateInvokeClient(daprEndpoint: "http://localhost:3500");
+            var client = DaprClient.CreateInvokeHttpClient(daprEndpoint: "http://localhost:3500");
             Assert.Null(client.BaseAddress);
         }
     }

--- a/test/Dapr.Client.Test/InvocationHandlerTests.cs
+++ b/test/Dapr.Client.Test/InvocationHandlerTests.cs
@@ -19,9 +19,51 @@ namespace Dapr.Client
     public class InvocationHandlerTests 
     {
         [Fact]
-        public void TryRewriteUri_FailsForInvalidUris()
+        public void DaprEndpoint_InvalidScheme()
         {
-            var uri = new Uri("/test"); // We don't handle many invalid cases today, just non-absolute URIs
+            var handler = new InvocationHandler();
+            var ex = Assert.Throws<ArgumentException>(() => 
+            { 
+                handler.DaprEndpoint = "ftp://localhost:3500";
+            });
+
+            Assert.Contains("The URI scheme of the Dapr endpoint must be http or https.", ex.Message);
+        }
+
+        [Fact]
+        public void DaprEndpoint_InvalidUri()
+        {
+            var handler = new InvocationHandler();
+            Assert.Throws<UriFormatException>(() =>
+            { 
+                handler.DaprEndpoint = "";
+            });
+
+            // Exception message comes from the runtime, not validating it here
+        }
+
+        [Fact]
+        public void TryRewriteUri_FailsForNullUri()
+        {
+            var handler = new InvocationHandler();
+            Assert.False(handler.TryRewriteUri(null!, out var rewritten));
+            Assert.Null(rewritten);
+        }
+
+        [Fact]
+        public void TryRewriteUri_FailsForBadScheme()
+        {
+            var uri = new Uri("ftp://test", UriKind.Relative);
+
+            var handler = new InvocationHandler();
+            Assert.False(handler.TryRewriteUri(uri, out var rewritten));
+            Assert.Null(rewritten);
+        }
+
+        [Fact]
+        public void TryRewriteUri_FailsForRelativeUris()
+        {
+            var uri = new Uri("test", UriKind.Relative);
 
             var handler = new InvocationHandler();
             Assert.False(handler.TryRewriteUri(uri, out var rewritten));

--- a/test/Dapr.Client.Test/InvocationHandlerTests.cs
+++ b/test/Dapr.Client.Test/InvocationHandlerTests.cs
@@ -1,0 +1,143 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+#nullable enable
+
+namespace Dapr.Client
+{
+    public class InvocationHandlerTests 
+    {
+        [Fact]
+        public void TryRewriteUri_FailsForInvalidUris()
+        {
+            var uri = new Uri("/test"); // We don't handle many invalid cases today, just non-absolute URIs
+
+            var handler = new InvocationHandler();
+            Assert.False(handler.TryRewriteUri(uri, out var rewritten));
+            Assert.Null(rewritten);
+        }
+
+        [Theory]
+        [InlineData("http://bank", "https://some.host:3499/v1.0/invoke/bank/method/")]
+        [InlineData("http://bank:3939", "https://some.host:3499/v1.0/invoke/bank/method/")]
+        [InlineData("http://app-id.with.dots", "https://some.host:3499/v1.0/invoke/app-id.with.dots/method/")]
+        [InlineData("http://bank:3939/", "https://some.host:3499/v1.0/invoke/bank/method/")]
+        [InlineData("http://bank:3939/some/path", "https://some.host:3499/v1.0/invoke/bank/method/some/path")]
+        [InlineData("http://bank:3939/some/path?q=test&p=another#fragment", "https://some.host:3499/v1.0/invoke/bank/method/some/path?q=test&p=another#fragment")]
+        public void TryRewriteUri_RewritesUriToDaprInvoke(string uri, string expected)
+        {
+            var handler = new InvocationHandler()
+            {
+                DaprEndpoint = "https://some.host:3499",
+            };
+
+            Assert.True(handler.TryRewriteUri(new Uri(uri), out var rewritten));
+            Assert.Equal(expected, rewritten!.OriginalString);
+        }
+
+        [Fact]
+        public async Task SendAsync_InvalidUri_ThrowsException()
+        {
+            var handler = new InvocationHandler();
+            var ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
+            {
+                await CallSendAsync(handler, new HttpRequestMessage(){ }); // No URI set
+            });
+
+            Assert.Contains("The request URI '' is not a valid Dapr service invocation destination.", ex.Message);
+        }
+
+        [Fact]
+        public async Task SendAsync_RewritesUri()
+        {
+            var uri = "http://bank/accounts/17?";
+
+            var capture = new CaptureHandler();
+            var handler = new InvocationHandler()
+            {
+                InnerHandler = capture,
+
+                DaprEndpoint = "https://localhost:5000",
+                DaprApiToken = null,
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, uri);
+            var response = await CallSendAsync(handler, request);
+
+            Assert.Equal("https://localhost:5000/v1.0/invoke/bank/method/accounts/17?", capture.RequestUri?.OriginalString);
+            Assert.Null(capture.DaprApiToken);
+
+            Assert.Equal(uri, request.RequestUri?.OriginalString);
+            Assert.False(request.Headers.TryGetValues("dapr-api-token", out _));
+        }
+
+        [Fact]
+        public async Task SendAsync_RewritesUri_AndAddsApiToken()
+        {
+            var uri = "http://bank/accounts/17?";
+
+            var capture = new CaptureHandler();
+            var handler = new InvocationHandler()
+            {
+                InnerHandler = capture,
+
+                DaprEndpoint = "https://localhost:5000",
+                DaprApiToken = "super-duper-secure",
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, uri);
+            var response = await CallSendAsync(handler, request);
+
+            Assert.Equal("https://localhost:5000/v1.0/invoke/bank/method/accounts/17?", capture.RequestUri?.OriginalString);
+            Assert.Equal("super-duper-secure", capture.DaprApiToken);
+
+            Assert.Equal(uri, request.RequestUri?.OriginalString);
+            Assert.False(request.Headers.TryGetValues("dapr-api-token", out _));
+        }
+
+        private async Task<HttpResponseMessage> CallSendAsync(InvocationHandler handler, HttpRequestMessage message, CancellationToken cancellationToken = default)
+        {
+            // SendAsync is protected, can't call it directly.
+            var method = handler.GetType().GetMethod("SendAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            try
+            {
+                return await (Task<HttpResponseMessage>)method!.Invoke(handler, new object[]{ message, cancellationToken, })!;
+            }
+            catch (TargetInvocationException tie) // reflection always adds an extra layer of exceptions.
+            {
+                throw tie.InnerException!;
+            }
+        }
+
+        private class CaptureHandler : HttpMessageHandler
+        {
+            public Uri? RequestUri { get; private set; }
+
+            public string? DaprApiToken { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                RequestUri = request.RequestUri;
+                if (request.Headers.TryGetValues("dapr-api-token", out var tokens))
+                {
+                    DaprApiToken = tokens.SingleOrDefault();
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+    }
+}

--- a/test/Dapr.Client.Test/InvocationHandlerTests.cs
+++ b/test/Dapr.Client.Test/InvocationHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Dapr.Client
         [Fact]
         public void TryRewriteUri_FailsForBadScheme()
         {
-            var uri = new Uri("ftp://test", UriKind.Relative);
+            var uri = new Uri("ftp://test", UriKind.Absolute);
 
             var handler = new InvocationHandler();
             Assert.False(handler.TryRewriteUri(uri, out var rewritten));


### PR DESCRIPTION
# Description

- Adds a new message handler for HttpClient interop
- Adds an easy way to create HttpClient instances
- A bunch of sample cleanup/polish/simplification

The main thing here is the added ability to interop with HttpClient. We'll be making some future changes to the service invocation APIs in DaprClient to address https://github.com/dapr/dapr/issues/2342 since that issues greatly simplifies the interface we're dealing with. 

## Issue reference

Fixes: #526

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
