### PR TITLE
FIX Allow actor healthz endpoint are now always AllowAnonymous

### DIFF
--- a/src/Dapr.Actors.AspNetCore/ActorsEndpointRouteBuilderExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/ActorsEndpointRouteBuilderExtensions.cs
@@ -16,7 +16,7 @@ using System.Text;
 using Dapr.Actors;
 using Dapr.Actors.Communication;
 using Dapr.Actors.Runtime;
-using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Builder
                 MapActorMethodEndpoint(endpoints),
                 MapReminderEndpoint(endpoints),
                 MapTimerEndpoint(endpoints),
-                MapActorHealthChecks(endpoints),
+                MapActorHealthChecks(endpoints)
             };
 
             return new CompositeEndpointConventionBuilder(builders);
@@ -171,7 +171,7 @@ namespace Microsoft.AspNetCore.Builder
 
         private static IEndpointConventionBuilder MapActorHealthChecks(this IEndpointRouteBuilder endpoints)
         {
-            var builder = endpoints.MapHealthChecks("/healthz");
+            var builder = endpoints.MapHealthChecks("/healthz").WithMetadata(new AllowAnonymousAttribute());
             builder.Add(b =>
             {
                 // Sets the route order so that this is matched with lower priority than an endpoint

--- a/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Dapr.Actors.AspNetCore\Dapr.Actors.AspNetCore.csproj" />
     <ProjectReference Include="..\Dapr.Actors.AspNetCore.IntegrationTest.App\Dapr.Actors.AspNetCore.IntegrationTest.App.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description

Allowing anonymous calls to the /healthz endpoint when exposing actors' health checks.

## Issue reference

Please reference the issue this PR will close: #908 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
