### PR TITLE
Fix App API token authentication

### DIFF
--- a/src/Dapr.Actors/Client/ActorProxyOptions.cs
+++ b/src/Dapr.Actors/Client/ActorProxyOptions.cs
@@ -45,7 +45,7 @@ namespace Dapr.Actors.Client
         /// <summary>
         /// The Dapr Api Token that is added to the header for all requests.
         /// </summary>
-        public string DaprApiToken { get; set; } = DaprDefaults.GetDefaultApiToken();
+        public string DaprApiToken { get; set; } = DaprDefaults.GetDefaultDaprApiToken();
 
         /// <summary>
         /// Gets or sets the HTTP endpoint URI used to communicate with the Dapr sidecar.

--- a/src/Dapr.Actors/Runtime/ActorRuntimeOptions.cs
+++ b/src/Dapr.Actors/Runtime/ActorRuntimeOptions.cs
@@ -33,7 +33,7 @@ namespace Dapr.Actors.Runtime
             Enabled = false,
         };
         private JsonSerializerOptions jsonSerializerOptions = JsonSerializerDefaults.Web;
-        private string daprApiToken = DaprDefaults.GetDefaultApiToken();
+        private string daprApiToken = DaprDefaults.GetDefaultDaprApiToken();
         private int? remindersStoragePartitions = null;
 
         /// <summary>

