### PR TITLE
Fixing falsely logged default subscription message

### DIFF
--- a/src/Dapr.AspNetCore/DaprEndpointRouteBuilderExtensions.cs
+++ b/src/Dapr.AspNetCore/DaprEndpointRouteBuilderExtensions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Builder
 
                         if (logger != null)
                         {
-                            if (defaultRoutes.Count() > 0)
+                            if (defaultRoutes.Count() > 1)
                             {
                                 logger.LogError("A default subscription to topic {name} on pubsub {pubsub} already exists.", first.Name, first.PubsubName);
                             }


### PR DESCRIPTION
# Description

There was an off-by-one bug in the check for duplicate default subscriptions for a given topic/pubsub.

## Issue reference

Closes #760

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
