### PR TITLE
Fix issue where state did not reset on actor error

### DIFF
--- a/all.sln
+++ b/all.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapr.E2E.Test.App.Grpc", "t
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationApi", "examples\Client\ConfigurationApi\ConfigurationApi.csproj", "{F80F837E-D2FC-4FFC-B68F-3CF0EC015F66}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapr.E2E.Test.App.ReentrantActors", "test\Dapr.E2E.Test.App.ReentrantActor\Dapr.E2E.Test.App.ReentrantActors.csproj", "{5BE7F505-7D77-4C3A-ABFD-54088774DAA7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -205,6 +207,10 @@ Global
 		{F80F837E-D2FC-4FFC-B68F-3CF0EC015F66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F80F837E-D2FC-4FFC-B68F-3CF0EC015F66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F80F837E-D2FC-4FFC-B68F-3CF0EC015F66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5BE7F505-7D77-4C3A-ABFD-54088774DAA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BE7F505-7D77-4C3A-ABFD-54088774DAA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BE7F505-7D77-4C3A-ABFD-54088774DAA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BE7F505-7D77-4C3A-ABFD-54088774DAA7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -242,6 +248,7 @@ Global
 		{2AED1542-A8ED-488D-B6D0-E16AB5D6EF6C} = {DD020B34-460F-455F-8D17-CF4A949F100B}
 		{E8212911-344B-4638-ADC3-B215BCDCAFD1} = {DD020B34-460F-455F-8D17-CF4A949F100B}
 		{F80F837E-D2FC-4FFC-B68F-3CF0EC015F66} = {A7F41094-8648-446B-AECD-DCC2CC871F73}
+		{5BE7F505-7D77-4C3A-ABFD-54088774DAA7} = {DD020B34-460F-455F-8D17-CF4A949F100B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {65220BF2-EAE1-4CB2-AA58-EBE80768CB40}

--- a/src/Dapr.Actors/Runtime/ActorManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorManager.cs
@@ -114,22 +114,14 @@ namespace Dapr.Actors.Runtime
             {
                 IActorResponseMessageBody responseMsgBody = null;
 
-                try
-                {
-                    responseMsgBody = (IActorResponseMessageBody)await methodDispatcher.DispatchAsync(
-                        actor,
-                        actorMessageHeader.MethodId,
-                        actorMessageBody,
-                        this.messageBodyFactory,
-                        ct);
+                responseMsgBody = (IActorResponseMessageBody)await methodDispatcher.DispatchAsync(
+                    actor,
+                    actorMessageHeader.MethodId,
+                    actorMessageBody,
+                    this.messageBodyFactory,
+                    ct);
 
-                    return this.CreateResponseMessage(responseMsgBody, interfaceId);
-                }
-                catch (Exception exception)
-                {
-                    // return exception response message
-                    return this.CreateExceptionResponseMessage(exception);
-                }
+                return this.CreateResponseMessage(responseMsgBody, interfaceId);
             }
 
             return await this.DispatchInternalAsync(actorId, actorMethodContext, RequestFunc, cancellationToken);
@@ -390,18 +382,6 @@ namespace Dapr.Actors.Runtime
             }
 
             return new Tuple<string, byte[]>(string.Empty, responseMsgBodyBytes);
-        }
-
-        private Tuple<string, byte[]> CreateExceptionResponseMessage(Exception ex)
-        {
-            var responseHeader = new ActorResponseMessageHeader();
-            responseHeader.AddHeader("HasRemoteException", Array.Empty<byte>());
-            var responseHeaderBytes = this.serializersManager.GetHeaderSerializer().SerializeResponseHeader(responseHeader);
-            var serializedHeader = Encoding.UTF8.GetString(responseHeaderBytes, 0, responseHeaderBytes.Length);
-
-            var responseMsgBody = ActorInvokeException.FromException(ex);
-            
-            return new Tuple<string, byte[]>(serializedHeader, responseMsgBody);
         }
     }
 }