--- a/src/Dapr.AspNetCore/DaprAuthenticationBuilderExtensions.cs
+++ b/src/Dapr.AspNetCore/DaprAuthenticationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,22 +23,22 @@ namespace Microsoft.AspNetCore.Authentication
     public static class DaprAuthenticationBuilderExtensions
     {
         /// <summary>
-        /// Adds Dapr API token authentication.
-        /// See https://docs.dapr.io/operations/security/api-token/ for more information about API token authentication in Dapr.
-        /// By default, the token will be read from the DAPR_API_TOKEN environment variable.
+        /// Adds Dapr App API token authentication.
+        /// See https://docs.dapr.io/operations/security/app-api-token/ for more information about App API token authentication in Dapr.
+        /// By default, the token will be read from the APP_API_TOKEN environment variable.
         /// </summary>
         /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>
         /// <returns>A reference to <paramref name="builder"/> after the operation has completed.</returns>
         public static AuthenticationBuilder AddDapr(this AuthenticationBuilder builder) => builder.AddDapr(configureOptions: null);
 
         /// <summary>
-        /// Adds Dapr API token authentication.
-        /// See https://docs.dapr.io/operations/security/api-token/ for more information about API token authentication in Dapr.
+        /// Adds Dapr App API token authentication.
+        /// See https://docs.dapr.io/operations/security/app-api-token/ for more information about App API token authentication in Dapr.
         /// </summary>
         /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>
         /// <param name="configureOptions">
         /// A delegate that allows configuring <see cref="DaprAuthenticationOptions"/>.
-        /// By default, the token will be read from the DAPR_API_TOKEN environment variable.
+        /// By default, the token will be read from the APP_API_TOKEN environment variable.
         /// </param>
         /// <returns>A reference to <paramref name="builder"/> after the operation has completed.</returns>
         public static AuthenticationBuilder AddDapr(this AuthenticationBuilder builder, Action<DaprAuthenticationOptions> configureOptions)

--- a/src/Dapr.AspNetCore/DaprAuthenticationBuilderExtensions.cs
+++ b/src/Dapr.AspNetCore/DaprAuthenticationBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Authentication
     public static class DaprAuthenticationBuilderExtensions
     {
         /// <summary>
-        /// Adds Dapr App API token authentication.
+        /// Adds App API token authentication.
         /// See https://docs.dapr.io/operations/security/app-api-token/ for more information about App API token authentication in Dapr.
         /// By default, the token will be read from the APP_API_TOKEN environment variable.
         /// </summary>
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Authentication
         public static AuthenticationBuilder AddDapr(this AuthenticationBuilder builder) => builder.AddDapr(configureOptions: null);
 
         /// <summary>
-        /// Adds Dapr App API token authentication.
+        /// Adds App API token authentication.
         /// See https://docs.dapr.io/operations/security/app-api-token/ for more information about App API token authentication in Dapr.
         /// </summary>
         /// <param name="builder">The <see cref="AuthenticationBuilder"/>.</param>

--- a/src/Dapr.AspNetCore/DaprAuthenticationHandler.cs
+++ b/src/Dapr.AspNetCore/DaprAuthenticationHandler.cs
@@ -48,7 +48,7 @@ namespace Dapr.AspNetCore
             var expectedToken = Options.Token;
             if (string.IsNullOrWhiteSpace(expectedToken))
             {
-                return AuthenticateResult.Fail("Dapr App API Token not configured.");
+                return AuthenticateResult.Fail("App API Token not configured.");
             }
 
             if (!string.Equals(token, expectedToken))

--- a/src/Dapr.AspNetCore/DaprAuthenticationHandler.cs
+++ b/src/Dapr.AspNetCore/DaprAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ namespace Dapr.AspNetCore
         public DaprAuthenticationHandler(
             IOptionsMonitor<DaprAuthenticationOptions> options,
             ILoggerFactory logger,
-            UrlEncoder encoder, 
+            UrlEncoder encoder,
             ISystemClock clock) : base(options, logger, encoder, clock)
         {
         }
@@ -48,7 +48,7 @@ namespace Dapr.AspNetCore
             var expectedToken = Options.Token;
             if (string.IsNullOrWhiteSpace(expectedToken))
             {
-                return AuthenticateResult.Fail("Dapr API Token not configured.");
+                return AuthenticateResult.Fail("Dapr App API Token not configured.");
             }
 
             if (!string.Equals(token, expectedToken))

--- a/src/Dapr.AspNetCore/DaprAuthenticationOptions.cs
+++ b/src/Dapr.AspNetCore/DaprAuthenticationOptions.cs
@@ -26,7 +26,7 @@ namespace Dapr.AspNetCore
         internal string Scheme { get; } = DefaultScheme;
 
         /// <summary>
-        /// Gets or sets the Dapr App API token.
+        /// Gets or sets the App API token.
         /// By default, the token will be read from the APP_API_TOKEN environment variable.
         /// </summary>
         public string Token { get; set; } = DaprDefaults.GetDefaultAppApiToken();

--- a/src/Dapr.AspNetCore/DaprAuthenticationOptions.cs
+++ b/src/Dapr.AspNetCore/DaprAuthenticationOptions.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ namespace Dapr.AspNetCore
 {
     /// <summary>
     /// Options class provides information needed to control Dapr Authentication handler behavior.
-    /// See https://docs.dapr.io/operations/security/api-token/ for more information about API token authentication in Dapr.
+    /// See https://docs.dapr.io/operations/security/app-api-token/ for more information about App API token authentication in Dapr.
     /// </summary>
     public class DaprAuthenticationOptions : AuthenticationSchemeOptions
     {
@@ -26,9 +26,9 @@ namespace Dapr.AspNetCore
         internal string Scheme { get; } = DefaultScheme;
 
         /// <summary>
-        /// Gets or sets the Dapr API token.
-        /// By default, the token will be read from the DAPR_API_TOKEN environment variable.
+        /// Gets or sets the Dapr App API token.
+        /// By default, the token will be read from the APP_API_TOKEN environment variable.
         /// </summary>
-        public string Token { get; set; } = DaprDefaults.GetDefaultApiToken();
+        public string Token { get; set; } = DaprDefaults.GetDefaultAppApiToken();
     }
 }

--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -121,7 +121,7 @@ namespace Dapr.Client
         /// Optional gRPC endpoint for calling Dapr, defaults to <see cref="DaprDefaults.GetDefaultGrpcEndpoint"/>.
         /// </param>
         /// <param name="daprApiToken">
-        /// Optional token to be attached to all requests, defaults to <see cref="DaprDefaults.GetDefaultApiToken"/>.
+        /// Optional token to be attached to all requests, defaults to <see cref="DaprDefaults.GetDefaultDaprApiToken"/>.
         /// </param>
         /// <returns>An <see cref="CallInvoker"/> to be used for proxied gRPC calls through Dapr.</returns>
         /// <remarks>
@@ -133,7 +133,7 @@ namespace Dapr.Client
         public static CallInvoker CreateInvocationInvoker(string appId, string daprEndpoint = null, string daprApiToken = null)
         {
             var channel = GrpcChannel.ForAddress(daprEndpoint ?? DaprDefaults.GetDefaultGrpcEndpoint());
-            return channel.Intercept(new InvocationInterceptor(appId, daprApiToken ?? DaprDefaults.GetDefaultApiToken()));
+            return channel.Intercept(new InvocationInterceptor(appId, daprApiToken ?? DaprDefaults.GetDefaultDaprApiToken()));
         }
 
         internal static KeyValuePair<string, string>? GetDaprApiTokenHeader(string apiToken)

--- a/src/Dapr.Client/DaprClientBuilder.cs
+++ b/src/Dapr.Client/DaprClientBuilder.cs
@@ -40,7 +40,7 @@ namespace Dapr.Client
             };
 
             this.JsonSerializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-            this.DaprApiToken = DaprDefaults.GetDefaultApiToken();
+            this.DaprApiToken = DaprDefaults.GetDefaultDaprApiToken();
         }
 
         // property exposed for testing purposes

