### PR TITLE
Include .NET 5 in all builds and check test status

### DIFF
--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -23,16 +23,19 @@ jobs:
         include:
         - dotnet-version: '3.1'
           install-3: true
+          install-5: false
           display-name: '.NET Core 3.1'
           framework: 'netcoreapp3.1'
           prefix: 'netcoreapp31'
         - dotnet-version: '5.0'
           install-3: false
+          install-5: true
           display-name: '.NET 5.0'
           framework: 'net5'
           prefix: 'net5'
         - dotnet-version: '6.0'
           install-3: false
+          install-5: false
           display-name: '.NET 6.0'
           framework: 'net6'
           prefix: 'net6'
@@ -112,7 +115,12 @@ jobs:
         if: matrix.install-3
         with:
           dotnet-version: 3.1.x
-      - name: Setup .NET 6.0
+      - name: Setup .NET 5.0
+        uses: actions/setup-dotnet@v1
+        if: matrix.install-5
+        with:
+          dotnet-version: 5.0.x
+      - name: Setup .NET 6.0 # We always need 6.0 to build.
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 6.0.x
@@ -120,6 +128,7 @@ jobs:
         # disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
         run: dotnet build --configuration release /p:GITHUB_ACTIONS=false
       - name: Run Test
+        id: tests
         continue-on-error: true # proceed if tests fail, the report step will report the failure with more details.
         run: |
           dotnet test ${{ github.workspace }}/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj \
@@ -133,6 +142,9 @@ jobs:
             /p:CollectCoverage=true \
             /p:CoverletOutputFormat=opencover \
             /p:GITHUB_ACTIONS=false
+      - name: Check test failure in PR
+        if: github.event_name == 'pull_request' && steps.tests.outcome != 'success'
+        run: exit 1
       - name: Upload test coverage
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -46,16 +46,19 @@ jobs:
         include:
         - dotnet-version: '3.1'
           install-3: true
+          install-5: false
           display-name: '.NET Core 3.1'
           framework: 'netcoreapp3.1'
           prefix: 'netcoreapp31'
         - dotnet-version: '5.0'
           install-3: false
+          install-5: true
           display-name: '.NET 5.0'
           framework: 'net5'
           prefix: 'net5'
         - dotnet-version: '6.0'
           install-3: false
+          install-5: false
           display-name: '.NET 6.0'
           framework: 'net6'
           prefix: 'net6'
@@ -68,7 +71,12 @@ jobs:
       if: matrix.install-3
       with:
         dotnet-version: 3.1.x
-    - name: Setup .NET 6.0
+    - name: Setup .NET 5.0
+      uses: actions/setup-dotnet@v1
+      if: matrix.install-5
+      with:
+        dotnet-version: 5.0.x
+    - name: Setup .NET 6.0 # We always need 6.0 to build.
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
@@ -76,7 +84,8 @@ jobs:
       # disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
       run: dotnet build --configuration release /p:GITHUB_ACTIONS=false
     - name: Test
-      continue-on-error: true # proceed if tests fail, the report step will report the failure with more details.
+      id: tests
+      continue-on-error: true # proceed if tests fail to allow for the report generation in master or next step failure in PR
       run: |
         dotnet test \
           --configuration release \
@@ -90,6 +99,9 @@ jobs:
           /p:CollectCoverage=true \
           /p:CoverletOutputFormat=opencover \
           /p:GITHUB_ACTIONS=false
+    - name: Check test failure in PR
+      if: github.event_name == 'pull_request' && steps.tests.outcome != 'success'
+      run: exit 1
     - name: Upload test coverage
       uses: codecov/codecov-action@v1
       with:

--- a/test/Dapr.E2E.Test/DaprTestApp.cs
+++ b/test/Dapr.E2E.Test/DaprTestApp.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -124,7 +124,18 @@ namespace Dapr.E2E.Test
         {
             var targetFrameworkName = ((TargetFrameworkAttribute)Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(TargetFrameworkAttribute), false).FirstOrDefault()).FrameworkName;
             string frameworkMoniker;
-            frameworkMoniker = targetFrameworkName == ".NETCoreApp,Version=v3.1" ? "netcoreapp3.1" : "net5";
+            if (targetFrameworkName == ".NETCoreApp,Version=v3.1")
+            {
+                frameworkMoniker = "netcoreapp3.1";
+            }
+            else if (targetFrameworkName == ".NETCoreApp,Version=v5.0")
+            {
+                frameworkMoniker = "net5";
+            }
+            else
+            {
+                frameworkMoniker = "net6";
+            }
             return frameworkMoniker;
         }
 


### PR DESCRIPTION
# Description
Include .NET 5 in all builds and check test status. The tests were only showing as failed in `master` as the report step doesn't actually run in PRs.

Signed-off-by: Hal Spang <halspang@microsoft.com>

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