--- a/test/Dapr.E2E.Test.Actors/RegressionActor/IRegression762Actor.cs
+++ b/test/Dapr.E2E.Test.Actors/RegressionActor/IRegression762Actor.cs
@@ -1,0 +1,32 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Dapr.Actors;
+
+/// <summary>
+/// This actor is being used to test the specific regression found in:
+///
+/// https://github.com/dapr/dotnet-sdk/issues/762
+/// </summary>
+namespace Dapr.E2E.Test.Actors.ErrorTesting
+{
+    public interface IRegression762Actor : IPingActor, IActor
+    {
+        Task<string> GetState(string id);
+
+        Task SaveState(StateCall call);
+
+        Task RemoveState(string id);
+    }
+}

--- a/test/Dapr.E2E.Test.Actors/RegressionActor/StateCall.cs
+++ b/test/Dapr.E2E.Test.Actors/RegressionActor/StateCall.cs
@@ -1,0 +1,22 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+namespace Dapr.E2E.Test.Actors.ErrorTesting
+{
+    public class StateCall
+    {
+        public string Key { get; set; }
+        public string Value { get; set; }
+        public string Operation { get; set; }
+    }
+}

--- a/test/Dapr.E2E.Test.App.ReentrantActor/Actors/ReentrantActor.cs
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/Actors/ReentrantActor.cs
@@ -11,7 +11,6 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dapr.Actors.Runtime;
 

--- a/test/Dapr.E2E.Test.App.ReentrantActor/Dapr.E2E.Test.App.ReentrantActors.csproj
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/Dapr.E2E.Test.App.ReentrantActors.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Dapr.E2E.Test.App.ReentrantActor' " />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\Dapr.Actors.AspNetCore\Dapr.Actors.AspNetCore.csproj" />
+    <ProjectReference Include="..\Dapr.E2E.Test.Actors\Dapr.E2E.Test.Actors.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Dapr.E2E.Test.App.ReentrantActor/Program.cs
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/Program.cs
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Dapr.E2E.Test.App.ReentrantActors
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/test/Dapr.E2E.Test.App.ReentrantActor/Startup.cs
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/Startup.cs
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Dapr.E2E.Test.Actors.Reentrancy;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Dapr.E2E.Test.App.ReentrantActors
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddActors(options =>
+            {
+                options.Actors.RegisterActor<ReentrantActor>();
+                options.ReentrancyConfig = new() { Enabled = true };
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapActorsHandlers();
+            });
+        }
+    }
+}

--- a/test/Dapr.E2E.Test.App.ReentrantActor/appsettings.Development.json
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/test/Dapr.E2E.Test.App.ReentrantActor/appsettings.json
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/test/Dapr.E2E.Test.App/Actors/Regression762Actor.cs
+++ b/test/Dapr.E2E.Test.App/Actors/Regression762Actor.cs
@@ -1,0 +1,65 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Dapr.Actors.Runtime;
+using Dapr.E2E.Test.Actors.ErrorTesting;
+
+namespace Dapr.E2E.Test.App.ErrorTesting
+{
+    public class Regression762Actor : Actor, IRegression762Actor
+    {
+        public Regression762Actor(ActorHost host) : base(host)
+        {
+        }
+
+        public Task Ping()
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task<string> GetState(string id)
+        {
+            var data = await this.StateManager.TryGetStateAsync<string>(id);
+
+            if (data.HasValue)
+            {
+                return data.Value;
+            }
+            return string.Empty;
+        }        
+
+        public async Task RemoveState(string id)
+        {
+            await this.StateManager.TryRemoveStateAsync(id);
+        }
+
+        public async Task SaveState(StateCall call)
+        {
+            if (call.Operation == "ThrowException")
+            {
+                await this.StateManager.SetStateAsync<string>(call.Key, call.Value);
+                throw new NotImplementedException();
+            }
+            else if (call.Operation == "SetState")
+            {
+                await this.StateManager.SetStateAsync<string>(call.Key, call.Value);
+            }
+            else if (call.Operation == "SaveState")
+            {
+                await this.StateManager.SaveStateAsync();
+            }
+        }
+    }
+}

