### PR TITLE
[WIP] Added support for custom delimiters in secret keys.

### DIFF
--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
@@ -83,7 +83,7 @@ namespace Dapr.Extensions.Configuration
             this IConfigurationBuilder configurationBuilder,
             string store,
             DaprClient client,
-            IList<string> keyDelimiters)
+            IEnumerable<string> keyDelimiters)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(store, nameof(store));
             ArgumentVerifier.ThrowIfNull(client, nameof(client));

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
@@ -83,7 +83,7 @@ namespace Dapr.Extensions.Configuration
             this IConfigurationBuilder configurationBuilder,
             string store,
             DaprClient client,
-            IEnumerable<string> keyDelimiters)
+            IList<string> keyDelimiters)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(store, nameof(store));
             ArgumentVerifier.ThrowIfNull(client, nameof(client));

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
@@ -76,14 +76,14 @@ namespace Dapr.Extensions.Configuration
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
         /// <param name="store">Dapr secret store name.</param>
-        /// <param name="customDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
+        /// <param name="keyDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
         /// <param name="client">The Dapr client</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddDaprSecretStore(
             this IConfigurationBuilder configurationBuilder,
             string store,
             DaprClient client,
-            IEnumerable<string> customDelimiters)
+            IEnumerable<string> keyDelimiters)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(store, nameof(store));
             ArgumentVerifier.ThrowIfNull(client, nameof(client));
@@ -91,7 +91,7 @@ namespace Dapr.Extensions.Configuration
             configurationBuilder.Add(new DaprSecretStoreConfigurationSource()
             {
                 Store = store,
-                CustomDelimiters = customDelimiters,
+                KeyDelimiters = keyDelimiters,
                 Client = client
             });
 

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Dapr.Client;
 using Microsoft.Extensions.Configuration;
 using Dapr.Extensions.Configuration.DaprSecretStore;
+using System.Linq;
 
 namespace Dapr.Extensions.Configuration
 {
@@ -91,7 +92,7 @@ namespace Dapr.Extensions.Configuration
             configurationBuilder.Add(new DaprSecretStoreConfigurationSource()
             {
                 Store = store,
-                KeyDelimiters = keyDelimiters,
+                KeyDelimiters = keyDelimiters?.ToList(),
                 Client = client
             });
 

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationExtensions.cs
@@ -72,6 +72,33 @@ namespace Dapr.Extensions.Configuration
         }
 
         /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the Dapr Secret Store.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="store">Dapr secret store name.</param>
+        /// <param name="customDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
+        /// <param name="client">The Dapr client</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddDaprSecretStore(
+            this IConfigurationBuilder configurationBuilder,
+            string store,
+            DaprClient client,
+            IEnumerable<string> customDelimiters)
+        {
+            ArgumentVerifier.ThrowIfNullOrEmpty(store, nameof(store));
+            ArgumentVerifier.ThrowIfNull(client, nameof(client));
+
+            configurationBuilder.Add(new DaprSecretStoreConfigurationSource()
+            {
+                Store = store,
+                CustomDelimiters = customDelimiters,
+                Client = client
+            });
+
+            return configurationBuilder;
+        }
+
+        /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from the command line.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationProvider.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationProvider.cs
@@ -21,7 +21,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
 
         private readonly bool normalizeKey;
 
-        private readonly IEnumerable<string> keyDelimiters;
+        private readonly IList<string> keyDelimiters;
 
         private readonly IEnumerable<DaprSecretDescriptor> secretDescriptors;
 
@@ -61,7 +61,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         /// <param name="keyDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
         /// <param name="secretDescriptors">The secrets to retrieve.</param>
         /// <param name="client">Dapr client used to retrieve Secrets</param>
-        public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IEnumerable<string> keyDelimiters, IEnumerable<DaprSecretDescriptor> secretDescriptors, DaprClient client)
+        public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IList<string> keyDelimiters, IEnumerable<DaprSecretDescriptor> secretDescriptors, DaprClient client)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(store, nameof(store));
             ArgumentVerifier.ThrowIfNull(secretDescriptors, nameof(secretDescriptors));
