### PR TITLE
Support PubSub DeadLetterTopic in topic attribute

### DIFF
--- a/examples/AspNetCore/ControllerSample/CustomTopicAttribute.cs
+++ b/examples/AspNetCore/ControllerSample/CustomTopicAttribute.cs
@@ -35,6 +35,9 @@ namespace ControllerSample
         public string Name { get; }
 
         /// <inheritdoc/>
+        public string DeadLetterTopicName { get; }
+
+        /// <inheritdoc/>
         public new string Match { get; }
 
         /// <inheritdoc/>

--- a/src/Dapr.AspNetCore/DaprEndpointRouteBuilderExtensions.cs
+++ b/src/Dapr.AspNetCore/DaprEndpointRouteBuilderExtensions.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNetCore.Builder
                         var topicMetadata = e.Metadata.GetOrderedMetadata<ITopicMetadata>();
                         var originalTopicMetadata = e.Metadata.GetOrderedMetadata<IOriginalTopicMetadata>();
 
-                        var subs = new List<(string PubsubName, string Name, bool? EnableRawPayload, string Match, int Priority, Dictionary<string, string[]> OriginalTopicMetadata, string MetadataSeparator, RoutePattern RoutePattern)>();
+                        var subs = new List<(string PubsubName, string Name, bool? EnableRawPayload, string Match, int Priority, Dictionary<string, string[]> OriginalTopicMetadata, string MetadataSeparator, RoutePattern RoutePattern, string DeadLetterTopicName)>();
 
                         for (int i = 0; i < topicMetadata.Count(); i++)
                         {
@@ -85,7 +85,8 @@ namespace Microsoft.AspNetCore.Builder
                                                      .GroupBy(c => c.Name)
                                                      .ToDictionary(m => m.Key, m => m.Select(c => c.Value).Distinct().ToArray()),
                                 (topicMetadata[i] as IOwnedOriginalTopicMetadata)?.MetadataSeparator,
-                                e.RoutePattern));
+                                e.RoutePattern,
+                                topicMetadata[i].DeadLetterTopicName));
                         }
 
                         return subs;
@@ -131,6 +132,7 @@ namespace Microsoft.AspNetCore.Builder
                             Topic = first.Name,
                             PubsubName = first.PubsubName,
                             Metadata = metadata.Count > 0 ? metadata : null,
+                            DeadLetterTopic = first.DeadLetterTopicName
                         };
 
                         // Use the V2 routing rules structure

--- a/src/Dapr.AspNetCore/ITopicMetadata.cs
+++ b/src/Dapr.AspNetCore/ITopicMetadata.cs
@@ -24,6 +24,11 @@ namespace Dapr
         string Name { get; }
 
         /// <summary>
+        /// Gets the dead letter topic name
+        /// </summary>
+        string DeadLetterTopicName { get; }
+
+        /// <summary>
         /// Gets the pubsub component name name.
         /// </summary>
         string PubsubName { get; }

--- a/src/Dapr.AspNetCore/Subscription.cs
+++ b/src/Dapr.AspNetCore/Subscription.cs
@@ -26,6 +26,11 @@ namespace Dapr
         public string Topic { get; set; }
 
         /// <summary>
+        /// Gets or sets the dead letter topic name.
+        /// </summary>
+        public string DeadLetterTopic { get; set; }
+
+        /// <summary>
         /// Gets or sets the pubsub name
         /// </summary>
         public string PubsubName { get; set; }

--- a/src/Dapr.AspNetCore/TopicAttribute.cs
+++ b/src/Dapr.AspNetCore/TopicAttribute.cs
@@ -28,7 +28,8 @@ namespace Dapr
         /// <param name="name">The topic name.</param>
         /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
         /// <param name="metadataSeparator">Separator to use for metadata.</param>
-        public TopicAttribute(string pubsubName, string name, string[] ownedMetadatas = null, string metadataSeparator = null)
+        /// <param name="deadLetterTopicName">The dead letter topic name.</param>
+        public TopicAttribute(string pubsubName, string name, string[] ownedMetadatas = null, string metadataSeparator = null, string deadLetterTopicName = null)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
             ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -37,6 +38,7 @@ namespace Dapr
             this.PubsubName = pubsubName;
             this.OwnedMetadatas = ownedMetadatas;
             this.MetadataSeparator = metadataSeparator;
