### PR TITLE
Add IActorProxyFactory to DI

### DIFF
--- a/src/Dapr.Actors.AspNetCore/ActorsServiceCollectionExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/ActorsServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 using System;
+using Dapr.Actors.Client;
 using Dapr.Actors.Runtime;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -38,7 +39,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 var options = s.GetRequiredService<IOptions<ActorRuntimeOptions>>().Value;
                 var loggerFactory = s.GetRequiredService<ILoggerFactory>();
                 var activatorFactory = s.GetRequiredService<ActorActivatorFactory>();
-                return new ActorRuntime(options, loggerFactory, activatorFactory);
+                var proxyFactory = s.GetRequiredService<ActorProxyFactory>();
+                return new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
+            });
+
+            services.TryAddSingleton<ActorProxyFactory>(s =>
+            {
+                var options = s.GetRequiredService<IOptions<ActorRuntimeOptions>>().Value;
+                var factory = new ActorProxyFactory() 
+                { 
+                    DefaultOptions =
+                    {
+                        JsonSerializerOptions = options.JsonSerializerOptions,
+                    }
+                };
+
+                return factory;
             });
 
             if (configure != null)

--- a/src/Dapr.Actors.AspNetCore/ActorsServiceCollectionExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/ActorsServiceCollectionExtensions.cs
@@ -39,11 +39,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 var options = s.GetRequiredService<IOptions<ActorRuntimeOptions>>().Value;
                 var loggerFactory = s.GetRequiredService<ILoggerFactory>();
                 var activatorFactory = s.GetRequiredService<ActorActivatorFactory>();
-                var proxyFactory = s.GetRequiredService<ActorProxyFactory>();
+                var proxyFactory = s.GetRequiredService<IActorProxyFactory>();
                 return new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
             });
 