@@ -105,7 +105,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         /// <param name="keyDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
         /// <param name="metadata">A collection of metadata key-value pairs that will be provided to the secret store. The valid metadata keys and values are determined by the type of secret store used.</param>
         /// <param name="client">Dapr client used to retrieve Secrets</param>
-        public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IEnumerable<string> keyDelimiters, IReadOnlyDictionary<string, string> metadata, DaprClient client)
+        public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IList<string> keyDelimiters, IReadOnlyDictionary<string, string> metadata, DaprClient client)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(store, nameof(store));
             ArgumentVerifier.ThrowIfNull(client, nameof(client));
@@ -119,7 +119,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
 
         private string NormalizeKey(string key)
         {
-            if (this.keyDelimiters?.Any() == true)
+            if (this.keyDelimiters?.Count > 0)
             {
                 foreach (var keyDelimiter in this.keyDelimiters)
                 {

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationProvider.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationProvider.cs
@@ -21,7 +21,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
 
         private readonly bool normalizeKey;
 
-        private readonly IEnumerable<string> customDelimiters;
+        private readonly IEnumerable<string> keyDelimiters;
 
         private readonly IEnumerable<DaprSecretDescriptor> secretDescriptors;
 
@@ -33,7 +33,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         /// Creates a new instance of <see cref="DaprSecretStoreConfigurationProvider"/>.
         /// </summary>
         /// <param name="store">Dapr Secre Store name.</param>
-        /// <param name="normalizeKey">Replace "__" with delimiter ":".</param>
+        /// <param name="normalizeKey">Indicates whether any key delimiters should be replaced with the delimiter ":".</param>
         /// <param name="secretDescriptors">The secrets to retrieve.</param>
         /// <param name="client">Dapr client used to retrieve Secrets</param>
         public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IEnumerable<DaprSecretDescriptor> secretDescriptors, DaprClient client)
@@ -57,11 +57,11 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         /// Creates a new instance of <see cref="DaprSecretStoreConfigurationProvider"/>.
         /// </summary>
         /// <param name="store">Dapr Secre Store name.</param>
-        /// <param name="normalizeKey">Replace "__" and any custom delimiters with the delimiter ":".</param>
-        /// <param name="customDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
+        /// <param name="normalizeKey">Indicates whether any key delimiters should be replaced with the delimiter ":".</param>
+        /// <param name="keyDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
         /// <param name="secretDescriptors">The secrets to retrieve.</param>
         /// <param name="client">Dapr client used to retrieve Secrets</param>
-        public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IEnumerable<string> customDelimiters, IEnumerable<DaprSecretDescriptor> secretDescriptors, DaprClient client)
+        public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IEnumerable<string> keyDelimiters, IEnumerable<DaprSecretDescriptor> secretDescriptors, DaprClient client)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(store, nameof(store));
             ArgumentVerifier.ThrowIfNull(secretDescriptors, nameof(secretDescriptors));
@@ -74,7 +74,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
 
             this.store = store;
             this.normalizeKey = normalizeKey;
-            this.customDelimiters = customDelimiters;
+            this.keyDelimiters = keyDelimiters;
             this.secretDescriptors = secretDescriptors;
             this.client = client;
         }
@@ -83,7 +83,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         /// Creates a new instance of <see cref="DaprSecretStoreConfigurationProvider"/>.
         /// </summary>
         /// <param name="store">Dapr Secre Store name.</param>
-        /// <param name="normalizeKey">Replace "__" with delimiter ":".</param>
+        /// <param name="normalizeKey">Indicates whether any key delimiters should be replaced with the delimiter ":".</param>
         /// <param name="metadata">A collection of metadata key-value pairs that will be provided to the secret store. The valid metadata keys and values are determined by the type of secret store used.</param>
         /// <param name="client">Dapr client used to retrieve Secrets</param>
         public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IReadOnlyDictionary<string, string> metadata, DaprClient client)
