### PR TITLE
Fix missing assignment

### DIFF
--- a/src/Dapr.Actors/Runtime/ActorHost.cs
+++ b/src/Dapr.Actors/Runtime/ActorHost.cs
@@ -100,6 +100,7 @@ namespace Dapr.Actors.Runtime
         {
             this.ActorTypeInfo = actorTypeInfo;
             this.Id = id;
+            this.JsonSerializerOptions = jsonSerializerOptions;
             this.LoggerFactory = loggerFactory;
             this.ProxyFactory = proxyFactory;
             this.TimerManager = timerManager;

--- a/test/Dapr.Actors.AspNetCore.Test/Runtime/DependencyInjectionActorActivatorTests.cs
+++ b/test/Dapr.Actors.AspNetCore.Test/Runtime/DependencyInjectionActorActivatorTests.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,6 +63,18 @@ namespace Dapr.Actors.Runtime
 
             Assert.Same(actor1.SingletonService, actor2.SingletonService);
             Assert.NotSame(actor1.ScopedService, actor2.ScopedService);
+        }
+
+        [Fact]
+        public async Task CreateAsync_CustomJsonOptions()
+        {
+            var jsonOptions = new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = false };
+            var activator = CreateActivator(typeof(TestActor));
+
+            var host = ActorHost.CreateForTest<TestActor>(new ActorTestOptions { JsonSerializerOptions = jsonOptions });
+            var state = await activator.CreateAsync(host);
+
+            Assert.Same(jsonOptions, state.Actor.Host.JsonSerializerOptions);
         }
 
         [Fact]


### PR DESCRIPTION
# Description

The property "JsonSerializerOptions" in the class "ActorHost" is always null due to missing assignment in the constructor.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #814

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
