### PR TITLE
Fix inverted default http and gRpc ports

### DIFF
--- a/src/Shared/DaprDefaults.cs
+++ b/src/Shared/DaprDefaults.cs
@@ -36,7 +36,7 @@ namespace Dapr
             if (httpEndpoint == null)
             {
                 var port = Environment.GetEnvironmentVariable("DAPR_HTTP_PORT");
-                port = string.IsNullOrEmpty(port) ? "3500" : port;
+                port = string.IsNullOrEmpty(port) ? "50001" : port;
                 httpEndpoint = $"http://127.0.0.1:{port}";
             }
 
@@ -48,7 +48,7 @@ namespace Dapr
             if (grpcEndpoint == null)
             {
                 var port = Environment.GetEnvironmentVariable("DAPR_GRPC_PORT");
-                port = string.IsNullOrEmpty(port) ? "50001" : port;
+                port = string.IsNullOrEmpty(port) ? "3500" : port;
                 grpcEndpoint = $"http://127.0.0.1:{port}";
             }
 


### PR DESCRIPTION
# Description

Fix inverted default http and gRpc ports

## Issue reference 
https://github.com/dapr/dotnet-sdk/issues/643

Please reference the issue this PR will close: #643 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