@@ -101,29 +101,27 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         /// Creates a new instance of <see cref="DaprSecretStoreConfigurationProvider"/>.
         /// </summary>
         /// <param name="store">Dapr Secre Store name.</param>
-        /// <param name="normalizeKey">Replace "__" and any custom delimiters with the delimiter ":".</param>
-        /// <param name="customDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
+        /// <param name="normalizeKey">Indicates whether any key delimiters should be replaced with the delimiter ":".</param>
+        /// <param name="keyDelimiters">A collection of delimiters that will be replaced by ':' in the key of every secret.</param>
         /// <param name="metadata">A collection of metadata key-value pairs that will be provided to the secret store. The valid metadata keys and values are determined by the type of secret store used.</param>
         /// <param name="client">Dapr client used to retrieve Secrets</param>
-        public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IEnumerable<string> customDelimiters, IReadOnlyDictionary<string, string> metadata, DaprClient client)
+        public DaprSecretStoreConfigurationProvider(string store, bool normalizeKey, IEnumerable<string> keyDelimiters, IReadOnlyDictionary<string, string> metadata, DaprClient client)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(store, nameof(store));
             ArgumentVerifier.ThrowIfNull(client, nameof(client));
 
             this.store = store;
             this.normalizeKey = normalizeKey;
-            this.customDelimiters = customDelimiters;
+            this.keyDelimiters = keyDelimiters;
             this.metadata = metadata;
             this.client = client;
         }
 
         private string NormalizeKey(string key)
         {
-            key = key.Replace("__", ConfigurationPath.KeyDelimiter);
-
-            if (this.customDelimiters?.Any() == true)
+            if (this.keyDelimiters?.Any() == true)
             {
-                foreach (var keyDelimiter in this.customDelimiters)
+                foreach (var keyDelimiter in this.keyDelimiters)
                 {
                     key = key.Replace(keyDelimiter, ConfigurationPath.KeyDelimiter);
                 }

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationSource.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationSource.cs
@@ -21,15 +21,15 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         public string Store { get; set; }
 
         /// <summary>
-        /// Gets or sets if replace "__" and any custom delimiters with the delimiter ":".
+        /// Gets or sets a value indicating whether any key delimiters should be replaced with the delimiter ":".
         /// Default value true.
         /// </summary>
         public bool NormalizeKey { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the custom key delimiters.
+        /// Gets or sets the custom key delimiters. Contains the '__' delimiter by default.
         /// </summary>
-        public IEnumerable<string> CustomDelimiters { get; set; }
+        public IEnumerable<string> KeyDelimiters { get; set; } = new List<string> { "__" };
 
         /// <summary>
         /// Gets or sets the secret descriptors.
@@ -56,11 +56,11 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
                     throw new ArgumentException($"{nameof(Metadata)} must be null when {nameof(SecretDescriptors)} is set", nameof(Metadata));
                 }
 
-                return new DaprSecretStoreConfigurationProvider(Store, NormalizeKey, CustomDelimiters, SecretDescriptors, Client);
+                return new DaprSecretStoreConfigurationProvider(Store, NormalizeKey, KeyDelimiters, SecretDescriptors, Client);
             }
             else
             {
-                return new DaprSecretStoreConfigurationProvider(Store, NormalizeKey, CustomDelimiters, Metadata, Client);
+                return new DaprSecretStoreConfigurationProvider(Store, NormalizeKey, KeyDelimiters, Metadata, Client);
             }
         }
     }

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationSource.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationSource.cs
@@ -21,10 +21,15 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         public string Store { get; set; }
 
         /// <summary>
-        /// Gets or sets if replace "__" with delimiter ":".
+        /// Gets or sets if replace "__" and any custom delimiters with the delimiter ":".
         /// Default value true.
         /// </summary>
         public bool NormalizeKey { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the custom key delimiters.
+        /// </summary>
+        public IEnumerable<string> CustomDelimiters { get; set; }
 
         /// <summary>
         /// Gets or sets the secret descriptors.
@@ -51,11 +56,11 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
                     throw new ArgumentException($"{nameof(Metadata)} must be null when {nameof(SecretDescriptors)} is set", nameof(Metadata));
                 }
 
