### PR TITLE
Add more unit tests for InvokeBindingAsync

### DIFF
--- a/test/Dapr.Client.Test/InvokeBindingApiTest.cs
+++ b/test/Dapr.Client.Test/InvokeBindingApiTest.cs
@@ -184,7 +184,7 @@ namespace Dapr.Client.Test
         }
 
         [Fact]
-        public async Task InvokeBindingAsync_WithCustomNullPayload_ValidateRequestResponse()
+        public async Task InvokeBindingAsync_WithNullPayload_ValidateRequestResponse()
         {
             await using var client = TestClient.CreateForDaprClient();
 


### PR DESCRIPTION
# Description

Added two unit tests: 
1. Invoke Binding Async with  custom data and validate payload deserialization
2. Invoke Binding Async with  Null custom data and validate payload deserialization

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #550 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
