### PR TITLE
Modify the registration method of JsonSerializerOptions()

### DIFF
--- a/examples/AspNetCore/RoutingSample/Startup.cs
+++ b/examples/AspNetCore/RoutingSample/Startup.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,13 +59,13 @@ namespace RoutingSample
         /// <param name="services">Service Collection.</param>
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDaprClient();
-
-            services.AddSingleton(new JsonSerializerOptions()
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                PropertyNameCaseInsensitive = true,
-            });
+            services.AddDaprClient(builder =>
+              builder.UseJsonSerializationOptions(
+                  new JsonSerializerOptions()
+                  {
+                      PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                      PropertyNameCaseInsensitive = true,
+                  }));
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Modify the registration method of `JsonSerializerOptions()` through the [document](https://github.com/dapr/dotnet-sdk/tree/master/examples/AspNetCore/RoutingSample#code-samples) .

Update `services.AddSingleton(new JsonSerializerOptions())` to `services.AddDaprClient(..UseJsonSerializationOptions`

Signed-off-by: HueiFeng <695979933@qq.com>

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation