### PR TITLE
Fix issue with event serialization

### DIFF
--- a/src/Dapr.Client/TypeConverters.cs
+++ b/src/Dapr.Client/TypeConverters.cs
@@ -31,7 +31,7 @@ namespace Dapr.Client
         /// <returns>The given data as JSON based byte string.</returns>
         public static ByteString ToJsonByteString<T>(T data, JsonSerializerOptions options)
         {
-            var bytes = JsonSerializer.SerializeToUtf8Bytes(data, options);
+            var bytes = JsonSerializer.SerializeToUtf8Bytes(data, data.GetType(), options);
             return ByteString.CopyFrom(bytes);
         }
 


### PR DESCRIPTION
# Description

This PR changes the serialization behavior so that when you're using a non-concrete type variable as input for the `PublishEventAsync` method, it will still be serialized as the concrete type it represents.

## Issue reference

#846

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
