### PR TITLE
optional httpClientHandler

### DIFF
--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -53,7 +53,7 @@ namespace Dapr.Client
         /// </param>
         /// <param name="daprEndpoint">The HTTP endpoint of the Dapr process to use for service invocation calls.</param>
         /// <param name="daprApiToken">The token to be added to all request headers to Dapr runtime.</param>
-        /// <param name="clientHandler">An optional handler to handle outgoing requests.</param>
+        /// <param name="handler">An optional handler to handle outgoing requests.</param>
         /// <returns>An <see cref="HttpClient" /> that can be used to perform service invocation requests.</returns>
         /// <remarks>
         /// <para>
@@ -62,21 +62,21 @@ namespace Dapr.Client
         /// a single client object can be reused for the life of the application.
         /// </para>
         /// </remarks>
-        public static HttpClient CreateInvokeHttpClient(string appId = null, string daprEndpoint = null, string daprApiToken = null, HttpClientHandler clientHandler = null)
+        public static HttpClient CreateInvokeHttpClient(string appId = null, string daprEndpoint = null, string daprApiToken = null, HttpClientHandler handler = null)
         {
-            var handler = new InvocationHandler()
+            var internalHandler = new InvocationHandler()
             {
-                InnerHandler = clientHandler ?? new HttpClientHandler(),
+                InnerHandler = handler ?? new HttpClientHandler(),
                 DaprApiToken = daprApiToken
             };
 
             if (daprEndpoint is string)
             {
                 // DaprEndpoint performs validation.
-                handler.DaprEndpoint = daprEndpoint;
+                internalHandler.DaprEndpoint = daprEndpoint;
             }
 
-            var httpClient = new HttpClient(handler);
+            var httpClient = new HttpClient(internalHandler);
             
             if (appId is string)
             {

--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -53,6 +53,7 @@ namespace Dapr.Client
         /// </param>
         /// <param name="daprEndpoint">The HTTP endpoint of the Dapr process to use for service invocation calls.</param>
         /// <param name="daprApiToken">The token to be added to all request headers to Dapr runtime.</param>
+        /// <param name="clientHandler">An optional handler to handle outgoing requests.</param>
         /// <returns>An <see cref="HttpClient" /> that can be used to perform service invocation requests.</returns>
         /// <remarks>
         /// <para>
@@ -61,11 +62,11 @@ namespace Dapr.Client
         /// a single client object can be reused for the life of the application.
         /// </para>
         /// </remarks>
-        public static HttpClient CreateInvokeHttpClient(string appId = null, string daprEndpoint = null, string daprApiToken = null)
+        public static HttpClient CreateInvokeHttpClient(string appId = null, string daprEndpoint = null, string daprApiToken = null, HttpClientHandler clientHandler = null)
         {
             var handler = new InvocationHandler()
             {
-                InnerHandler = new HttpClientHandler(),
+                InnerHandler = clientHandler ?? new HttpClientHandler(),
                 DaprApiToken = daprApiToken
             };
 


### PR DESCRIPTION
# Description

Adds an optional `HttpClientHandler` parameter (defaults to null) to `DaprClient.CreateInvokeHttpClient` to enable providing your own client handler. This should be useful for diagnostic scenarios as well as collecting additional telemetry, performing additional logging or propagating additional contextual data while making outgoing HTTP requests.

## Issue reference

#647 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Extended the documentation