+            this.DeadLetterTopicName = deadLetterTopicName;
         }
 
         /// <summary>
@@ -47,7 +49,8 @@ namespace Dapr
         /// <param name="enableRawPayload">The enable/disable raw pay load flag.</param>
         /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
         /// <param name="metadataSeparator">Separator to use for metadata.</param>
-        public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string[] ownedMetadatas = null, string metadataSeparator = null)
+        /// <param name="deadLetterTopicName">The dead letter topic name.</param>
+        public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string[] ownedMetadatas = null, string metadataSeparator = null, string deadLetterTopicName = null)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
             ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -57,6 +60,7 @@ namespace Dapr
             this.EnableRawPayload = enableRawPayload;
             this.OwnedMetadatas = ownedMetadatas;
             this.MetadataSeparator = metadataSeparator;
+            this.DeadLetterTopicName = deadLetterTopicName;
         }
 
         /// <summary>
@@ -68,7 +72,8 @@ namespace Dapr
         /// <param name="priority">The priority of the rule (low-to-high values).</param>
         /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
         /// <param name="metadataSeparator">Separator to use for metadata.</param>
-        public TopicAttribute(string pubsubName, string name, string match, int priority, string[] ownedMetadatas = null, string metadataSeparator = null)
+        /// <param name="deadLetterTopicName">The dead letter topic name.</param>
+        public TopicAttribute(string pubsubName, string name, string match, int priority, string[] ownedMetadatas = null, string metadataSeparator = null, string deadLetterTopicName = null)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
             ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -79,6 +84,7 @@ namespace Dapr
             this.Priority = priority;
             this.OwnedMetadatas = ownedMetadatas;
             this.MetadataSeparator = metadataSeparator;
+            this.DeadLetterTopicName = deadLetterTopicName;
         }
 
         /// <summary>
@@ -91,7 +97,8 @@ namespace Dapr
         /// <param name="priority">The priority of the rule (low-to-high values).</param>
         /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
         /// <param name="metadataSeparator">Separator to use for metadata.</param>
-        public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string match, int priority, string[] ownedMetadatas = null, string metadataSeparator = null)
+        /// <param name="deadLetterTopicName">The dead letter topic name.</param>
+        public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string match, int priority, string[] ownedMetadatas = null, string metadataSeparator = null, string deadLetterTopicName = null)
         {
             ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
             ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -103,10 +110,14 @@ namespace Dapr
             this.Priority = priority;
             this.OwnedMetadatas = ownedMetadatas;
             this.MetadataSeparator = metadataSeparator;
+            this.DeadLetterTopicName = deadLetterTopicName;
         }
 
         /// <inheritdoc/>
         public string Name { get; }
+
+        /// <inheritdoc/>
+        public string DeadLetterTopicName { get; }
 
         /// <inheritdoc/>
         public string PubsubName { get; }

--- a/test/Dapr.AspNetCore.IntegrationTest.App/CustomTopicAttribute.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/CustomTopicAttribute.cs
@@ -25,6 +25,8 @@ namespace Dapr.AspNetCore.IntegrationTest.App
 
         public string Name { get; }
 
+        public string DeadLetterTopicName { get; }
+
         public string PubsubName { get; }
 
         public new string Match { get; }


### PR DESCRIPTION
# Description

We need the ability to define the PubSub Dead Letter Topic name in the C# "Topic" Attribute. I have not yet implemented tests as I am curious if I am on the right track with this pull request.

![image](https://user-images.githubusercontent.com/3374673/181840346-cec83ec0-c965-4d7d-8f62-c461bb7542e0.png)

This returns the dead letter topic name in the `/dapr/subscribe` endpoint.

![image](https://user-images.githubusercontent.com/3374673/181840134-53408a88-b854-4818-bfc3-7a79fd1be2cc.png)

## Issue reference

N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests (Holding off until receiving further direction)
* [ ] Extended the documentation (Holding off until receiving further direction)