-                return new DaprSecretStoreConfigurationProvider(Store, NormalizeKey, SecretDescriptors, Client);
+                return new DaprSecretStoreConfigurationProvider(Store, NormalizeKey, CustomDelimiters, SecretDescriptors, Client);
             }
             else
             {
-                return new DaprSecretStoreConfigurationProvider(Store, NormalizeKey, Metadata, Client);
+                return new DaprSecretStoreConfigurationProvider(Store, NormalizeKey, CustomDelimiters, Metadata, Client);
             }
         }
     }

--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationSource.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationSource.cs
@@ -29,7 +29,7 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
         /// <summary>
         /// Gets or sets the custom key delimiters. Contains the '__' delimiter by default.
         /// </summary>
-        public IEnumerable<string> KeyDelimiters { get; set; } = new List<string> { "__" };
+        public IList<string> KeyDelimiters { get; set; } = new List<string> { "__" };
 
         /// <summary>
         /// Gets or sets the secret descriptors.

--- a/test/Dapr.Extensions.Configuration.Test/DaprSecretStoreConfigurationProviderTest.cs
+++ b/test/Dapr.Extensions.Configuration.Test/DaprSecretStoreConfigurationProviderTest.cs
@@ -415,6 +415,242 @@ namespace Dapr.Extensions.Configuration.Test
             config["first_secret__value"].Should().Be("secret1");
         }
 
