### PR TITLE
Diable TRX parser on forks

### DIFF
--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Parse Trx files
         uses: NasAmin/trx-parser@v0.1.0
         id: trx-parser
+        if: github.repository == 'dapr/dotnet-sdk'
         with:
           TRX_PATH: ${{ github.workspace }}/TestResults
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -92,6 +92,7 @@ jobs:
     - name: Parse Trx files
       uses: NasAmin/trx-parser@v0.1.0
       id: trx-parser
+      if: github.repository == 'dapr/dotnet-sdk'
       with:
         TRX_PATH: ${{ github.workspace }}/TestResults
         REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Unfortunately this action requires permissions that a workflow running
for a fork does not have. You can see an example of this failing here:
https://github.com/dapr/dotnet-sdk/pull/617/checks?check_run_id=2033224542
