### PR TITLE
docs fix: only UseHttpsRedirection for non-dev env

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-howto.md
@@ -291,8 +291,14 @@ namespace MyActorService
             {
                 app.UseDeveloperExceptionPage();
             }
-
-            app.UseHttpsRedirection();
+            else
+            {
+                // By default, ASP.Net Core uses port 5000 for HTTP. The HTTP
+                // redirection will interfere with the Dapr runtime. You can
+                // move this out of the else block if you use port 5001 in this
+                // example, and developer tooling (such as the VSCode extension).
+                app.UseHttpsRedirection();
+            }
 
             app.UseRouting();
 


### PR DESCRIPTION
# Description

Moved the UseHttpsRedirection to the else block of the IsDevelopment
check, and add a comment describing why.

The Dapr runtime reports and error and aborts the request after an HTTP
redirection. By default ASP.Net Core uses port 5000 for HTTP, and port
5001 for HTTPs. This means that if the instructions are followed exactly
the example won't work. The VSCode extension also breaks.

# Remarks

The alternative is to update all the docs with port 5001 instead, in addition to the VSCode extension defaults.