### PR TITLE
Changed application port number for actors example

### DIFF
--- a/examples/Actor/DemoActor/Properties/launchSettings.json
+++ b/examples/Actor/DemoActor/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://127.0.0.1:5000/",
+      "applicationUrl": "http://127.0.0.1:5010/",
       "sslPort": 0
     }
   },
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000/"
+      "applicationUrl": "http://localhost:5010/"
     }
   }
 }

--- a/examples/Actor/README.md
+++ b/examples/Actor/README.md
@@ -25,7 +25,7 @@ To run the actor service locally run this command in `DemoActor` directory:
  dapr run --dapr-http-port 3500 --app-id demo_actor --app-port 5010 dotnet run
 ```
 
-The `DemoActor` service will listen on port `5000` for HTTP.
+The `DemoActor` service will listen on port `5010` for HTTP.
 
 ### Make client calls
 

--- a/examples/Actor/README.md
+++ b/examples/Actor/README.md
@@ -22,7 +22,7 @@ The Actor example shows how to create a virtual actor (`DemoActor`) and invoke i
 To run the actor service locally run this command in `DemoActor` directory:
 
 ```sh
- dapr run --dapr-http-port 3500 --app-id demo_actor --app-port 5000 dotnet run
+ dapr run --dapr-http-port 3500 --app-id demo_actor --app-port 5010 dotnet run
 ```
 
 The `DemoActor` service will listen on port `5000` for HTTP.


### PR DESCRIPTION
# Description

The actors example was failing due to the port number. Therefore, the application port number is modified for actors examples both in the code as well as the readme file to make the examples run successfully.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
