### PR TITLE
Add note about ARM64 compatibility

### DIFF
--- a/examples/Workflow/README.md
+++ b/examples/Workflow/README.md
@@ -9,6 +9,8 @@ This Dapr workflow example shows how to create a Dapr workflow (`Workflow`) and 
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://github.com/dapr/dotnet-sdk/)
 
+> NOTE: The alpha version of the Dapr Workflow authoring SDK (`Dapr.Workflow`) is not compatible with ARM-based processors, such as the Apple M1 and M2 chips for macOS. ARM64 compatibility will be added in a future release.
+
 ## Projects in sample
 
 This sample contains a single [WorkflowWebApp](./WorkflowWebApp) ASP.NET Core project. It combines both the workflow implementations and the web APIs for starting and querying workflows instances.


### PR DESCRIPTION
# Description

Trying to run the Dapr Workflow authoring SDK on macOS with M1 or M2 chips will fail with the following error message:

```
== APP == Unhandled exception. System.IO.FileNotFoundException: Error loading native library. Not found in any of the possible locations: /Users/xxx/src/xxx/dotnet-sdk/bin/Debug/examples/WorkflowWebApp/net6.0/libgrpc_csharp_ext.arm64.dylib,/Users/xxx/src/xxx/dotnet-sdk/bin/Debug/examples/WorkflowWebApp/net6.0/runtimes/osx-arm64/native/libgrpc_csharp_ext.arm64.dylib,/Users/xxx/src/xxx/dotnet-sdk/bin/Debug/examples/WorkflowWebApp/net6.0/../../runtimes/osx-arm64/native/libgrpc_csharp_ext.arm64.dylib
== APP ==    at Grpc.Core.Internal.UnmanagedLibrary.FirstValidLibraryPath(String[] libraryPathAlternatives)
== APP ==    at Grpc.Core.Internal.UnmanagedLibrary..ctor(String[] libraryPathAlternatives)
== APP ==    at Grpc.Core.Internal.NativeExtension.LoadNativeMethodsUsingExplicitLoad()
== APP ==    at Grpc.Core.Internal.NativeExtension.LoadNativeMethods()
```

This PR adds a note about this to the workflow example README.md file so that users will hopefully get the heads-up they need.

Separate PRs will be used to update official documentation.