+        [Fact]
+        public void LoadSecrets_FromSecretStoreThatReturnsCustomDelimitedKey()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    var secrets = new Dictionary<string, string>()
+                    {
+                        ["secretName--value"] = "secret",
+                    };
+                    await SendResponseWithSecrets(secrets, entry);
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore((conf) =>
+                    {
+                        conf.Store = "store";
+                        conf.Client = daprClient;
+                        conf.SecretDescriptors = new DaprSecretDescriptor[] { new DaprSecretDescriptor("secretName--value") };
+                        conf.CustomDelimiters = new[] { "--" };
+                    })
+                    .Build();
+
+            config["secretName:value"].Should().Be("secret");
+        }
+
+        [Fact]
+        public void LoadSecrets_FromSecretStoreThatReturnsDifferentCustomDelimitedKeys()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    // The following is an attempt at handling multiple secret descriptors for unit tests.
+                    var content = await entry.Request.Content.ReadAsStringAsync();
+                    if (content.Contains("secretName--value"))
+                    {
+                        await SendResponseWithSecrets(new Dictionary<string, string>()
+                        {
+                            ["secretName--value"] = "secret",
+                        }, entry);
+                    }
+                    else if (content.Contains("otherSecretName≡value"))
+                    {
+                        await SendResponseWithSecrets(new Dictionary<string, string>()
+                        {
+                            ["otherSecretName≡value"] = "secret",
+                        }, entry);
+                    }
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore((conf) =>
+                    {
+                        conf.Store = "store";
+                        conf.Client = daprClient;
+                        conf.SecretDescriptors = new DaprSecretDescriptor[]
+                        {
+                            new DaprSecretDescriptor("secretName--value"),
+                            new DaprSecretDescriptor("otherSecretName≡value"),
+                        };
+                        conf.CustomDelimiters = new[] { "--", "≡" };
+                    })
+                    .Build();
+
+            config["secretName:value"].Should().Be("secret");
+            config["otherSecretName:value"].Should().Be("secret");
+        }
+
+        [Fact]
+        public void BulkLoadSecrets_FromSecretStoreThatReturnsCustomDelimitedKey()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    var secrets = new Dictionary<string, string>()
+                    {
+                        ["first_secret--value"] = "secret1"
+                    };
+                    await SendBulkResponseWithSecrets(secrets, entry);
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore("store", daprClient, new[] { "--" })
+                    .Build();
+
+            config["first_secret:value"].Should().Be("secret1");
+        }
+
+        [Fact]
+        public void BulkLoadSecrets_FromSecretStoreThatReturnsDifferentCustomDelimitedKey()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    var secrets = new Dictionary<string, string>()
+                    {
+                        ["first_secret--value"] = "secret1",
+                        ["second_secret≡value"] = "secret2",
+                    };
+                    await SendBulkResponseWithSecrets(secrets, entry);
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore("store", daprClient, new[] { "--", "≡" })
+                    .Build();
+
+            config["first_secret:value"].Should().Be("secret1");
+            config["second_secret:value"].Should().Be("secret2");
+        }
+
+        [Fact]
+        public void BulkLoadSecrets_FromSecretStoreThatReturnsPlainAndCustomDelimitedKey()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    var secrets = new Dictionary<string, string>()
+                    {
+                        ["first_secret__value"] = "secret1",
+                        ["second_secret--value"] = "secret2",
+                        ["third_secret≡value"] = "secret3",
+                    };
+                    await SendBulkResponseWithSecrets(secrets, entry);
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore("store", daprClient, new[] { "--", "≡" })
+                    .Build();
+
+            config["first_secret:value"].Should().Be("secret1");
+            config["second_secret:value"].Should().Be("secret2");
+            config["third_secret:value"].Should().Be("secret3");
+        }
+
+        [Fact]
+        public void LoadSecrets_FromSecretStoreThatReturnsCustomDelimitedKeyDisabledNormalizeKey()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    var secrets = new Dictionary<string, string>()
+                    {
+                        ["secretName--value"] = "secret"
+                    };
+                    await SendResponseWithSecrets(secrets, entry);
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore((conf) =>
+                    {
+                        conf.Store = "store";
+                        conf.Client = daprClient;
+                        conf.SecretDescriptors = new DaprSecretDescriptor[] { new DaprSecretDescriptor("secretName--value") };
+                        conf.NormalizeKey = false;
+                        conf.CustomDelimiters = new[] { "--" };
+                    })
+                    .Build();
+
+            config["secretName--value"].Should().Be("secret");
+        }
+
+        [Fact]
+        public void BulkLoadSecrets_FromSecretStoreThatReturnsCustomDelimitedKeyDisabledNormalizeKey()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    var secrets = new Dictionary<string, string>()
+                    {
+                        ["first_secret--value"] = "secret1"
+                    };
+                    await SendBulkResponseWithSecrets(secrets, entry);
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore((conf) =>
+                    {
+                        conf.Store = "store";
+                        conf.Client = daprClient;
+                        conf.NormalizeKey = false;
+                        conf.CustomDelimiters = new[] { "--" };
+                    })
+                    .Build();
+
+            config["first_secret--value"].Should().Be("secret1");
+        }
+
         private IConfigurationBuilder CreateBuilder()
         {
             return new ConfigurationBuilder();

--- a/test/Dapr.Extensions.Configuration.Test/DaprSecretStoreConfigurationProviderTest.cs
+++ b/test/Dapr.Extensions.Configuration.Test/DaprSecretStoreConfigurationProviderTest.cs
@@ -449,6 +449,72 @@ namespace Dapr.Extensions.Configuration.Test
         }
 
         [Fact]
