### PR TITLE
Adding match and priority to TopicAttribute for PubSub routing.

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-troubleshooting/dotnet-troubleshooting-pubsub.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-troubleshooting/dotnet-troubleshooting-pubsub.md
@@ -130,6 +130,11 @@ If you're using a controller for pub/sub you should have a method like:
 [Topic("pubsub", "deposit")]
 [HttpPost("deposit")]
 public async Task<ActionResult> Deposit(...)
+
+// Using Pub/Sub routing
+[Topic("pubsub", "transactions", "event.type == \"withdraw.v2\"", 1)]
+[HttpPost("withdraw")]
+public async Task<ActionResult> Withdraw(...)
 ```
 
 In this example the `Topic` and `HttpPost` attributes are required, but other details might be different.
@@ -154,8 +159,23 @@ In this step we'll verify that the entries registered with pub/sub are reachable
 
 ```json
 [
-    {"topic":"deposit","route":"deposit","pubsubName":"pubsub"},
-    {"topic":"withdraw","route":"withdraw","pubsubName":"pubsub"}
+  {
+    "pubsubName": "pubsub",
+    "topic": "deposit",
+    "route": "deposit"
+  },
+  {
+    "pubsubName": "pubsub",
+    "topic": "deposit",
+    "routes": {
+      "rules": [
+        {
+          "match": "event.type == \"withdraw.v2\"",
+          "path": "withdraw"
+        }
+      ]
+    }
+  }
 ]
 ```
 

--- a/examples/AspNetCore/ControllerSample/Controllers/SampleController.cs
+++ b/examples/AspNetCore/ControllerSample/Controllers/SampleController.cs
@@ -93,6 +93,35 @@ namespace ControllerSample.Controllers
         }
 
         /// <summary>
+        /// Method for withdrawing from account as specified in transaction.
+        /// </summary>
+        /// <param name="transaction">Transaction info.</param>
+        /// <param name="daprClient">State client to interact with Dapr runtime.</param>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        ///  "pubsub", the first parameter into the Topic attribute, is name of the default pub/sub configured by the Dapr CLI.
+        [Topic("pubsub", "withdraw", "event.type ==\"withdraw.v2\"", 1)]
+        [HttpPost("withdraw.v2")]
+        public async Task<ActionResult<Account>> WithdrawV2(TransactionV2 transaction, [FromServices] DaprClient daprClient)
+        {
+            logger.LogDebug("Enter withdraw.v2");
+            if (transaction.Channel == "mobile" && transaction.Amount > 10000)
+            {
+                return this.Unauthorized("mobile transactions for large amounts are not permitted.");
+            }
+
+            var state = await daprClient.GetStateEntryAsync<Account>(StoreName, transaction.Id);
+
+            if (state.Value == null)
+            {
+                return this.NotFound();
+            }
+
+            state.Value.Balance -= transaction.Amount;
+            await state.SaveAsync();
+            return state.Value;
+        }
+
+        /// <summary>
         /// Method for returning a BadRequest result which will cause Dapr sidecar to throw an RpcException
         [HttpPost("throwException")]
         public async Task<ActionResult<Account>> ThrowException(Transaction transaction, [FromServices] DaprClient daprClient)

--- a/examples/AspNetCore/ControllerSample/CustomTopicAttribute.cs
+++ b/examples/AspNetCore/ControllerSample/CustomTopicAttribute.cs
@@ -18,7 +18,6 @@ namespace ControllerSample
         {
             this.PubsubName = Environment.ExpandEnvironmentVariables(pubsubName);
             this.Name = Environment.ExpandEnvironmentVariables(name);
-            this.Priority = int.MaxValue;
         }
 
         /// <inheritdoc/>

--- a/examples/AspNetCore/ControllerSample/CustomTopicAttribute.cs
+++ b/examples/AspNetCore/ControllerSample/CustomTopicAttribute.cs
@@ -18,12 +18,19 @@ namespace ControllerSample
         {
             this.PubsubName = Environment.ExpandEnvironmentVariables(pubsubName);
             this.Name = Environment.ExpandEnvironmentVariables(name);
+            this.Priority = int.MaxValue;
         }
+
+        /// <inheritdoc/>
+        public string PubsubName { get; }
 
         /// <inheritdoc/>
         public string Name { get; }
 
         /// <inheritdoc/>
-        public string PubsubName { get; }
+        public new string Match { get; }
+
+        /// <inheritdoc/>
+        public int Priority { get; }
     }
 }

--- a/examples/AspNetCore/ControllerSample/TransactionV2.cs
+++ b/examples/AspNetCore/ControllerSample/TransactionV2.cs
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+namespace ControllerSample
+{
+    using System.ComponentModel.DataAnnotations;
+
+    /// <summary>
+    /// Represents a transaction used by sample code.
+    /// </summary>
+    public class TransactionV2
+    {
+        /// <summary>
+        /// Gets or sets account id for the transaction.
+        /// </summary>
+        [Required]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets amount for the transaction.
+        /// </summary>
+        [Range(0, double.MaxValue)]
+        public decimal Amount { get; set; }
+
+        /// <summary>
+        /// Gets or sets channel from which this transaction was received.
+        /// </summary>
+        [Required]
+        public string Channel { get; set; }
+    }
+}

--- a/src/Dapr.AspNetCore/ITopicMetadata.cs
+++ b/src/Dapr.AspNetCore/ITopicMetadata.cs
@@ -6,7 +6,7 @@
 namespace Dapr
 {
     /// <summary>
-    /// Metadata that describes an endpoint as a subscriber to a topic.
+    /// ITopicMetadata that describes an endpoint as a subscriber to a topic.
     /// </summary>
     public interface ITopicMetadata
     {
@@ -19,5 +19,15 @@ namespace Dapr
         /// Gets the pubsub component name name.
         /// </summary>
         string PubsubName { get; }
+
+        /// <summary>
+        /// The CEL expression to use to match events for this handler.
+        /// </summary>
+        string Match { get; }
+
+        /// <summary>
+        /// The priority in which this rule should be evaluated (lower to higher).
+        /// </summary>
+        int Priority { get; }
     }
 }

--- a/src/Dapr.AspNetCore/Subscription.cs
+++ b/src/Dapr.AspNetCore/Subscription.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Dapr
 {
     /// <summary>
@@ -26,6 +28,11 @@ namespace Dapr
         public string Route { get; set; }
 
         /// <summary>
+        /// Gets or sets the routes
+        /// </summary>
+        public Routes Routes { get; set; }
+
+        /// <summary>
         /// Gets or sets the metadata.
         /// </summary>
         public Metadata Metadata { get; set; }
@@ -37,8 +44,34 @@ namespace Dapr
     internal class Metadata
     {
         /// <summary>
-        /// Gets or sets the rawoayload
+        /// Gets or sets the raw payload
         /// </summary>
         public string RawPayload { get; set; }
+    }
+
+    internal class Routes
+    {
+        /// <summary>
+        /// Gets or sets the default route
+        /// </summary>
+        public string Default { get; set; }
+
+        /// <summary>
+        /// Gets or sets the routing rules
+        /// </summary>
+        public List<Rule> Rules { get; set; }
+    }
+
+    internal class Rule
+    {
+        /// <summary>
+        /// Gets or sets the CEL expression to match this route.
+        /// </summary>
+        public string Match { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path of the route.
+        /// </summary>
+        public string Path { get; set; }
     }
 }

--- a/src/Dapr.AspNetCore/TopicAttribute.cs
+++ b/src/Dapr.AspNetCore/TopicAttribute.cs
@@ -8,7 +8,7 @@ namespace Dapr
     using System;
 
     /// <summary>
-    /// Metadata that describes an endpoint as a subscriber to a topic.
+    /// TopicAttribute describes an endpoint as a subscriber to a topic.
     /// </summary>
     public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata
     {
@@ -24,6 +24,7 @@ namespace Dapr
 
             this.Name = name;
             this.PubsubName = pubsubName;
+            this.Priority = int.MaxValue;
         }
 
         /// <summary>
@@ -40,6 +41,45 @@ namespace Dapr
             this.Name = name;
             this.PubsubName = pubsubName;
             this.EnableRawPayload = enableRawPayload;
+            this.Priority = int.MaxValue;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TopicAttribute" /> class.
+        /// </summary>
+        /// <param name="pubsubName">The name of the pubsub component to use.</param>
+        /// <param name="name">The topic name.</param>
+        /// <param name="match">The CEL expression to test the cloud event with.</param>
+        /// <param name="priority">The priority of the rule (low-to-high values).</param>
+        public TopicAttribute(string pubsubName, string name, string match, int priority)
+        {
+            ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
+            ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
+
+            this.Name = name;
+            this.PubsubName = pubsubName;
+            this.Match = match;
+            this.Priority = priority;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TopicAttribute" /> class.
+        /// </summary>
+        /// <param name="pubsubName">The name of the pubsub component to use.</param>
+        /// <param name="name">The topic name.</param>
+        /// <param name="enableRawPayload">The enable/disable raw pay load flag.</param>
+        /// <param name="match">The CEL expression to test the cloud event with.</param>
+        /// <param name="priority">The priority of the rule (low-to-high values).</param>
+        public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string match, int priority)
+        {
+            ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
+            ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
+
+            this.Name = name;
+            this.PubsubName = pubsubName;
+            this.EnableRawPayload = enableRawPayload;
+            this.Match = match;
+            this.Priority = priority;
         }
 
         /// <inheritdoc/>
@@ -50,5 +90,11 @@ namespace Dapr
 
         /// <inheritdoc/>
         public bool? EnableRawPayload { get; }
+
+        /// <inheritdoc/>
+        public new string Match { get; }
+
+        /// <inheritdoc/>
+        public int Priority { get; }
     }
 }

--- a/src/Dapr.AspNetCore/TopicAttribute.cs
+++ b/src/Dapr.AspNetCore/TopicAttribute.cs
@@ -24,7 +24,6 @@ namespace Dapr
 
             this.Name = name;
             this.PubsubName = pubsubName;
-            this.Priority = int.MaxValue;
         }
 
         /// <summary>
@@ -41,7 +40,6 @@ namespace Dapr
             this.Name = name;
             this.PubsubName = pubsubName;
             this.EnableRawPayload = enableRawPayload;
-            this.Priority = int.MaxValue;
         }
 
         /// <summary>

--- a/src/Dapr.Client/Protos/dapr/proto/dapr/v1/appcallback.proto
+++ b/src/Dapr.Client/Protos/dapr/proto/dapr/v1/appcallback.proto
@@ -70,6 +70,10 @@ message TopicEventRequest {
 
   // The name of the pubsub the publisher sent to.
   string pubsub_name = 8;
+
+  // The matching path from TopicSubscription/routes (if specified) for this event.
+  // This value is used by OnTopicEvent to "switch" inside the handler.
+  string path = 9;
 }
 
 // TopicEventResponse is response from app on published message
@@ -144,6 +148,30 @@ message TopicSubscription {
 
   // The optional properties used for this topic's subscription e.g. session id
   map<string,string> metadata = 3;
+
+  // The optional routing rules to match against. In the gRPC interface, OnTopicEvent
+  // is still invoked but the matching path is sent in the TopicEventRequest.
+  TopicRoutes routes = 5;
+}
+
+message TopicRoutes {
+  // The list of rules for this topic.
+  repeated TopicRule rules = 1;
+
+  // The default path for this topic.
+  string default = 2;
+}
+
+message TopicRule {
+  // The optional CEL expression used to match the event.
+	// If the match is not specified, then the route is considered
+	// the default.
+  string match = 1;
+
+  // The path used to identify matches for this subscription.
+  // This value is passed in TopicEventRequest and used by OnTopicEvent to "switch"
+  // inside the handler.
+  string path = 2;
 }
 
 // ListInputBindingsResponse is the message including the list of input bindings.

--- a/test/Dapr.AspNetCore.IntegrationTest.App/CustomTopicAttribute.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/CustomTopicAttribute.cs
@@ -18,5 +18,9 @@ namespace Dapr.AspNetCore.IntegrationTest.App
         public string Name { get; }
 
         public string PubsubName { get; }
+
+        public new string Match { get; }
+
+        public int Priority { get; }
     }
 }

--- a/test/Dapr.AspNetCore.IntegrationTest.App/DaprController.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/DaprController.cs
@@ -41,6 +41,18 @@ namespace Dapr.AspNetCore.IntegrationTest.App
         {
         }
 
+        [Topic("pubsub", "E", false, "event.type == \"critical\"", 1)]
+        [HttpPost("/E-Critical")]
+        public void TopicECritical()
+        {
+        }
+
+        [Topic("pubsub", "E", false, "event.type == \"important\"", 2)]
+        [HttpPost("/E-Important")]
+        public void TopicEImportant()
+        {
+        }
+
         [Topic("pubsub", "register-user")]
         [HttpPost("/register-user")]
         public ActionResult<UserInfo> RegisterUser(UserInfo user)

--- a/test/Dapr.AspNetCore.IntegrationTest/SubscribeEndpointTest.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest/SubscribeEndpointTest.cs
@@ -71,9 +71,9 @@ namespace Dapr.AspNetCore.IntegrationTest
                     subscriptions.Should().Contain(("pubsub", "register-user", "register-user", string.Empty, string.Empty));
                     subscriptions.Should().Contain(("pubsub", "register-user-plaintext", "register-user-plaintext", string.Empty, string.Empty));
                     subscriptions.Should().Contain(("pubsub", "D", "D", "true", string.Empty));
-                    subscriptions.Should().Contain(("pubsub", "E", "E", "false", string.Empty));
-                    subscriptions.Should().Contain(("pubsub", "E", "E-Critical", "false", "event.type == \"critical\""));
-                    subscriptions.Should().Contain(("pubsub", "E", "E-Important", "false", "event.type == \"important\""));
+                    subscriptions.Should().Contain(("pubsub", "E", "E", string.Empty, string.Empty));
+                    subscriptions.Should().Contain(("pubsub", "E", "E-Critical", string.Empty, "event.type == \"critical\""));
+                    subscriptions.Should().Contain(("pubsub", "E", "E-Important", string.Empty, "event.type == \"important\""));
 
                     // Test priority route sorting
                     var eTopic = subscriptions.FindAll(e => e.Topic == "E");

--- a/test/Dapr.AspNetCore.IntegrationTest/SubscribeEndpointTest.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest/SubscribeEndpointTest.cs
@@ -32,28 +32,55 @@ namespace Dapr.AspNetCore.IntegrationTest
 
                     json.ValueKind.Should().Be(JsonValueKind.Array);
                     json.GetArrayLength().Should().Be(7);
-                    var subscriptions = new List<(string PubsubName, string Topic, string Route, string rawPayload)>();
+                    var subscriptions = new List<(string PubsubName, string Topic, string Route, string rawPayload, string match)>();
                     foreach (var element in json.EnumerateArray())
                     {
                         var pubsubName = element.GetProperty("pubsubName").GetString();
                         var topic = element.GetProperty("topic").GetString();
-                        var route = element.GetProperty("route").GetString();
                         var rawPayload = string.Empty;
-                        if(element.TryGetProperty("metadata", out JsonElement metadata))
+                        if (element.TryGetProperty("metadata", out JsonElement metadata))
                         {
                             rawPayload = metadata.GetProperty("rawPayload").GetString();
                         }
-                        
-                        subscriptions.Add((pubsubName, topic, route,rawPayload));
+
+                        if (element.TryGetProperty("route", out JsonElement route))
+                        {
+                            subscriptions.Add((pubsubName, topic, route.GetString(), rawPayload, string.Empty));
+                        }
+                        else if (element.TryGetProperty("routes", out JsonElement routes))
+                        {
+                            if (routes.TryGetProperty("rules", out JsonElement rules))
+                            {
+                                foreach (var rule in rules.EnumerateArray())
+                                {
+                                    var match = rule.GetProperty("match").GetString();
+                                    var path = rule.GetProperty("path").GetString();
+                                    subscriptions.Add((pubsubName, topic, path, rawPayload, match));
+                                }
+                            }
+                            if (routes.TryGetProperty("default", out JsonElement defaultProperty))
+                            {
+                                subscriptions.Add((pubsubName, topic, defaultProperty.GetString(), rawPayload, string.Empty));
+                            }                            
+                        }
                     }
 
-                    subscriptions.Should().Contain(("testpubsub", "A", "topic-a", string.Empty));
-                    subscriptions.Should().Contain(("pubsub", "B", "B", string.Empty));
-                    subscriptions.Should().Contain(("custom-pubsub", "custom-C", "C", string.Empty));
-                    subscriptions.Should().Contain(("pubsub", "register-user", "register-user", string.Empty));
-                    subscriptions.Should().Contain(("pubsub", "register-user-plaintext", "register-user-plaintext", string.Empty));
-                    subscriptions.Should().Contain(("pubsub", "D", "D", "true"));
-                    subscriptions.Should().Contain(("pubsub", "E", "E", "false"));
+                    subscriptions.Should().Contain(("testpubsub", "A", "topic-a", string.Empty, string.Empty));
+                    subscriptions.Should().Contain(("pubsub", "B", "B", string.Empty, string.Empty));
+                    subscriptions.Should().Contain(("custom-pubsub", "custom-C", "C", string.Empty, string.Empty));
+                    subscriptions.Should().Contain(("pubsub", "register-user", "register-user", string.Empty, string.Empty));
+                    subscriptions.Should().Contain(("pubsub", "register-user-plaintext", "register-user-plaintext", string.Empty, string.Empty));
+                    subscriptions.Should().Contain(("pubsub", "D", "D", "true", string.Empty));
+                    subscriptions.Should().Contain(("pubsub", "E", "E", "false", string.Empty));
+                    subscriptions.Should().Contain(("pubsub", "E", "E-Critical", "false", "event.type == \"critical\""));
+                    subscriptions.Should().Contain(("pubsub", "E", "E-Important", "false", "event.type == \"important\""));
+
+                    // Test priority route sorting
+                    var eTopic = subscriptions.FindAll(e => e.Topic == "E");
+                    eTopic.Count.Should().Be(3);
+                    eTopic[0].Route.Should().Be("E-Critical");
+                    eTopic[1].Route.Should().Be("E-Important");
+                    eTopic[2].Route.Should().Be("E");
                 }
             }
         }


### PR DESCRIPTION
# Description

Add PubSub routing per dapr/dapr#3406.

Example usage

```C#
[Topic("pubsub", "transactions", "event.type == \"withdraw.v2\"", 1)]
[HttpPost("withdraw")]
public async Task<ActionResult> Withdraw(...)
```

## Issue reference

Part of dapr/dapr#2582

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
