### PR TITLE
Updated README.md with .NET 5 wording, link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This repo builds the following packages:
 
 ### Prerequisites
 
-Each project is a normal C# project. At minimum, you need [.NET Core SDK 5.0](https://dotnet.microsoft.com/download/dotnet-core/5.0) to build, test, and generate NuGet packages.
+Each project is a normal C# project. At minimum, you need [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) to build, test, and generate NuGet packages.
 
 Also make sure to reference the [.NET SDK contribution guide](https://docs.dapr.io/contributing/dotnet-contributing/)
 


### PR DESCRIPTION
# Description

1. The official name for .NET starting version 5.0 does not include word Core
2. Used the appropriate link (the previous one has been redirected anyway)
3. Put SDK in the right position in the sentence

## Issue reference

n/a