### PR TITLE
Update DurableTask SDK dependency to get ARM64 compatibility

### DIFF
--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.0-rc.1" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.0-rc.1" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.0" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dapr.Workflow/WorkflowEngineClient.cs
+++ b/src/Dapr.Workflow/WorkflowEngineClient.cs
@@ -18,10 +18,13 @@ namespace Dapr.Workflow
     using Microsoft.DurableTask;
     using Microsoft.DurableTask.Client;
 
-    // TODO: This will be replaced by the official Dapr Workflow management client.
     /// <summary>
     /// Defines client operations for managing Dapr Workflow instances.
     /// </summary>
+    /// <remarks>
+    /// This is an alternative to the general purpose Dapr client. It uses a gRPC connection to send
+    /// commands directly to the workflow engine, bypassing the Dapr API layer.
+    /// </remarks>
     public sealed class WorkflowEngineClient : IAsyncDisposable
     {
         readonly DurableTaskClient innerClient;
@@ -70,7 +73,7 @@ namespace Dapr.Workflow
         /// </param>
         public async Task<WorkflowState> GetWorkflowStateAsync(string instanceId, bool getInputsAndOutputs = false)
         {
-            OrchestrationMetadata? metadata = await this.innerClient.GetInstanceMetadataAsync(
+            OrchestrationMetadata? metadata = await this.innerClient.GetInstancesAsync(
                 instanceId,
                 getInputsAndOutputs);
             return new WorkflowState(metadata);

--- a/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
+++ b/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
@@ -53,7 +53,13 @@ namespace Dapr.Workflow
                 string? daprPortStr = Environment.GetEnvironmentVariable("DAPR_GRPC_PORT");
                 if (int.TryParse(Environment.GetEnvironmentVariable("DAPR_GRPC_PORT"), out int daprGrpcPort))
                 {
+                    // There is a bug in the Durable Task SDK that requires us to change the format of the address
+                    // depending on the version of .NET that we're targeting. For now, we work around this manually.
+#if NET6_0_OR_GREATER
+                    address = $"http://localhost:{daprGrpcPort}";
+#else
                     address = $"localhost:{daprGrpcPort}";
+#endif
                     return true;
                 }
 

--- a/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
+++ b/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.15.8" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.12" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.47.0" />
     <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />


### PR DESCRIPTION
# Description

An issue was discovered that prevents the Dapr Workflow authoring SDK from working on ARM64-based processors, including M1 and M2 macs. When trying, the following exception is encountered:

```
== APP == Unhandled exception. System.IO.FileNotFoundException: Error loading native library. Not found in any of the possible locations: /Users/xxx/src/xxx/dotnet-sdk/bin/Debug/examples/WorkflowWebApp/net6.0/libgrpc_csharp_ext.arm64.dylib,/Users/xxx/src/xxx/dotnet-sdk/bin/Debug/examples/WorkflowWebApp/net6.0/runtimes/osx-arm64/native/libgrpc_csharp_ext.arm64.dylib,/Users/xxx/src/xxx/dotnet-sdk/bin/Debug/examples/WorkflowWebApp/net6.0/../../runtimes/osx-arm64/native/libgrpc_csharp_ext.arm64.dylib
== APP ==    at Grpc.Core.Internal.UnmanagedLibrary.FirstValidLibraryPath(String[] libraryPathAlternatives)
== APP ==    at Grpc.Core.Internal.UnmanagedLibrary..ctor(String[] libraryPathAlternatives)
== APP ==    at Grpc.Core.Internal.NativeExtension.LoadNativeMethodsUsingExplicitLoad()
== APP ==    at Grpc.Core.Internal.NativeExtension.LoadNativeMethods()
```

The problem appears to be an old version of a gRPC dependency used by the Durable Task SDK dependency.

The fix is to update the Durable Task SDK dependency to the v1.0.0, which should have a fix for the gRPC dependency issue. This PR makes that dependency update.

## Issue reference

Please reference the issue this PR will close: TODO

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
