### PR TITLE
Change log level to information in pubsub examples

### DIFF
--- a/examples/AspNetCore/ControllerSample/Controllers/SampleController.cs
+++ b/examples/AspNetCore/ControllerSample/Controllers/SampleController.cs
@@ -68,10 +68,10 @@ namespace ControllerSample.Controllers
         [HttpPost("deposit")]
         public async Task<ActionResult<Account>> Deposit(Transaction transaction, [FromServices] DaprClient daprClient)
         {
-            logger.LogDebug("Enter deposit");
+            logger.LogInformation("Enter deposit");
             var state = await daprClient.GetStateEntryAsync<Account>(StoreName, transaction.Id);
             state.Value ??= new Account() { Id = transaction.Id, };
-            logger.LogDebug("Id is {0}, the amount to be deposited is {1}", transaction.Id, transaction.Amount);
+            logger.LogInformation("Id is {0}, the amount to be deposited is {1}", transaction.Id, transaction.Amount);
 
             if (transaction.Amount < 0m)
             {
@@ -79,7 +79,7 @@ namespace ControllerSample.Controllers
             }
 
             state.Value.Balance += transaction.Amount;
-            logger.LogDebug("Balance is {0}", state.Value.Balance);
+            logger.LogInformation("Balance is {0}", state.Value.Balance);
             await state.SaveAsync();
             return state.Value;
         }
@@ -93,7 +93,7 @@ namespace ControllerSample.Controllers
         [HttpPost("deadLetterTopicRoute")]
         public ActionResult<Account> ViewErrorMessage(Transaction transaction)
         {
-            logger.LogDebug("The amount cannot be negative: {0}", transaction.Amount);
+            logger.LogInformation("The amount cannot be negative: {0}", transaction.Amount);
             return Ok();
         }
 
@@ -108,9 +108,9 @@ namespace ControllerSample.Controllers
         [HttpPost("withdraw")]
         public async Task<ActionResult<Account>> Withdraw(Transaction transaction, [FromServices] DaprClient daprClient)
         {
-            logger.LogDebug("Enter withdraw method...");
+            logger.LogInformation("Enter withdraw method...");
             var state = await daprClient.GetStateEntryAsync<Account>(StoreName, transaction.Id);
-            logger.LogDebug("Id is {0}, the amount to be withdrawn is {1}", transaction.Id, transaction.Amount);
+            logger.LogInformation("Id is {0}, the amount to be withdrawn is {1}", transaction.Id, transaction.Amount);
 
             if (state.Value == null)
             {
@@ -122,7 +122,7 @@ namespace ControllerSample.Controllers
             }
 
             state.Value.Balance -= transaction.Amount;
-            logger.LogDebug("Balance is {0}", state.Value.Balance);
+            logger.LogInformation("Balance is {0}", state.Value.Balance);
             await state.SaveAsync();
             return state.Value;
         }
