### PR TITLE
Create empty Grpc files on LUT build

### DIFF
--- a/src/Dapr.Client/Dapr.Client.csproj
+++ b/src/Dapr.Client/Dapr.Client.csproj
@@ -14,6 +14,11 @@
     <Protobuf Include="Protos\dapr\proto\dapr\v1\dapr.proto" ProtoRoot="Protos" GrpcServices="Client" />
     <Protobuf Include="Protos\dapr\proto\dapr\v1\appcallback.proto" ProtoRoot="Protos" GrpcServices="Server" />
   </ItemGroup>
+  
+  <Target Name="WriteToFile" AfterTargets="Protobuf_Compile" Condition="'$(BuildingForLiveUnitTesting)' == 'true'">
+    <!-- Workaround to generate the empty file on a LUT build -->
+    <WriteLinesToFile File="$(IntermediateOutputPath)dapr\proto\common\v1\CommonGrpc.cs" Lines="" Overwrite="true" />
+  </Target>
 
   <!-- Additional Nuget package properties. -->
   <PropertyGroup>

--- a/test/Dapr.Client.Test/Dapr.Client.Test.csproj
+++ b/test/Dapr.Client.Test/Dapr.Client.Test.csproj
@@ -28,6 +28,11 @@
     <Protobuf Include="Protos\test.proto" ProtoRoot="Protos" GrpcServices="Client" />
   </ItemGroup>
 
+  <Target Name="WriteToFile" AfterTargets="Protobuf_Compile" Condition="'$(BuildingForLiveUnitTesting)' == 'true'">
+    <!-- Workaround to generate the empty file on a LUT build -->
+    <WriteLinesToFile File="$(IntermediateOutputPath)TestGrpc.cs" Lines="" Overwrite="true" />
+  </Target>
+
   <ItemGroup>
     <Compile Include="..\Shared\AppCallbackClient.cs" />
     <Compile Include="..\Shared\TestClient.cs" />


### PR DESCRIPTION
# Description

Create a workaround that generates an empty file if it is a Live Unit Testing build.

## Issue reference

Will close: #685

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
