### PR TITLE
Fix StateManager can't get dapr-api-token header.

### DIFF
--- a/src/Dapr.Actors/Runtime/ActorRuntimeOptions.cs
+++ b/src/Dapr.Actors/Runtime/ActorRuntimeOptions.cs
@@ -25,7 +25,7 @@ namespace Dapr.Actors.Runtime
             Enabled = false,
         };
         private JsonSerializerOptions jsonSerializerOptions = JsonSerializerDefaults.Web;
-        private string daprApiToken = null;
+        private string daprApiToken = DaprDefaults.GetDefaultApiToken();
         private int? remindersStoragePartitions = null;
 
         /// <summary>


### PR DESCRIPTION
When "dapr_api_token" is specified in the environment variable, actor.statemanager cannot correctly set "dapr-api-token" in the request header。

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
