### PR TITLE
Only isolate state when using reentrancy

### DIFF
--- a/src/Dapr.Actors/Runtime/ActorManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorManager.cs
@@ -339,10 +339,13 @@ namespace Dapr.Actors.Runtime
             T retval;
             try
             {
-                // Set the state context of the request, if possible.
-                if (state.Actor.StateManager is IActorContextualState contextualStateManager)
+                // Set the state context of the request, if required and possible.
+                if (ActorReentrancyContextAccessor.ReentrancyContext != null)
                 {
-                    await contextualStateManager.SetStateContext(Guid.NewGuid().ToString());
+                    if (state.Actor.StateManager is IActorContextualState contextualStateManager)
+                    {
+                        await contextualStateManager.SetStateContext(Guid.NewGuid().ToString());
+                    }
                 }
 
                 // invoke the function of the actor


### PR DESCRIPTION
# Description
Non-reentrant actors can utilize their state manager's cache
for repeated calls. They should still be able to do this unless
using reentrancy.

## Issue reference

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [] Created/updated tests
* [ ] Extended the documentation
