### PR TITLE
Replace relative path with absolute path for localstorage component

### DIFF
--- a/examples/Client/DistributedLock/Components/localstorage.yaml
+++ b/examples/Client/DistributedLock/Components/localstorage.yaml
@@ -8,4 +8,4 @@ spec:
   version: v1
   metadata:
   - name: rootPath
-    value: ./tmp
+    value: /tmp/localstorage

--- a/examples/Client/DistributedLock/README.md
+++ b/examples/Client/DistributedLock/README.md
@@ -80,5 +80,5 @@ Note that both apps succeed and fail to lock files. This is due to the two apps 
 Any files that are leftover can be safely removed.
 
 ```bash
-rm -rf ./tmp
+rm -rf /tmp/localstorage
 ```


### PR DESCRIPTION
Fixes https://github.com/dapr/dotnet-sdk/issues/1022

Signed-off-by: Yash Nisar <yashnisar@microsoft.com>

# Description
Dapr quits unexpectedly because the localstorage component yaml doesn't have the correct metadata format.
https://github.com/dapr/dotnet-sdk/blob/master/examples/Client/DistributedLock/Components/localstorage.yaml#L11 should have the absolute path for rootPath. See https://docs.dapr.io/reference/components-reference/supported-bindings/localstorage/#spec-metadata-fields

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dotnet-sdk/issues/1022

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