@@ -138,7 +138,7 @@ namespace ControllerSample.Controllers
         [HttpPost("withdraw.v2")]
         public async Task<ActionResult<Account>> WithdrawV2(TransactionV2 transaction, [FromServices] DaprClient daprClient)
         {
-            logger.LogDebug("Enter withdraw.v2");
+            logger.LogInformation("Enter withdraw.v2");
             if (transaction.Channel == "mobile" && transaction.Amount > 10000)
             {
                 return this.Unauthorized("mobile transactions for large amounts are not permitted.");
@@ -161,7 +161,7 @@ namespace ControllerSample.Controllers
         [HttpPost("throwException")]
         public async Task<ActionResult<Account>> ThrowException(Transaction transaction, [FromServices] DaprClient daprClient)
         {
-            logger.LogDebug("Enter ThrowException");
+            logger.LogInformation("Enter ThrowException");
             var task = Task.Delay(10);
             await task;
             return BadRequest(new { statusCode = 400, message = "bad request" });

--- a/examples/AspNetCore/RoutingSample/Startup.cs
+++ b/examples/AspNetCore/RoutingSample/Startup.cs
@@ -110,20 +110,20 @@ namespace RoutingSample
 
             async Task Balance(HttpContext context)
             {
-                logger.LogDebug("Enter Balance");
+                logger.LogInformation("Enter Balance");
                 var client = context.RequestServices.GetRequiredService<DaprClient>();
 
                 var id = (string)context.Request.RouteValues["id"];
-                logger.LogDebug("id is {0}", id);
+                logger.LogInformation("id is {0}", id);
                 var account = await client.GetStateAsync<Account>(StoreName, id);
                 if (account == null)
                 {
-                    logger.LogDebug("Account not found");
+                    logger.LogInformation("Account not found");
                     context.Response.StatusCode = 404;
                     return;
                 }
 
-                logger.LogDebug("Account balance is {0}", account.Balance);
+                logger.LogInformation("Account balance is {0}", account.Balance);
 
                 context.Response.ContentType = "application/json";
                 await JsonSerializer.SerializeAsync(context.Response.Body, account, serializerOptions);
@@ -131,12 +131,12 @@ namespace RoutingSample
 
             async Task Deposit(HttpContext context)
             {
-                logger.LogDebug("Enter Deposit");
+                logger.LogInformation("Enter Deposit");
 
                 var client = context.RequestServices.GetRequiredService<DaprClient>();
                 var transaction = await JsonSerializer.DeserializeAsync<Transaction>(context.Request.Body, serializerOptions);
 
-                logger.LogDebug("Id is {0}, Amount is {1}", transaction.Id, transaction.Amount);
+                logger.LogInformation("Id is {0}, Amount is {1}", transaction.Id, transaction.Amount);
 
                 var account = await client.GetStateAsync<Account>(StoreName, transaction.Id);
                 if (account == null)
@@ -146,14 +146,14 @@ namespace RoutingSample
 
                 if (transaction.Amount < 0m)
                 {
-                    logger.LogDebug("Invalid amount");
+                    logger.LogInformation("Invalid amount");
                     context.Response.StatusCode = 400;
                     return;
                 }
 
                 account.Balance += transaction.Amount;
                 await client.SaveStateAsync(StoreName, transaction.Id, account);
-                logger.LogDebug("Balance is {0}", account.Balance);
+                logger.LogInformation("Balance is {0}", account.Balance);
 
                 context.Response.ContentType = "application/json";
                 await JsonSerializer.SerializeAsync(context.Response.Body, account, serializerOptions);
@@ -164,38 +164,38 @@ namespace RoutingSample
                 var client = context.RequestServices.GetRequiredService<DaprClient>();
                 var transaction = await JsonSerializer.DeserializeAsync<Transaction>(context.Request.Body, serializerOptions);
 
-                logger.LogDebug("The amount cannot be negative: {0}", transaction.Amount);
+                logger.LogInformation("The amount cannot be negative: {0}", transaction.Amount);
 
                 return;
             }
 
             async Task Withdraw(HttpContext context)
             {
-                logger.LogDebug("Enter Withdraw");
+                logger.LogInformation("Enter Withdraw");
 
                 var client = context.RequestServices.GetRequiredService<DaprClient>();
                 var transaction = await JsonSerializer.DeserializeAsync<Transaction>(context.Request.Body, serializerOptions);
 
-                logger.LogDebug("Id is {0}, Amount is {1}", transaction.Id, transaction.Amount);
+                logger.LogInformation("Id is {0}, Amount is {1}", transaction.Id, transaction.Amount);
 
                 var account = await client.GetStateAsync<Account>(StoreName, transaction.Id);
                 if (account == null)
                 {
-                    logger.LogDebug("Account not found");
+                    logger.LogInformation("Account not found");
                     context.Response.StatusCode = 404;
                     return;
                 }
 
                 if (transaction.Amount < 0m)
                 {
-                    logger.LogDebug("Invalid amount");
+                    logger.LogInformation("Invalid amount");
                     context.Response.StatusCode = 400;
                     return;
                 }
 
                 account.Balance -= transaction.Amount;
                 await client.SaveStateAsync(StoreName, transaction.Id, account);
-                logger.LogDebug("Balance is {0}", account.Balance);
+                logger.LogInformation("Balance is {0}", account.Balance);
 
                 context.Response.ContentType = "application/json";
                 await JsonSerializer.SerializeAsync(context.Response.Body, account, serializerOptions);


### PR DESCRIPTION
Fixes https://github.com/dapr/dotnet-sdk/issues/936

Signed-off-by: Yash Nisar <yashnisar@microsoft.com>

# Description

Currently, we do support logging but the log level is debug in pubsub examples. Since the default log level in `appsettings.json` is information, logging is suppressed. We need to enable logging by replacing `logger.LogDebug(...)` by `logger.LogInformation(...)`

## Issue reference

https://github.com/dapr/dotnet-sdk/issues/936

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