+        public void LoadSecrets_FromSecretStoreThatReturnsCustomDelimitedKey_NullDelimiters()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    var secrets = new Dictionary<string, string>()
+                    {
+                        ["secretName--value"] = "secret",
+                    };
+                    await SendResponseWithSecrets(secrets, entry);
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore((conf) =>
+                    {
+                        conf.Store = "store";
+                        conf.Client = daprClient;
+                        conf.SecretDescriptors = new DaprSecretDescriptor[] { new DaprSecretDescriptor("secretName--value") };
+                        conf.KeyDelimiters = null;
+                    })
+                    .Build();
+
+            config["secretName--value"].Should().Be("secret");
+        }
+
+        [Fact]
+        public void LoadSecrets_FromSecretStoreThatReturnsCustomDelimitedKey_EmptyDelimiters()
+        {
+            // Configure Client
+            var httpClient = new TestHttpClient()
+            {
+                Handler = async (entry) =>
+                {
+                    var secrets = new Dictionary<string, string>()
+                    {
+                        ["secretName--value"] = "secret",
+                    };
+                    await SendResponseWithSecrets(secrets, entry);
+                }
+            };
+
+            var daprClient = new DaprClientBuilder()
+                .UseGrpcChannelOptions(new GrpcChannelOptions { HttpClient = httpClient })
+                .Build();
+
+            var config = CreateBuilder()
+                    .AddDaprSecretStore((conf) =>
+                    {
+                        conf.Store = "store";
+                        conf.Client = daprClient;
+                        conf.SecretDescriptors = new DaprSecretDescriptor[] { new DaprSecretDescriptor("secretName--value") };
+                        conf.KeyDelimiters = new List<string>();
+                    })
+                    .Build();
+
+            config["secretName--value"].Should().Be("secret");
+        }
+
+        [Fact]
         public void LoadSecrets_FromSecretStoreThatReturnsDifferentCustomDelimitedKeys()
         {
             // Configure Client

--- a/test/Dapr.Extensions.Configuration.Test/DaprSecretStoreConfigurationProviderTest.cs
+++ b/test/Dapr.Extensions.Configuration.Test/DaprSecretStoreConfigurationProviderTest.cs
@@ -441,7 +441,7 @@ namespace Dapr.Extensions.Configuration.Test
                         conf.Store = "store";
                         conf.Client = daprClient;
                         conf.SecretDescriptors = new DaprSecretDescriptor[] { new DaprSecretDescriptor("secretName--value") };
-                        conf.CustomDelimiters = new[] { "--" };
+                        conf.KeyDelimiters = new[] { "--" };
                     })
                     .Build();
 
@@ -489,7 +489,7 @@ namespace Dapr.Extensions.Configuration.Test
                             new DaprSecretDescriptor("secretName--value"),
                             new DaprSecretDescriptor("otherSecretName≡value"),
                         };
-                        conf.CustomDelimiters = new[] { "--", "≡" };
+                        conf.KeyDelimiters = new[] { "--", "≡" };
                     })
                     .Build();
 
@@ -563,7 +563,7 @@ namespace Dapr.Extensions.Configuration.Test
                 {
                     var secrets = new Dictionary<string, string>()
                     {
-                        ["first_secret__value"] = "secret1",
+                        ["first_secret:value"] = "secret1",
                         ["second_secret--value"] = "secret2",
                         ["third_secret≡value"] = "secret3",
                     };
@@ -611,7 +611,7 @@ namespace Dapr.Extensions.Configuration.Test
                         conf.Client = daprClient;
                         conf.SecretDescriptors = new DaprSecretDescriptor[] { new DaprSecretDescriptor("secretName--value") };
                         conf.NormalizeKey = false;
-                        conf.CustomDelimiters = new[] { "--" };
+                        conf.KeyDelimiters = new[] { "--" };
                     })
                     .Build();
 
@@ -644,7 +644,7 @@ namespace Dapr.Extensions.Configuration.Test
                         conf.Store = "store";
                         conf.Client = daprClient;
                         conf.NormalizeKey = false;
-                        conf.CustomDelimiters = new[] { "--" };
+                        conf.KeyDelimiters = new[] { "--" };
                     })
                     .Build();
 


### PR DESCRIPTION
# Description

This PR proposes the addition of a `CustomDelimiters` property. The custom delimiters can be used in two ways:

```csharp
.AddDaprSecretStore("store", daprClient, new[] { "--", "≡" }) // Example of multiple delimiters
```

or

```csharp
.AddDaprSecretStore((conf) =>
{
    conf.Store = "store";
    conf.Client = daprClient;
    conf.CustomDelimiters = new[] { "--", "≡" }; // Example of multiple delimiters
})
```

This preserves the double underscore replacement regardless of the developer defining any custom delimiters or not. Documentation will be added after getting some initial opinion on this.

## Issue reference

This PR closes issue: #627 

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