-            services.TryAddSingleton<ActorProxyFactory>(s =>
+            services.TryAddSingleton<IActorProxyFactory>(s =>
             {
                 var options = s.GetRequiredService<IOptions<ActorRuntimeOptions>>().Value;
                 var factory = new ActorProxyFactory() 

--- a/src/Dapr.Actors/Runtime/Actor.cs
+++ b/src/Dapr.Actors/Runtime/Actor.cs
@@ -9,6 +9,7 @@ namespace Dapr.Actors.Runtime
     using System.Reflection;
     using System.Text.Json;
     using System.Threading.Tasks;
+    using Dapr.Actors.Client;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -51,6 +52,12 @@ namespace Dapr.Actors.Runtime
         /// </summary>
         /// <value>The <see cref="ActorHost"/> for the actor.</value>
         public ActorHost Host { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IActorProxyFactory" /> used to create proxy client instances for communicating
+        /// with other actors.
+        /// </summary>
+        public IActorProxyFactory ProxyFactory => this.Host.ProxyFactory;
 
         /// <summary>
         /// Gets the StateManager for the actor.

--- a/src/Dapr.Actors/Runtime/ActorHost.cs
+++ b/src/Dapr.Actors/Runtime/ActorHost.cs
@@ -6,6 +6,7 @@
 namespace Dapr.Actors.Runtime
 {
     using System.Text.Json;
+    using Dapr.Actors.Client;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -20,15 +21,19 @@ namespace Dapr.Actors.Runtime
         /// <param name="id">The id of the Actor instance.</param>
         /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use for actor state persistence and message deserialization.</param>
         /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="proxyFactory">The <see cref="ActorProxyFactory" />.</param>
         public ActorHost(
             ActorTypeInformation actorTypeInfo,
             ActorId id,
             JsonSerializerOptions jsonSerializerOptions,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            IActorProxyFactory proxyFactory)
         {
             this.ActorTypeInfo = actorTypeInfo;
             this.Id = id;
             this.LoggerFactory = loggerFactory;
+            this.ProxyFactory = proxyFactory;
+            
             this.StateProvider = new DaprStateProvider(jsonSerializerOptions);
         }
 
@@ -51,6 +56,11 @@ namespace Dapr.Actors.Runtime
         /// Gets the <see cref="DaprStateProvider" />.
         /// </summary>
         public JsonSerializerOptions JsonSerializerOptions { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IActorProxyFactory" />.
+        /// </summary>
+        public IActorProxyFactory ProxyFactory { get; }
 
         internal DaprStateProvider StateProvider { get; }
     }

--- a/src/Dapr.Actors/Runtime/ActorRuntime.cs
+++ b/src/Dapr.Actors/Runtime/ActorRuntime.cs
@@ -12,6 +12,7 @@ namespace Dapr.Actors.Runtime
     using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
+    using Dapr.Actors.Client;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -24,12 +25,14 @@ namespace Dapr.Actors.Runtime
         private readonly ActorRuntimeOptions options;
         private readonly ILogger logger;
         private readonly ActorActivatorFactory activatorFactory;
+        private readonly IActorProxyFactory proxyFactory;
 
-        internal ActorRuntime(ActorRuntimeOptions options, ILoggerFactory loggerFactory, ActorActivatorFactory activatorFactory)
+        internal ActorRuntime(ActorRuntimeOptions options, ILoggerFactory loggerFactory, ActorActivatorFactory activatorFactory, IActorProxyFactory proxyFactory)
         {
             this.options = options;
             this.logger = loggerFactory.CreateLogger(this.GetType());
             this.activatorFactory = activatorFactory;
+            this.proxyFactory = proxyFactory;
 
             // Loop through actor registrations and create the actor manager for each one. 
             // We do this up front so that we can catch initialization errors early, and so
@@ -42,7 +45,8 @@ namespace Dapr.Actors.Runtime
                     actor,
                     actor.Activator ?? this.activatorFactory.CreateActivator(actor.Type),
                     this.options.JsonSerializerOptions,
-                    loggerFactory);
+                    loggerFactory, 
+                    proxyFactory);
             }
         }
 

--- a/test/Dapr.Actors.AspNetCore.Test/Runtime/DependencyInjectionActorActivatorTests.cs
+++ b/test/Dapr.Actors.AspNetCore.Test/Runtime/DependencyInjectionActorActivatorTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Dapr.Actors.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -31,7 +32,7 @@ namespace Dapr.Actors.Runtime
         {
             var activator = CreateActivator(typeof(TestActor));
 
-            var host = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var state = await activator.CreateAsync(host);
             var actor = Assert.IsType<TestActor>(state.Actor);
 
@@ -44,11 +45,11 @@ namespace Dapr.Actors.Runtime
         {
             var activator = CreateActivator(typeof(TestActor));
 
-            var host1 = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host1 = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var state1 = await activator.CreateAsync(host1);
             var actor1 = Assert.IsType<TestActor>(state1.Actor);
 
-            var host2 = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host2 = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var state2 = await activator.CreateAsync(host2);
             var actor2 = Assert.IsType<TestActor>(state2.Actor);
 
@@ -61,7 +62,7 @@ namespace Dapr.Actors.Runtime
         {
             var activator = CreateActivator(typeof(TestActor));
 
-            var host = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var state = await activator.CreateAsync(host);
             var actor = Assert.IsType<TestActor>(state.Actor);
 
@@ -77,7 +78,7 @@ namespace Dapr.Actors.Runtime
         {
             var activator = CreateActivator(typeof(DisposableActor));
 
-            var host = new ActorHost(ActorTypeInformation.Get(typeof(DisposableActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host = new ActorHost(ActorTypeInformation.Get(typeof(DisposableActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var state = await activator.CreateAsync(host);
             var actor = Assert.IsType<DisposableActor>(state.Actor);
 
@@ -91,7 +92,7 @@ namespace Dapr.Actors.Runtime
         {
             var activator = CreateActivator(typeof(AsyncDisposableActor));
 
-            var host = new ActorHost(ActorTypeInformation.Get(typeof(AsyncDisposableActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host = new ActorHost(ActorTypeInformation.Get(typeof(AsyncDisposableActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var state = await activator.CreateAsync(host);
             var actor = Assert.IsType<AsyncDisposableActor>(state.Actor);
 

--- a/test/Dapr.Actors.Test/Runtime/ActorManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorManagerTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Dapr.Actors.Client;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -16,7 +17,7 @@ namespace Dapr.Actors.Runtime
         private ActorManager CreateActorManager(Type type, ActorActivator activator = null)
         {
             var registration = new ActorRegistration(ActorTypeInformation.Get(type));
-            return new ActorManager(registration, activator ?? new DefaultActorActivator(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            return new ActorManager(registration, activator ?? new DefaultActorActivator(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
         }
 
         [Fact]

--- a/test/Dapr.Actors.Test/Runtime/ActorRuntimeOptionsTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorRuntimeOptionsTests.cs
@@ -11,6 +11,7 @@ namespace Dapr.Actors.Test.Runtime
     using Microsoft.Extensions.Logging;
     using System;
     using FluentAssertions;
+    using Dapr.Actors.Client;
 
     public sealed class ActorRuntimeOptionsTests
     {
@@ -19,7 +20,7 @@ namespace Dapr.Actors.Test.Runtime
         {
             var actorType = typeof(TestActor);
             var actorTypeInformation = ActorTypeInformation.Get(actorType);
-            var host = new ActorHost(actorTypeInformation, ActorId.CreateRandom(), JsonSerializerDefaults.Web, new LoggerFactory());
+            var host = new ActorHost(actorTypeInformation, ActorId.CreateRandom(), JsonSerializerDefaults.Web, new LoggerFactory(), ActorProxy.DefaultProxyFactory);
             var actor = new TestActor(host);
 
             var activator = Mock.Of<ActorActivator>();

--- a/test/Dapr.Actors.Test/Runtime/ActorRuntimeTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorRuntimeTests.cs
@@ -16,12 +16,15 @@ namespace Dapr.Actors.Test
     using Dapr.Actors.Runtime;
     using Microsoft.Extensions.Logging;
     using Xunit;
+    using Dapr.Actors.Client;
 
     public sealed class ActorRuntimeTests
     {
         private const string RenamedActorTypeName = "MyRenamedActor";
         private readonly ILoggerFactory loggerFactory = new LoggerFactory();
         private readonly ActorActivatorFactory activatorFactory = new DefaultActorActivatorFactory();
+
+        private readonly IActorProxyFactory proxyFactory = ActorProxy.DefaultProxyFactory;
 
         private interface ITestActor : IActor
         {
@@ -34,7 +37,7 @@ namespace Dapr.Actors.Test
             
             var options = new ActorRuntimeOptions();
             options.Actors.RegisterActor<TestActor>();
-            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory);
+            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
 
             Assert.Contains(actorType.Name, runtime.RegisteredActors.Select(a => a.Type.ActorTypeName), StringComparer.InvariantCulture);
         }
@@ -45,7 +48,7 @@ namespace Dapr.Actors.Test
             var actorType = typeof(RenamedActor);
             var options = new ActorRuntimeOptions();
             options.Actors.RegisterActor<RenamedActor>();
-            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory);
+            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
 
             Assert.NotEqual(RenamedActorTypeName, actorType.Name);
             Assert.Contains(RenamedActorTypeName, runtime.RegisteredActors.Select(a => a.Type.ActorTypeName), StringComparer.InvariantCulture);
@@ -59,7 +62,7 @@ namespace Dapr.Actors.Test
 
             var options = new ActorRuntimeOptions();
             options.Actors.RegisterActor<MyActor>();
-            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory);
+            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
             Assert.Contains(actorType.Name, runtime.RegisteredActors.Select(a => a.Type.ActorTypeName), StringComparer.InvariantCulture);
 
             var output = new MemoryStream();
@@ -81,7 +84,7 @@ namespace Dapr.Actors.Test
             {
                 options.Activator = activator;
             });
-            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory);
+            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
             Assert.Contains(actorType.Name, runtime.RegisteredActors.Select(a => a.Type.ActorTypeName), StringComparer.InvariantCulture);
 
             var output = new MemoryStream();
@@ -107,7 +110,7 @@ namespace Dapr.Actors.Test
             options.DrainOngoingCallTimeout = TimeSpan.FromSeconds(55);
             options.DrainRebalancedActors = true;
 
-            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory);
+            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
 
             Assert.Contains(actorType.Name, runtime.RegisteredActors.Select(a => a.Type.ActorTypeName), StringComparer.InvariantCulture);
 

--- a/test/Dapr.Actors.Test/Runtime/ActorTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorTests.cs
@@ -13,6 +13,7 @@ namespace Dapr.Actors.Test.Runtime
     using Xunit;
     using Microsoft.Extensions.Logging;
     using System.Threading.Tasks;
+    using Dapr.Actors.Client;
 
     public sealed class ActorTests
     {
@@ -115,7 +116,7 @@ namespace Dapr.Actors.Test.Runtime
         {
             var actorTypeInformation = ActorTypeInformation.Get(typeof(TestActor));
             var loggerFactory = new LoggerFactory();
-            var host = new ActorHost(actorTypeInformation, ActorId.CreateRandom(), JsonSerializerDefaults.Web, loggerFactory);
+            var host = new ActorHost(actorTypeInformation, ActorId.CreateRandom(), JsonSerializerDefaults.Web, loggerFactory, ActorProxy.DefaultProxyFactory);
             var testActor = new TestActor(host, actorStateManager);
             return testActor;
         }

--- a/test/Dapr.Actors.Test/Runtime/DefaultActorActivatorTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/DefaultActorActivatorTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Dapr.Actors.Client;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace Dapr.Actors.Runtime
         {
             var activator = new DefaultActorActivator();
 
-            var host = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var state = await activator.CreateAsync(host);
             Assert.IsType<TestActor>(state.Actor);
         }
@@ -27,7 +28,7 @@ namespace Dapr.Actors.Runtime
         {
             var activator = new DefaultActorActivator();
 
-            var host = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host = new ActorHost(ActorTypeInformation.Get(typeof(TestActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var actor = new TestActor(host);
             var state = new ActorActivatorState(actor);
 
@@ -39,7 +40,7 @@ namespace Dapr.Actors.Runtime
         {
             var activator = new DefaultActorActivator();
 
-            var host = new ActorHost(ActorTypeInformation.Get(typeof(DisposableActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host = new ActorHost(ActorTypeInformation.Get(typeof(DisposableActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var actor = new DisposableActor(host);
             var state = new ActorActivatorState(actor);
 
@@ -53,7 +54,7 @@ namespace Dapr.Actors.Runtime
         {
             var activator = new DefaultActorActivator();
 
-            var host = new ActorHost(ActorTypeInformation.Get(typeof(AsyncDisposableActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance);
+            var host = new ActorHost(ActorTypeInformation.Get(typeof(AsyncDisposableActor)), ActorId.CreateRandom(), JsonSerializerDefaults.Web, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory);
             var actor = new AsyncDisposableActor(host);
             var state = new ActorActivatorState(actor);
 


### PR DESCRIPTION
# Description

This change adds IActorProxyFactory to DI when used with ASP.NET Core,
and makes it also available as a property on the Actor base class. This
way if you've configured the ActorRuntimeOptions with your JSON
settings, its easy to have them picked up in Actors client use cases as
well.

This doesn't quite go all the way to unifying the settings with
DaprClient - we don't want to make a change that disruptive this close
to release.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Fixes: #532

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
