### PR TITLE
Upgrade gRPC to the version 2.43.

### DIFF
--- a/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
+++ b/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
@@ -10,11 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.30.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.32.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.43.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.43.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.44.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Client/PublishSubscribe/PublishSubscribe.csproj
+++ b/examples/Client/PublishSubscribe/PublishSubscribe.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.5.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.44.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/examples/Client/ServiceInvocation/ServiceInvocation.csproj
+++ b/examples/Client/ServiceInvocation/ServiceInvocation.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.5.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.44.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/examples/Client/StateManagement/StateManagement.csproj
+++ b/examples/Client/StateManagement/StateManagement.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.5.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.44.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
+++ b/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
@@ -21,4 +21,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Dapr.Actors\Dapr.Actors.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+  </ItemGroup>
 </Project>

--- a/src/Dapr.Actors/Dapr.Actors.csproj
+++ b/src/Dapr.Actors/Dapr.Actors.csproj
@@ -22,5 +22,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+  </ItemGroup>
 
 </Project>

--- a/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
+++ b/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
@@ -29,4 +29,8 @@
     <ProjectReference Include="..\Dapr.Client\Dapr.Client.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Dapr.Client/Constants.cs
+++ b/src/Dapr.Client/Constants.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,14 @@ using System.Net.Mime;
 
 namespace Dapr.Client
 {
-    internal class Constants
+    internal static class Constants
     {
+#if NETSTANDARD2_0
+        public const string ContentTypeApplicationJson = "application/json";
+#else
         public const string ContentTypeApplicationJson = MediaTypeNames.Application.Json;
+#endif
+
         public const string ContentTypeApplicationGrpc = "application/grpc";
     }
 }

--- a/src/Dapr.Client/Dapr.Client.csproj
+++ b/src/Dapr.Client/Dapr.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+      <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,15 +20,19 @@
     <Description>This package contains the reference assemblies for developing services using Dapr.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.32.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.43.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.44.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.CommonProtos" Version="2.5.0" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Protos\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapr.Client/InvocationHandler.cs
+++ b/src/Dapr.Client/InvocationHandler.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -117,7 +117,11 @@ namespace Dapr.Client
         }
 
         // Internal for testing
+#if NETSTANDARD2_0
+        internal bool TryRewriteUri(Uri uri, out Uri? rewritten)
+#else
         internal bool TryRewriteUri(Uri uri, [NotNullWhen(true)] out Uri? rewritten)
+#endif        
         {
             // For now the only invalid cases are when the request URI is missing or just silly.
             // We may support additional cases for validation in the future (like an allow-list of App-Ids).

--- a/src/Dapr.Extensions.Configuration/Dapr.Extensions.Configuration.csproj
+++ b/src/Dapr.Extensions.Configuration/Dapr.Extensions.Configuration.csproj
@@ -22,4 +22,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Shared/ArgumentVerifier.cs
+++ b/src/Shared/ArgumentVerifier.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,12 @@ namespace Dapr
         /// </summary>
         /// <param name="value">Argument value to check.</param>
         /// <param name="name">Name of Argument.</param>
+#if NETSTANDARD2_0
+        public static void ThrowIfNull(object? value, string name)
+#else
         public static void ThrowIfNull([NotNull] object? value, string name)
+#endif
+
         {
             if (value == null)
             {
@@ -44,7 +49,11 @@ namespace Dapr
         /// </summary>
         /// <param name="value">Argument value to check.</param>
         /// <param name="name">Name of Argument.</param>
+#if NETSTANDARD2_0
+        public static void ThrowIfNullOrEmpty(string? value, string name)
+#else
         public static void ThrowIfNullOrEmpty([NotNull] string? value, string name)
+#endif
         {
             if (value == null)
             {

--- a/test/Dapr.Client.Test/Dapr.Client.Test.csproj
+++ b/test/Dapr.Client.Test/Dapr.Client.Test.csproj
@@ -9,13 +9,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Grpc.Core.Testing" Version="2.38.1" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.38.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Grpc.Core.Testing" Version="2.44.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.43.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.44.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="moq" Version="4.14.7" />
-    <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.123" />      
+    <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.152" />      
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />      
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Dapr.E2E.Test.App.Grpc/Dapr.E2E.Test.App.Grpc.csproj
+++ b/test/Dapr.E2E.Test.App.Grpc/Dapr.E2E.Test.App.Grpc.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.39.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.43.0" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="Proto/message.proto" />

--- a/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
+++ b/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
@@ -4,9 +4,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.32.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.32.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.43.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.44.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
Compatibility with netStandard 2.0 is possible.
Change Dapr.Client from .netCore3.1 to netStandard 2.0 and 2.1.
Allow Dapr.Client to be used with .NET 4.6.1 and greater!

# Description

The current version of Grp.Client was not compatible with netStandard 2.0. This limit the usage of DaprClient to .netCore3.1 and greater. But the latest version of gRPC.Client is able to run on netStandard2.0. Allowing Dapr.Client to run also on .NET 4.6.1 and greater. This is an added value to bring Dapr in combination with MAN Sidekick project.

The Dapr.Client now target frameworks netStandard2.0 and netStandard2.1.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

No new unit tests were needed and they pass with sucess.