--- a/test/Dapr.E2E.Test.App/Startup.cs
+++ b/test/Dapr.E2E.Test.App/Startup.cs
@@ -16,6 +16,7 @@ namespace Dapr.E2E.Test
     using Dapr.E2E.Test.Actors.Reentrancy;
     using Dapr.E2E.Test.Actors.Reminders;
     using Dapr.E2E.Test.Actors.Timers;
+    using Dapr.E2E.Test.App.ErrorTesting;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
@@ -52,8 +53,7 @@ namespace Dapr.E2E.Test
             {
                 options.Actors.RegisterActor<ReminderActor>();
                 options.Actors.RegisterActor<TimerActor>();
-                options.Actors.RegisterActor<ReentrantActor>();
-                options.ReentrancyConfig.Enabled = true;
+                options.Actors.RegisterActor<Regression762Actor>();
             });
         }
 

--- a/test/Dapr.E2E.Test/ActorRuntimeChecker.cs
+++ b/test/Dapr.E2E.Test/ActorRuntimeChecker.cs
@@ -1,0 +1,44 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.E2E.Test.Actors;
+using Xunit.Abstractions;
+
+namespace Dapr.E2E.Test
+{
+    public static class ActorRuntimeChecker
+    {
+        public static async Task WaitForActorRuntimeAsync(string appId, ITestOutputHelper output, IPingActor proxy, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                output.WriteLine($"Waiting for actor to be ready in: {appId}");
+                cancellationToken.ThrowIfCancellationRequested();
+
+                try
+                {
+                    await proxy.Ping();
+                    output.WriteLine($"Found actor in: {appId}");
+                    break;
+                }
+                catch (DaprApiException)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(250));
+                }
+            }
+        }
+    }
+}

--- a/test/Dapr.E2E.Test/Actors/E2ETests.Regression762Tests.cs
+++ b/test/Dapr.E2E.Test/Actors/E2ETests.Regression762Tests.cs
@@ -1,0 +1,116 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Actors;
+using Dapr.E2E.Test.Actors.ErrorTesting;
+using Xunit;
+
+namespace Dapr.E2E.Test
+{
+    public partial class E2ETests : IAsyncLifetime
+    {
+        [Fact]
+        public async Task ActorSuccessfullyClearsStateAfterErrorWithRemoting()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var proxy = this.ProxyFactory.CreateActorProxy<IRegression762Actor>(ActorId.CreateRandom(), "Regression762Actor");
+
+            await WaitForActorRuntimeAsync(proxy, cts.Token);
+
+            var key = Guid.NewGuid().ToString();
+            var throwingCall = new StateCall
+            {
+                Key = key,
+                Value = "Throw value",
+                Operation = "ThrowException"
+            };
+
+            var setCall = new StateCall()
+            {
+                Key = key,
+                Value = "Real value",
+                Operation = "SetState"
+            };
+
+            var savingCall = new StateCall()
+            {
+                Operation = "SaveState"
+            };
+
+            // We attempt to delete it on the unlikely chance it's already there.
+            await proxy.RemoveState(throwingCall.Key);
+
+            // Initiate a call that will set the state, then throw.
+            await Assert.ThrowsAsync<ActorMethodInvocationException>(async () => await proxy.SaveState(throwingCall));
+
+            // Save the state and assert that the old value was not persisted.
+            await proxy.SaveState(savingCall);
+            var errorResp = await proxy.GetState(key);
+            Assert.Equal(string.Empty, errorResp);
+
+            // Persist normally and ensure it works.
+            await proxy.SaveState(setCall);
+            var resp = await proxy.GetState(key);
+            Assert.Equal("Real value", resp);
+        }
+
+        [Fact]
+        public async Task ActorSuccessfullyClearsStateAfterErrorWithoutRemoting()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var pingProxy = this.ProxyFactory.CreateActorProxy<IRegression762Actor>(ActorId.CreateRandom(), "Regression762Actor");
+            var proxy = this.ProxyFactory.Create(ActorId.CreateRandom(), "Regression762Actor");
+
+            await WaitForActorRuntimeAsync(pingProxy, cts.Token);
+
+            var key = Guid.NewGuid().ToString();
+            var throwingCall = new StateCall
+            {
+                Key = key,
+                Value = "Throw value",
+                Operation = "ThrowException"
+            };
+
+            var setCall = new StateCall()
+            {
+                Key = key,
+                Value = "Real value",
+                Operation = "SetState"
+            };
+
+            var savingCall = new StateCall()
+            {
+                Operation = "SaveState"
+            };
+
+            // We attempt to delete it on the unlikely chance it's already there.
+            await proxy.InvokeMethodAsync("RemoveState", throwingCall.Key);
+
+            // Initiate a call that will set the state, then throw.
+            await Assert.ThrowsAsync<DaprApiException>(async () => await proxy.InvokeMethodAsync("SaveState", throwingCall));
+                
+            // Save the state and assert that the old value was not persisted.
+            await proxy.InvokeMethodAsync("SaveState", savingCall);
+            var errorResp = await proxy.InvokeMethodAsync<string, string>("GetState", key);
+            Assert.Equal(string.Empty, errorResp);
+
+            // Persist normally and ensure it works.
+            await proxy.InvokeMethodAsync("SaveState", setCall);
+            var resp = await proxy.InvokeMethodAsync<string, string>("GetState", key);
+            Assert.Equal("Real value", resp);
+        }
+    }
+}