--- a/src/Dapr.Client/InvocationHandler.cs
+++ b/src/Dapr.Client/InvocationHandler.cs
@@ -51,7 +51,7 @@ namespace Dapr.Client
         public InvocationHandler()
         {
             this.parsedEndpoint = new Uri(DaprDefaults.GetDefaultHttpEndpoint(), UriKind.Absolute);
-            this.apiToken = DaprDefaults.GetDefaultApiToken();
+            this.apiToken = DaprDefaults.GetDefaultDaprApiToken();
         }
 
         /// <summary>

--- a/src/Shared/DaprDefaults.cs
+++ b/src/Shared/DaprDefaults.cs
@@ -19,24 +19,32 @@ namespace Dapr
     {
         private static string httpEndpoint;
         private static string grpcEndpoint;
-        private static string apiToken;
+        private static string daprApiToken;
         private static string appApiToken;
 
-        public static string GetDefaultApiToken()
+        /// <summary>
+        /// Get the value of environment variable DAPR_API_TOKEN
+        /// </summary>
+        /// <returns>The value of environment variable DAPR_API_TOKEN</returns>
+        public static string GetDefaultDaprApiToken()
         {
             // Lazy-init is safe because this is just populating the default
             // We don't plan to support the case where the user changes environment variables
             // for a running process.
-            if (apiToken == null)
+            if (daprApiToken == null)
             {
                 // Treat empty the same as null since it's an environment variable
                 var value = Environment.GetEnvironmentVariable("DAPR_API_TOKEN");
-                apiToken = (value == string.Empty) ? null : value;
+                daprApiToken = (value == string.Empty) ? null : value;
             }
 
-            return apiToken;
+            return daprApiToken;
         }
 
+        /// <summary>
+        /// Get the value of environment variable APP_API_TOKEN
+        /// </summary>
+        /// <returns>The value of environment variable APP_API_TOKEN</returns>
         public static string GetDefaultAppApiToken()
         {
             if (appApiToken == null)
@@ -48,6 +56,10 @@ namespace Dapr
             return appApiToken;
         }
 
+        /// <summary>
+        /// Get the value of environment variable DAPR_HTTP_PORT
+        /// </summary>
+        /// <returns>The value of environment variable DAPR_HTTP_PORT</returns>
         public static string GetDefaultHttpEndpoint()
         {
             if (httpEndpoint == null)
@@ -60,6 +72,10 @@ namespace Dapr
             return httpEndpoint;
         }
 
+        /// <summary>
+        /// Get the value of environment variable DAPR_GRPC_PORT
+        /// </summary>
+        /// <returns>The value of environment variable DAPR_GRPC_PORT</returns>
         public static string GetDefaultGrpcEndpoint()
         {
             if (grpcEndpoint == null)

--- a/src/Shared/DaprDefaults.cs
+++ b/src/Shared/DaprDefaults.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ namespace Dapr
         private static string httpEndpoint;
         private static string grpcEndpoint;
         private static string apiToken;
+        private static string appApiToken;
 
         public static string GetDefaultApiToken()
         {
@@ -34,8 +35,17 @@ namespace Dapr
             }
 
             return apiToken;
+        }
 
-            
+        public static string GetDefaultAppApiToken()
+        {
+            if (appApiToken == null)
+            {
+                var value = Environment.GetEnvironmentVariable("APP_API_TOKEN");
+                appApiToken = (value == string.Empty) ? null : value;
+            }
+
+            return appApiToken;
         }
 
         public static string GetDefaultHttpEndpoint()

--- a/test/Dapr.E2E.Test.App/Controllers/TestController.cs
+++ b/test/Dapr.E2E.Test.App/Controllers/TestController.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ namespace Dapr.E2E.Test
     using System.Threading.Tasks;
     using Dapr;
     using Dapr.Client;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
 
@@ -42,8 +43,20 @@ namespace Dapr.E2E.Test
         /// </summary>
         /// <param name="transaction">Transaction to process.</param>
         /// <returns>Account</returns>
-       [HttpPost("accountDetails")]
+        [HttpPost("accountDetails")]
         public ActionResult<Account> AccountDetails(Transaction transaction)
+        {
+            var account = new Account()
+            {
+                Id = transaction.Id,
+                Balance = transaction.Amount + 100
+            };
+            return account;
+        }
+
+        [Authorize("Dapr")]
+        [HttpPost("accountDetails-requires-api-token")]
+        public ActionResult<Account> AccountDetailsRequiresApiToken(Transaction transaction)
         {
             var account = new Account()
             {

--- a/test/Dapr.E2E.Test.App/Startup.cs
+++ b/test/Dapr.E2E.Test.App/Startup.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ namespace Dapr.E2E.Test
     using Dapr.E2E.Test.Actors.Reminders;
     using Dapr.E2E.Test.Actors.Timers;
     using Dapr.E2E.Test.App.ErrorTesting;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
@@ -48,6 +50,8 @@ namespace Dapr.E2E.Test
         /// <param name="services">Service Collection.</param>
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddAuthentication().AddDapr();
+            services.AddAuthorization(o => o.AddDapr());
             services.AddControllers().AddDapr();
             services.AddActors(options =>
             {
@@ -71,9 +75,11 @@ namespace Dapr.E2E.Test
 
             app.UseRouting();
 
-            app.UseCloudEvents();
+            app.UseAuthentication();
 
             app.UseAuthorization();
+
+            app.UseCloudEvents();
 
             app.UseEndpoints(endpoints =>
             {

--- a/test/Dapr.E2E.Test/DaprCommand.cs
+++ b/test/Dapr.E2E.Test/DaprCommand.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 namespace Dapr.E2E.Test
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using System.Threading;
@@ -31,6 +32,7 @@ namespace Dapr.E2E.Test
         private EventWaitHandle outputReceived = new EventWaitHandle(false, EventResetMode.ManualReset);
         public string DaprBinaryName { get; set; }
         public string Command { get; set; }
+        public Dictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
         public string[] OutputToMatch { get; set; }
         public TimeSpan Timeout { get; set; }
 
@@ -50,6 +52,10 @@ namespace Dapr.E2E.Test
                     CreateNoWindow = true,
                 }
             };
+            foreach (var (key, value) in EnvironmentVariables)
+            {
+                process.StartInfo.EnvironmentVariables.Add(key, value);
+            }
             process.OutputDataReceived += CheckOutput;
             process.ErrorDataReceived += CheckOutput;
 

--- a/test/Dapr.E2E.Test/DaprTestApp.cs
+++ b/test/Dapr.E2E.Test/DaprTestApp.cs
@@ -58,7 +58,7 @@ namespace Dapr.E2E.Test
                 "--components-path", componentsPath,
                 "--config", configPath,
                 "--log-level", "debug",
-                
+
             };
 
             if (configuration.UseAppPort)
@@ -68,7 +68,7 @@ namespace Dapr.E2E.Test
 
             if (!string.IsNullOrEmpty(configuration.AppProtocol))
             {
-                arguments.AddRange(new []{ "--app-protocol", configuration.AppProtocol });
+                arguments.AddRange(new[]{ "--app-protocol", configuration.AppProtocol });
             }
 
             arguments.AddRange(new[]
@@ -96,6 +96,10 @@ namespace Dapr.E2E.Test
                 Command = string.Join(" ", arguments),
                 OutputToMatch = outputToMatchOnStart,
                 Timeout = TimeSpan.FromSeconds(30),
+                EnvironmentVariables = new Dictionary<string, string>
+                {
+                    { "APP_API_TOKEN", "abcdefg" }
+                }
             };
 
             daprStart.Run();

--- a/test/Dapr.E2E.Test/ServiceInvocation/E2ETests.ServiceInvocationTests.cs
+++ b/test/Dapr.E2E.Test/ServiceInvocation/E2ETests.ServiceInvocationTests.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,25 @@ namespace Dapr.E2E.Test
             };
 
             var response = await client.PostAsJsonAsync<Transaction>("/accountDetails", transaction, cts.Token);
+            var (account, _) = await HttpAssert.AssertJsonResponseAsync<Account>(response);
+
+            Assert.Equal("1", account.Id);
+            Assert.Equal(150, account.Balance);
+        }
+
+        [Fact]
+        public async Task TestServiceInvocationRequiresApiToken()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+            using var client = DaprClient.CreateInvokeHttpClient(appId: this.AppId, daprEndpoint: this.HttpEndpoint);
+
+            var transaction = new Transaction()
+            {
+                Id = "1",
+                Amount = 50
+            };
+            var response = await client.PostAsJsonAsync<Transaction>("/accountDetails-requires-api-token", transaction, cts.Token);
             var (account, _) = await HttpAssert.AssertJsonResponseAsync<Account>(response);
 
             Assert.Equal("1", account.Id);


### PR DESCRIPTION
# Description

Fix App API Token support

docs: https://docs.dapr.io/operations/security/app-api-token/

According to the documentation, DaprAuthenticationOptions.Token should read the value of the APP_API_TOKEN environment variable, but currently it reads the value of the DAPR_API_TOKEN environment variable.

## Issue reference

#835

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
