### PR TITLE
Upgrade grpc.tools version to 2.47.0 for supporting arm64 architecture

### DIFF
--- a/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
+++ b/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.30.0" />
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.32.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
   </ItemGroup>
 

--- a/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
+++ b/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.30.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.32.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.47.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.47.0" />
     <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
   </ItemGroup>

--- a/examples/Client/PublishSubscribe/PublishSubscribe.csproj
+++ b/examples/Client/PublishSubscribe/PublishSubscribe.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/examples/Client/ServiceInvocation/ServiceInvocation.csproj
+++ b/examples/Client/ServiceInvocation/ServiceInvocation.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/examples/Client/StateManagement/StateManagement.csproj
+++ b/examples/Client/StateManagement/StateManagement.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapr.Client/Dapr.Client.csproj
+++ b/src/Dapr.Client/Dapr.Client.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.32.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.47.0" />
     <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />

--- a/src/Dapr.Client/Dapr.Client.csproj
+++ b/src/Dapr.Client/Dapr.Client.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.32.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>

--- a/test/Dapr.Client.Test/Dapr.Client.Test.csproj
+++ b/test/Dapr.Client.Test/Dapr.Client.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
     <PackageReference Include="Grpc.Core.Testing" Version="2.38.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.38.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.38.1" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="moq" Version="4.14.7" />
     <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.123" />      

--- a/test/Dapr.Client.Test/Dapr.Client.Test.csproj
+++ b/test/Dapr.Client.Test/Dapr.Client.Test.csproj
@@ -10,13 +10,13 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Grpc.Core.Testing" Version="2.38.1" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.38.0" />
+    <PackageReference Include="Grpc.Core.Testing" Version="2.46.3" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.47.0" />
     <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="moq" Version="4.14.7" />
-    <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.123" />      
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />      
+    <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.123" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
+++ b/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.32.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.32.0" PrivateAssets="All" />
+    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
+++ b/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.32.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.47.0" />
     <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Upgrade grpc.tools version to 2.47.0 to support arm64 architecture

## Issue reference

Please reference the issue this PR will close:  #919 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
