### PR TITLE
- Added null-conditional operator to StateEntryApplicationModelProvid…

### DIFF
--- a/src/Dapr.AspNetCore/StateEntryApplicationModelProvider.cs
+++ b/src/Dapr.AspNetCore/StateEntryApplicationModelProvider.cs
@@ -28,7 +28,7 @@ namespace Dapr.AspNetCore
                     {
                         // Not bindable.
                     }
-                    else if (property.BindingInfo.BindingSource.Id == "state")
+                    else if (property.BindingInfo.BindingSource?.Id == "state")
                     {
                         // Already configured, don't overwrite in case the user customized it.
                     }
@@ -46,7 +46,7 @@ namespace Dapr.AspNetCore
                         {
                             // Not bindable.
                         }
-                        else if (parameter.BindingInfo.BindingSource.Id == "state")
+                        else if (parameter.BindingInfo.BindingSource?.Id == "state")
                         {
                             // Already configured, don't overwrite in case the user customized it.
                         }

--- a/test/Dapr.AspNetCore.Test/StateEntryApplicationModelProviderTest.cs
+++ b/test/Dapr.AspNetCore.Test/StateEntryApplicationModelProviderTest.cs
@@ -1,0 +1,94 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+namespace Dapr.AspNetCore.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using Dapr.AspNetCore.Resources;
+    using Dapr.Client;
+    using Dapr.Client.Autogen.Grpc.v1;
+    using FluentAssertions;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.ApplicationModels;
+    using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+    using Microsoft.AspNetCore.Mvc.Routing;
+    using Microsoft.Extensions.DependencyInjection;
+    using Xunit;
+
+    public class StateEntryApplicationModelProviderTest
+    {
+        [Fact]
+        public void OnProvidersExecuted_NullActionsBindingSource()
+        {
+            var provider = new StateEntryApplicationModelProvider();
+            var context = CreateContext(nameof(ApplicationModelProviderTestController.Get));
+
+            Action action = () => provider.OnProvidersExecuted(context);
+
+            action
+                .Should()
+                .NotThrow<NullReferenceException>();
+        }
+
+        [Fact]
+        public void OnProvidersExecuted_StateEntryParameterThrows()
+        {
+            var provider = new StateEntryApplicationModelProvider();
+            var context = CreateContext(nameof(ApplicationModelProviderTestController.Post));
+
+            Action action = () => provider.OnProvidersExecuted(context);
+
+            action
+                .Should()
+                .Throw<InvalidOperationException>(SR.ErrorStateStoreNameNotProvidedForStateEntry);
+        }
+
+        private ApplicationModelProviderContext CreateContext(string methodName)
+        {
+            var controllerType = typeof(ApplicationModelProviderTestController).GetTypeInfo();
+            var typeInfoList = new List<TypeInfo> { controllerType };
+
+            var context = new ApplicationModelProviderContext(typeInfoList);
+            var controllerModel = new ControllerModel(controllerType, new List<object>(0));
+
+            context.Result.Controllers.Add(controllerModel);
+
+            var methodInfo = controllerType.AsType().GetMethods().First(m => m.Name.Equals(methodName));
+            var actionModel = new ActionModel(methodInfo, controllerModel.Attributes)
+            {
+                Controller = controllerModel
+            };
+
+            controllerModel.Actions.Add(actionModel);
+            var parameterInfo = actionModel.ActionMethod.GetParameters().First();
+            var parameterModel = new ParameterModel(parameterInfo, controllerModel.Attributes)
+            {
+                BindingInfo = new BindingInfo(),
+                Action = actionModel,
+            };
+
+            actionModel.Parameters.Add(parameterModel);
+
+            return context;
+        }
+
+        [Controller]
+        private class ApplicationModelProviderTestController : Controller
+        {
+            [HttpGet]
+            public void Get([Bind(Prefix = "s")]int someId) { }
+
+            [HttpPost]
+            public void Post(StateEntry<Subscription> bogusEntry) { }
+        }
+    }
+}


### PR DESCRIPTION
# Description
- Added null-conditional operator to `StateEntryApplicationModelProvider.OnProvidersExecuted` when checking BindingSource to prevent startup null reference exceptions in certain implementations.
- Added null check and thorws unit tests for `StateEntryApplicationModelProvider`

## Issue reference

Please reference the issue this PR will close: #764 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
    * N/A - Minor bug fix
