### PR TITLE
Fix Adds DaprClient in Dapr.AspNetCore from AddSingleton to TryAddSingleton

### DIFF
--- a/src/Dapr.AspNetCore/DaprServiceCollectionExtensions.cs
+++ b/src/Dapr.AspNetCore/DaprServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using System;
     using System.Linq;
     using Dapr.Client;
+    using Extensions;
 
     /// <summary>
     /// Provides extension methods for <see cref="IServiceCollection" />.
@@ -44,7 +45,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddSingleton<DaprClientMarkerService>();
 
-            services.AddSingleton(_ =>
+            services.TryAddSingleton(_ =>
             {
                 var builder = new DaprClientBuilder();
                 if (configure != null)


### PR DESCRIPTION
…gleton

Signed-off-by: zhenlei520 <wangzhenlei520@gmail.com>

# Description

I hope that AddDaprClient can be changed to TryAddSingleton. Although the AddDaprClient method only adds DaprClient to the current class library once, if other class libraries also add DaprClient and then use Dapr.AspNetCore, DaprClient will be added again.