### PR TITLE
Remove hardcoded application/json in favour of MediaTypeNames and use ContentTypeApplicationJson property

### DIFF
--- a/src/Dapr.Client/Constants.cs
+++ b/src/Dapr.Client/Constants.cs
@@ -3,11 +3,13 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
+using System.Net.Mime;
+
 namespace Dapr.Client
 {
     internal class Constants
     {
-        public const string ContentTypeApplicationJson = "application/json";
+        public const string ContentTypeApplicationJson = MediaTypeNames.Application.Json;
         public const string ContentTypeApplicationGrpc = "application/grpc";
     }
 }

--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -129,7 +129,7 @@ namespace Dapr.Client
             if (content != null)
             {
                 envelope.Data = content;
-                envelope.DataContentType = "application/json";
+                envelope.DataContentType = Constants.ContentTypeApplicationJson;
             }
 
             if (metadata != null)


### PR DESCRIPTION


# Description

Remove hardcoded application/json in favour of MediaTypeNames and use ContentTypeApplicationJson property.

## Issue reference

#663

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
