### PR TITLE
Support non-JSON text in cloud events middleware

### DIFF
--- a/src/Dapr.AspNetCore/CloudEventsMiddlewareOptions.cs
+++ b/src/Dapr.AspNetCore/CloudEventsMiddlewareOptions.cs
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+namespace Dapr
+{
+    /// <summary>
+    /// Provides optional settings to the cloud events middleware.
+    /// </summary>
+    public class CloudEventsMiddlewareOptions
+    {
+        /// <summary>
+        /// Gets or sets a value that will determine whether non-JSON textual payloads are decoded.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// In the 1.0 release of the Dapr .NET SDK the cloud events middleware would not JSON-decode
+        /// a textual cloud events payload. A cloud event payload containing <c>text/plain</c> data 
+        /// of <c>"data": "Hello, \"world!\""</c> would result in a request body containing <c>"Hello, \"world!\""</c>
+        /// instead of the expected JSON-decoded value of <c>Hello, "world!"</c>.
+        /// </para>
+        /// <para>
+        /// Setting this property to <c>true</c> restores the previous invalid behavior for compatiblity.
+        /// </para>
+        /// </remarks>
+        public bool SuppressJsonDecodingOfTextPayloads { get; set; }
+    }
+}

--- a/src/Dapr.AspNetCore/DaprApplicationBuilderExtensions.cs
+++ b/src/Dapr.AspNetCore/DaprApplicationBuilderExtensions.cs
@@ -26,7 +26,24 @@ namespace Microsoft.AspNetCore.Builder
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.UseMiddleware<CloudEventsMiddleware>();
+            return UseCloudEvents(builder, new CloudEventsMiddlewareOptions());
+        }
+
+        /// <summary>
+        /// Adds the cloud events middleware to the middleware pipeline. The cloud events middleware will unwrap
+        /// requests that use the cloud events structured format, allowing the event payload to be read directly.
+        /// </summary>
+        /// <param name="builder">An <see cref="IApplicationBuilder" />.</param>
+        /// <param name="options">The <see cref="CloudEventsMiddlewareOptions" /> to configure optional settings.</param>
+        /// <returns>The <see cref="IApplicationBuilder" />.</returns>
+        public static IApplicationBuilder UseCloudEvents(this IApplicationBuilder builder, CloudEventsMiddlewareOptions options)
+        {
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.UseMiddleware<CloudEventsMiddleware>(options);
             return builder;
         }
     }

--- a/test/Dapr.AspNetCore.IntegrationTest.App/DaprController.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/DaprController.cs
@@ -6,10 +6,12 @@
 namespace Dapr.AspNetCore.IntegrationTest.App
 {
     using System;
+    using System.Text;
     using System.Threading.Tasks;
     using Dapr;
     using Dapr.Client;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.WebUtilities;
 
     [ApiController]
     public class DaprController : ControllerBase
@@ -25,6 +27,15 @@ namespace Dapr.AspNetCore.IntegrationTest.App
         public ActionResult<UserInfo> RegisterUser(UserInfo user)
         {
             return user; // echo back the user for testing
+        }
+
+        [Topic("pubsub", "register-user-plaintext")]
+        [HttpPost("/register-user-plaintext")]
+        public async Task<ActionResult> RegisterUserPlaintext()
+        {
+            using var reader = new HttpRequestStreamReader(Request.Body, Encoding.UTF8);
+            var user = await reader.ReadToEndAsync();
+            return Content(user, "text/plain"); // echo back the user for testing
         }
 
         [HttpPost("/controllerwithoutstateentry/{widget}")]

--- a/test/Dapr.AspNetCore.IntegrationTest/CloudEventsIntegrationTest.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest/CloudEventsIntegrationTest.cs
@@ -101,6 +101,34 @@ namespace Dapr.AspNetCore.IntegrationTest
             }
         }
 
+        [Fact]
+        public async Task CanSendStructuredCloudEvent_WithNonJsonContentType()
+        {
+            using (var factory = new AppWebApplicationFactory())
+            {
+                var httpClient = factory.CreateClient();
+
+                var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/register-user-plaintext")
+                {
+                    Content = new StringContent(
+                    JsonSerializer.Serialize(
+                        new
+                        {
+                            data = "jimmy \"the cool guy\" smith",
+                            datacontenttype = "text/plain",
+                        }),
+                    Encoding.UTF8)
+                };
+                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/cloudevents+json");
+
+                var response = await httpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+
+                var user = await response.Content.ReadAsStringAsync();
+                user.Should().Be("jimmy \"the cool guy\" smith");
+            }
+        }
+
         // Yeah, I know, binary isn't a great term for this, it's what the cloudevents spec uses.
         // Basically this is here to test that an endpoint can handle requests with and without
         // an envelope.

--- a/test/Dapr.AspNetCore.IntegrationTest/SubscribeEndpointTest.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest/SubscribeEndpointTest.cs
@@ -30,7 +30,7 @@ namespace Dapr.AspNetCore.IntegrationTest
                     var json = await JsonSerializer.DeserializeAsync<JsonElement>(stream);
 
                     json.ValueKind.Should().Be(JsonValueKind.Array);
-                    json.GetArrayLength().Should().Be(3);
+                    json.GetArrayLength().Should().Be(4);
                     var topics = new List<string>();
                     var routes = new List<string>();
                     foreach (var element in json.EnumerateArray())
@@ -42,10 +42,12 @@ namespace Dapr.AspNetCore.IntegrationTest
                     topics.Should().Contain("A");
                     topics.Should().Contain("B");
                     topics.Should().Contain("register-user");
+                    topics.Should().Contain("register-user-plaintext");
 
                     routes.Should().Contain("B");
                     routes.Should().Contain("topic-a");
                     routes.Should().Contain("register-user");
+                    routes.Should().Contain("register-user-plaintext");
                 }
             }
         }


### PR DESCRIPTION
# Description

This change teaches the cloud events middleware to JSON-decode non-JSON
content when it appears in the `data` attribute in a cloud event.

There are three cases for cloud events that matter:

- data is used, content is a JSON object, datacontentype is JSON
- data is used, content is a JSON string, dataconenttype != JSON
- data_base64 is used, content is base64 bytes

We weren't handling the second of this. If you submitted the content:

`"data": "hello, "\world!\""` with datacontenttype = text/plain

You would end up with `"hello, \"world!\""` in the request body instead
of `hello, "world!"`.

This is a very subtle case, and I'm trying to fix it before users couple
their code to the wrong behavior. Since this is technically a breaking
change, I've added a opt-out so you can restore the buggy behavior.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Fixes: #592

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
