### PR TITLE
Changed distributedLock example to consider a new default port number

### DIFF
--- a/examples/Client/DistributedLock/Program.cs
+++ b/examples/Client/DistributedLock/Program.cs
@@ -21,7 +21,7 @@ namespace DistributedLock
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>()
-                        .UseUrls($"http://localhost:{Environment.GetEnvironmentVariable("APP_PORT")}");
+                        .UseUrls($"http://localhost:{Environment.GetEnvironmentVariable("APP_PORT") ?? "22222"}");
                 });
     }
 }


### PR DESCRIPTION
Signed-off-by: Amulya Varote <amulyavarote@microsoft.com>

# Description

_Please explain the changes you've made_

Changed distributedLock example to consider a new default port number to avoid default port conflict.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #NA

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
