### PR TITLE
Fix StateManager can't get dapr-api-token header.

### DIFF
--- a/src/Dapr.Actors/Runtime/ActorRuntimeOptions.cs
+++ b/src/Dapr.Actors/Runtime/ActorRuntimeOptions.cs
@@ -25,7 +25,7 @@ namespace Dapr.Actors.Runtime
             Enabled = false,
         };
         private JsonSerializerOptions jsonSerializerOptions = JsonSerializerDefaults.Web;
-        private string daprApiToken = null;
+        private string daprApiToken = DaprDefaults.GetDefaultApiToken();
         private int? remindersStoragePartitions = null;
 
         /// <summary>


### PR DESCRIPTION


# Description

When "dapr_api_token" is specified in the environment variable, actor.statemanager cannot correctly set "dapr-api-token" in the request header。

## Issue reference

#767

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* ~~[ ] Extended the documentation~~ this is a bug, don't need update documentation