--- a/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
+++ b/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\Dapr.E2E.Test.Actors\Dapr.E2E.Test.Actors.csproj" />
     <!-- This is here to force a rebuild when we run the tests. The tests assume this project has already been built. -->
     <ProjectReference Include="..\Dapr.E2E.Test.App\Dapr.E2E.Test.App.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Dapr.E2E.Test.App.ReentrantActor\Dapr.E2E.Test.App.ReentrantActors.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Dapr.E2E.Test.App.Grpc\Dapr.E2E.Test.App.Grpc.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Dapr.E2E.Test/DaprTestAppLifecycle.cs
+++ b/test/Dapr.E2E.Test/DaprTestAppLifecycle.cs
@@ -41,6 +41,8 @@ namespace Dapr.E2E.Test
 
         public string GrpcEndpoint => this.state?.GrpcEndpoint;
 
+        public ITestOutputHelper Output => this.output;
+
         public async Task InitializeAsync()
         {
             this.state = await this.fixture.StartAsync(this.output, this.Configuration);

--- a/test/Dapr.E2E.Test/E2ETests.cs
+++ b/test/Dapr.E2E.Test/E2ETests.cs
@@ -91,22 +91,7 @@ namespace Dapr.E2E.Test
 
         protected async Task WaitForActorRuntimeAsync(IPingActor proxy, CancellationToken cancellationToken)
         {
-            while (true)
-            {
-                this.Output.WriteLine($"Waiting for actor to be ready in: {this.AppId}");
-                cancellationToken.ThrowIfCancellationRequested();
-
-                try
-                {
-                    await proxy.Ping();
-                    this.Output.WriteLine($"Found actor in: {this.AppId}");
-                    break;
-                }
-                catch (DaprApiException)
-                {
-                    await Task.Delay(TimeSpan.FromMilliseconds(250));
-                }
-            }
+            await ActorRuntimeChecker.WaitForActorRuntimeAsync(this.AppId, this.Output, proxy, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
# Description

When an actor call fails, it is imperative that the state is reset.
In the remoting path, we were catching the exception and returning
an error response instead of propagating the exception. Without this,
the error path was never triggered. This allowed for state from
failed requests to persist on subsequent requests.

https://github.com/dapr/dotnet-sdk/issues/762

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #762

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
