### PR TITLE
fix: InvalidProgramException under ASP.Net 6.0

### DIFF
--- a/src/Dapr.Actors/Builder/MethodDispatcherBuilder.cs
+++ b/src/Dapr.Actors/Builder/MethodDispatcherBuilder.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------
+﻿// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // ------------------------------------------------------------
@@ -16,6 +16,7 @@ namespace Dapr.Actors.Builder
     internal class MethodDispatcherBuilder<TMethodDispatcher> : CodeBuilderModule
         where TMethodDispatcher : ActorMethodDispatcherBase
     {
+        private static readonly MethodInfo getTypeFromHandle = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle));
         private readonly Type methodDispatcherBaseType;
         private readonly MethodInfo continueWithResultMethodInfo;
         private readonly MethodInfo continueWithMethodInfo;
@@ -102,6 +103,7 @@ namespace Dapr.Actors.Builder
                     ilGen.Emit(OpCodes.Ldc_I4, i);
                     ilGen.Emit(OpCodes.Ldstr, argument.Name);
                     ilGen.Emit(OpCodes.Ldtoken, argument.ArgumentType);
+                    ilGen.Emit(OpCodes.Call, getTypeFromHandle);
                     ilGen.Emit(OpCodes.Callvirt, method);
                     ilGen.Emit(OpCodes.Unbox_Any, argument.ArgumentType);
                 }
@@ -332,7 +334,7 @@ namespace Dapr.Actors.Builder
             }
             else
             {
-                ilGen.Emit(OpCodes.Ldarg_0);
+                ilGen.Emit(OpCodes.Ldarg_0); // base
                 ilGen.Emit(OpCodes.Ldloc, invokeTask);
                 ilGen.EmitCall(OpCodes.Call, this.continueWithMethodInfo, null);
                 ilGen.Emit(OpCodes.Ret);

--- a/test/Dapr.Actors.Test/ActorCodeBuilderTests.cs
+++ b/test/Dapr.Actors.Test/ActorCodeBuilderTests.cs
@@ -1,11 +1,16 @@
-// ------------------------------------------------------------
+﻿// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
 namespace Dapr.Actors.Test
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Dapr.Actors.Builder;
+    using Dapr.Actors.Communication;
+    using Dapr.Actors.Description;
+    using Dapr.Actors.Runtime;
     using Xunit;
 
     /// <summary>
@@ -20,6 +25,23 @@ namespace Dapr.Actors.Test
         public void TestBuildActorProxyGenerator()
         {
             ActorProxyGenerator proxyGenerator = ActorCodeBuilder.GetOrCreateProxyGenerator(typeof(ITestActor));
+        }
+
+        [Fact]
+        public async Task ActorCodeBuilder_BuildDispatcher()
+        {
+            var host = ActorHost.CreateForTest<TestActor>();
+
+            var dispatcher = ActorCodeBuilder.GetOrCreateMethodDispatcher(typeof(ITestActor));
+            var methodId = MethodDescription.Create("test", typeof(ITestActor).GetMethod("GetCountAsync"), true).Id;
+
+            var impl = new TestActor(host);
+            var request = new ActorRequestMessageBody(0);
+            var response = new WrappedRequestMessageFactory();
+
+            var body = (WrappedMessage)await dispatcher.DispatchAsync(impl, methodId, request, response, default);
+            dynamic bodyValue = body.Value;
+            Assert.Equal(5, (int)bodyValue.retVal);
         }
     }
 }


### PR DESCRIPTION
# Description

Call `Type.GetTypeFromHandle` when calling `IActorRequestMessageBody.GetParameter`

The code that generates the `IActorRequestMessageBody` parameter setup for the dispatched call is technically incorrect, as it passes a `RuntimeTypeHandle` to a method expecting `Type`. The correct thing to do is to call `Type.GetTypeHandle` first to perform the conversion.

It looks like RyuJIT is now validating this, where it wasn't before. It is possible the 5.0 was automatically doing the coercion, or would have crashed if the branch was ever executed (it's pretty likely that this branch has never been executed).

The test will only fail when the test project and global.json are configured for the 6.0 SDK.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #705, #699

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation - N/A
