### PR TITLE
Using environment variable for dapr sidecar host and using localhost instead of 127.0.0.1 as DAPR default sidecar host

### DIFF
--- a/all.sln
+++ b/all.sln
@@ -104,6 +104,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BulkPublishEventExample", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WorkflowUnitTest", "examples\Workflow\WorkflowUnitTest\WorkflowUnitTest.csproj", "{8CA09061-2BEF-4506-A763-07062D2BD6AC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapr.Shared.Test", "test\Dapr.Shared.Test\Dapr.Shared.Test.csproj", "{072AB8B8-8006-4CE1-90C6-EBC99050ADC6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -248,6 +250,10 @@ Global
 		{DDC41278-FB60-403A-B969-2AEBD7C2D83C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8CA09061-2BEF-4506-A763-07062D2BD6AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8CA09061-2BEF-4506-A763-07062D2BD6AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{072AB8B8-8006-4CE1-90C6-EBC99050ADC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{072AB8B8-8006-4CE1-90C6-EBC99050ADC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{072AB8B8-8006-4CE1-90C6-EBC99050ADC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{072AB8B8-8006-4CE1-90C6-EBC99050ADC6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -293,6 +299,7 @@ Global
 		{4A175C27-EAFE-47E7-90F6-873B37863656} = {0EF6EA64-D7C3-420D-9890-EAE8D54A57E6}
 		{DDC41278-FB60-403A-B969-2AEBD7C2D83C} = {0EF6EA64-D7C3-420D-9890-EAE8D54A57E6}
 		{8CA09061-2BEF-4506-A763-07062D2BD6AC} = {BF3ED6BF-ADF3-4D25-8E89-02FB8D945CA9}
+		{072AB8B8-8006-4CE1-90C6-EBC99050ADC6} = {DD020B34-460F-455F-8D17-CF4A949F100B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {65220BF2-EAE1-4CB2-AA58-EBE80768CB40}

--- a/src/Dapr.Actors/Client/ActorProxyOptions.cs
+++ b/src/Dapr.Actors/Client/ActorProxyOptions.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,8 +52,11 @@ namespace Dapr.Actors.Client
         /// </summary>
         /// <remarks>
         /// The URI endpoint to use for HTTP calls to the Dapr runtime. The default value will be 
-        /// <c>http://127.0.0.1:DAPR_HTTP_PORT</c> where <c>DAPR_HTTP_PORT</c> represents the value of the 
-        /// <c>DAPR_HTTP_PORT</c> environment variable.
+        /// <c>DAPR_HOST:DAPR_HTTP_PORT</c> where <c>DAPR_HOST</c> represents the value of the 
+        /// <c>DAPR_HOST</c> environment variable and <c>DAPR_HTTP_PORT</c> represents the value of the 
+        /// <c>DAPR_HTTP_PORT</c> environment variable. If <c>DAPR_HOST</c> environment variable is 
+        /// undefined or empty <c>http://localhost</c> is used as default value. If <c>DAPR_HTTP_PORT</c> environment 
+        /// variable is undefined or empty <c>3500</c> is used as default value. 
         /// </remarks>
         /// <value></value>
         public string HttpEndpoint { get; set; } = DaprDefaults.GetDefaultHttpEndpoint();

--- a/src/Dapr.Actors/Constants.cs
+++ b/src/Dapr.Actors/Constants.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@ namespace Dapr.Actors
         public const string State = "state";
         public const string Actors = "actors";
         public const string Namespace = "urn:actors";
-        public const string DaprDefaultEndpoint = "127.0.0.1";
-        public const string DaprDefaultPort = "3500";
         public const string DaprVersion = "v1.0";
         public const string Method = "method";
         public const string Reminders = "reminders";

--- a/src/Dapr.Actors/Runtime/ActorRuntimeOptions.cs
+++ b/src/Dapr.Actors/Runtime/ActorRuntimeOptions.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -220,8 +220,11 @@ namespace Dapr.Actors.Runtime
         /// </summary>
         /// <remarks>
         /// The URI endpoint to use for HTTP calls to the Dapr runtime. The default value will be 
-        /// <c>http://127.0.0.1:DAPR_HTTP_PORT</c> where <c>DAPR_HTTP_PORT</c> represents the value of the 
-        /// <c>DAPR_HTTP_PORT</c> environment variable.
+        /// <c>DAPR_HOST:DAPR_HTTP_PORT</c> where <c>DAPR_HOST</c> represents the value of the 
+        /// <c>DAPR_HOST</c> environment variable and <c>DAPR_HTTP_PORT</c> represents the value of the 
+        /// <c>DAPR_HTTP_PORT</c> environment variable. If <c>DAPR_HOST</c> environment variable is 
+        /// undefined or empty <c>http://localhost</c> is used as default value. If <c>DAPR_HTTP_PORT</c> environment 
+        /// variable is undefined or empty <c>3500</c> is used as default value. 
         /// </remarks>
         /// <value></value>
         public string HttpEndpoint { get; set; } = DaprDefaults.GetDefaultHttpEndpoint();

--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -121,7 +121,12 @@ namespace Dapr.Client
         /// The appId that is targetted by Dapr for gRPC invocations.
         /// </param>
         /// <param name="daprEndpoint">
-        /// Optional gRPC endpoint for calling Dapr, defaults to <see cref="DaprDefaults.GetDefaultGrpcEndpoint"/>.
+        /// Optional gRPC endpoint for calling Dapr runtime. 
+        /// The default value will be <c>DAPR_HOST:DAPR_GRPC_PORT</c> where <c>DAPR_HOST</c> 
+        /// represents the value of the <c>DAPR_HOST</c> environment variable and <c>DAPR_GRPC_PORT</c> 
+        /// represents the value of the <c>DAPR_GRPC_PORT</c> environment variable. If <c>DAPR_HOST</c> environment 
+        /// variable is undefined or empty <c>http://localhost</c> is used as default value. 
+        /// If <c>DAPR_GRPC_PORT</c> environment ariable is undefined or empty <c>50001</c> is used as default value. 
         /// </param>
         /// <param name="daprApiToken">
         /// Optional token to be attached to all requests, defaults to <see cref="DaprDefaults.GetDefaultDaprApiToken"/>.

--- a/src/Dapr.Client/DaprClientBuilder.cs
+++ b/src/Dapr.Client/DaprClientBuilder.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,8 +63,11 @@ namespace Dapr.Client
         /// </summary>
         /// <param name="httpEndpoint">
         /// The URI endpoint to use for HTTP calls to the Dapr runtime. The default value will be 
-        /// <c>http://127.0.0.1:DAPR_HTTP_PORT</c> where <c>DAPR_HTTP_PORT</c> represents the value of the 
-        /// <c>DAPR_HTTP_PORT</c> environment variable.
+        /// <c>DAPR_HOST:DAPR_HTTP_PORT</c> where <c>DAPR_HOST</c> represents the value of the 
+        /// <c>DAPR_HOST</c> environment variable and <c>DAPR_HTTP_PORT</c> represents the value of the 
+        /// <c>DAPR_HTTP_PORT</c> environment variable. If <c>DAPR_HOST</c> environment variable is 
+        /// undefined or empty <c>http://localhost</c> is used as default value. If <c>DAPR_HTTP_PORT</c> environment 
+        /// variable is undefined or empty <c>3500</c> is used as default value. 
         /// </param>
         /// <returns>The <see cref="DaprClientBuilder" /> instance.</returns>
         public DaprClientBuilder UseHttpEndpoint(string httpEndpoint)
@@ -85,9 +88,12 @@ namespace Dapr.Client
         /// Overrides the gRPC endpoint used by <see cref="DaprClient" /> for communicating with the Dapr runtime.
         /// </summary>
         /// <param name="grpcEndpoint">
-        /// The URI endpoint to use for gRPC calls to the Dapr runtime. The default value will be 
-        /// <c>http://127.0.0.1:DAPR_GRPC_PORT</c> where <c>DAPR_GRPC_PORT</c> represents the value of the 
-        /// <c>DAPR_GRPC_PORT</c> environment variable.
+        /// The URI endpoint to use for gRPC calls to the Dapr runtime. 
+        /// The default value will be <c>DAPR_HOST:DAPR_GRPC_PORT</c> where <c>DAPR_HOST</c> 
+        /// represents the value of the <c>DAPR_HOST</c> environment variable and <c>DAPR_GRPC_PORT</c> 
+        /// represents the value of the <c>DAPR_GRPC_PORT</c> environment variable. If <c>DAPR_HOST</c> environment 
+        /// variable is undefined or empty <c>http://localhost</c> is used as default value. 
+        /// If <c>DAPR_GRPC_PORT</c> environment variable is undefined or empty <c>50001</c> is used as default value. 
         /// </param>
         /// <returns>The <see cref="DaprClientBuilder" /> instance.</returns>
         public DaprClientBuilder UseGrpcEndpoint(string grpcEndpoint)

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -10,6 +10,9 @@
     <VersionPrefix>0.1.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Shared\DaprDefaults.cs" Link="DaprDefaults.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.0" />

--- a/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
+++ b/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
@@ -56,8 +56,9 @@ namespace Dapr.Workflow
                     address = defaultGrpcAddress;
 #else
                     // Try to remove the schema 
-                    var position = defaultGrpcAddress.AsSpan().IndexOf(stackalloc char[] { ':', '/', '/' });
-                    address = position == -1 ? defaultGrpcAddress : defaultGrpcAddress[(position + 3)..];
+                    var addressAsSpan = defaultGrpcAddress.AsSpan();
+                    var position = addressAsSpan.IndexOf(stackalloc char[] { ':', '/', '/' });
+                    address = position == -1 ? defaultGrpcAddress : new string(addressAsSpan[(position + 3)..]);
 #endif
 
                     return true;

--- a/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
+++ b/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
@@ -56,7 +56,7 @@ namespace Dapr.Workflow
                     address = defaultGrpcAddress;
 #else
                     // Try to remove the schema 
-                    var position = defaultGrpcAddress.IndexOf("://");
+                    var position = defaultGrpcAddress.AsSpan().IndexOf(stackalloc char[] { ':', '/', '/' });
                     address = position == -1 ? defaultGrpcAddress : defaultGrpcAddress[(position + 3)..];
 #endif
 

--- a/src/Shared/DaprDefaults.cs
+++ b/src/Shared/DaprDefaults.cs
@@ -15,12 +15,19 @@ using System;
 
 namespace Dapr
 {
+#nullable disable
+
     internal static class DaprDefaults
     {
+        public const string DaprDefaultHost = "http://localhost";
+        public const string DaprDefaultHttpPort = "3500";
+        public const string DaprDefaultGrpcPort = "50001";
+
         private static string httpEndpoint;
         private static string grpcEndpoint;
         private static string daprApiToken;
         private static string appApiToken;
+        private static string host;
 
         /// <summary>
         /// Get the value of environment variable DAPR_API_TOKEN
@@ -57,35 +64,65 @@ namespace Dapr
         }
 
         /// <summary>
-        /// Get the value of environment variable DAPR_HTTP_PORT
+        /// Get the default value of URI endpoint to use for HTTP calls to the Dapr runtime. 
+        /// The default value will be <c>DAPR_HOST:DAPR_HTTP_PORT</c> where <c>DAPR_HOST</c> 
+        /// represents the value of the <c>DAPR_HOST</c> environment variable and <c>DAPR_HTTP_PORT</c> 
+        /// represents the value of the <c>DAPR_HTTP_PORT</c> environment variable. If <c>DAPR_HOST</c> environment 
+        /// variable is undefined or empty <c>http://localhost</c> is used as default value. 
+        /// If <c>DAPR_HTTP_PORT</c> environment variable is undefined or empty <c>3500</c> is used as default value. 
         /// </summary>
-        /// <returns>The value of environment variable DAPR_HTTP_PORT</returns>
+        /// <returns>The default value of URI endpoint to use for HTTP calls to the Dapr runtime.</returns>
         public static string GetDefaultHttpEndpoint()
         {
             if (httpEndpoint == null)
             {
                 var port = Environment.GetEnvironmentVariable("DAPR_HTTP_PORT");
-                port = string.IsNullOrEmpty(port) ? "3500" : port;
-                httpEndpoint = $"http://127.0.0.1:{port}";
+                port = string.IsNullOrEmpty(port) ? DaprDefaultHttpPort : port;
+                httpEndpoint = $"{GetHost()}:{port}";
             }
 
             return httpEndpoint;
         }
 
         /// <summary>
-        /// Get the value of environment variable DAPR_GRPC_PORT
+        /// Get the default value of URI endpoint to use for gRPC calls to the Dapr runtime. 
+        /// The default value will be <c>DAPR_HOST:DAPR_GRPC_PORT</c> where <c>DAPR_HOST</c> 
+        /// represents the value of the <c>DAPR_HOST</c> environment variable and <c>DAPR_GRPC_PORT</c> 
+        /// represents the value of the <c>DAPR_GRPC_PORT</c> environment variable. If <c>DAPR_HOST</c> environment 
+        /// variable is undefined or empty <c>http://localhost</c> is used as default value. 
+        /// If <c>DAPR_GRPC_PORT</c> environment variable is undefined or empty <c>50001</c> is used as default value. 
         /// </summary>
-        /// <returns>The value of environment variable DAPR_GRPC_PORT</returns>
+        /// <returns>The default value of URI endpoint to use for gRPC calls to the Dapr runtime.</returns>
         public static string GetDefaultGrpcEndpoint()
         {
             if (grpcEndpoint == null)
             {
                 var port = Environment.GetEnvironmentVariable("DAPR_GRPC_PORT");
-                port = string.IsNullOrEmpty(port) ? "50001" : port;
-                grpcEndpoint = $"http://127.0.0.1:{port}";
+                port = string.IsNullOrEmpty(port) ? DaprDefaultGrpcPort : port;
+
+                grpcEndpoint = $"{GetHost()}:{port}";
             }
 
             return grpcEndpoint;
         }
+
+        /// <summary>
+        /// Get the default value of DAPR host. Value is retrieved from DAPR_HOST 
+        /// environment variable, http://localhost is used when the environment variable 
+        /// is undefined or empty.
+        /// </summary>
+        /// <returns>The default value of DAPR host.</returns>
+        private static string GetHost() 
+        {
+            if (host == null)
+            {
+                var envHost = Environment.GetEnvironmentVariable("DAPR_HOST");
+                host = string.IsNullOrEmpty(envHost) ? DaprDefaultHost : envHost;
+            }
+
+            return host;
+        }
     }
+
+#nullable enable
 }

--- a/test/Dapr.Shared.Test/Dapr.Shared.Test.csproj
+++ b/test/Dapr.Shared.Test/Dapr.Shared.Test.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <RootNamespace>Dapr.Shared</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\Shared\DaprDefaults.cs" Link="DaprDefaults.cs" />
+  </ItemGroup>
+
+</Project>
+

--- a/test/Dapr.Shared.Test/DaprDefaultsTest.cs
+++ b/test/Dapr.Shared.Test/DaprDefaultsTest.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Reflection;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Dapr.Shared.Test
+{
+    public class DaprDefaultsTest
+    {
+        private const string defaultDaprHost = "http://localhost";
+        private const string notDefaultDaprHost = "http://1.1.1.1";
+        private const string badDaprHost = "bad URL";
+
+        private const string defaultDaprHttpPort = "3500";
+        private const string defaultDaprHttpEndpoint = defaultDaprHost + ":" + defaultDaprHttpPort;
+        private const string notDefaultDaprHttpPort = "8888";
+        private const string badDaprHttpPort = "bad http port";
+
+        private const string defaultDaprGrpcPort = "50001";
+        private const string defaultDaprGrpcEndpoint = defaultDaprHost + ":" + defaultDaprGrpcPort;
+        private const string notDefaultDaprGrpcPort = "88888";
+        private const string badDaprGrpcPort = "bad grpc port";
+
+        public DaprDefaultsTest()
+        {
+            SetNonPublicStaticFieldValue(typeof(DaprDefaults), "host", null );
+            SetNonPublicStaticFieldValue(typeof(DaprDefaults), "httpEndpoint", null);
+            SetNonPublicStaticFieldValue(typeof(DaprDefaults), "grpcEndpoint", null);
+        }
+
+        [Theory]
+        [InlineData("", "", defaultDaprHttpEndpoint)]
+        [InlineData(null, null, defaultDaprHttpEndpoint)]
+        [InlineData(null, "", defaultDaprHttpEndpoint)]
+        [InlineData("", null, defaultDaprHttpEndpoint)]
+        [InlineData(notDefaultDaprHost, null, notDefaultDaprHost + ":" + defaultDaprHttpPort)]
+        [InlineData("", notDefaultDaprHttpPort, defaultDaprHost + ":" + notDefaultDaprHttpPort)]
+        [InlineData(notDefaultDaprHost, notDefaultDaprHttpPort, notDefaultDaprHost  + ":" + notDefaultDaprHttpPort)]
+        [InlineData(notDefaultDaprHost, badDaprHttpPort, notDefaultDaprHost + ":" + badDaprHttpPort)]
+        [InlineData(badDaprHost, notDefaultDaprHttpPort, badDaprHost + ":" + notDefaultDaprHttpPort)]
+        public void GetDefaultHttpEndpoint(string hostEnvironmentVar, string portEnvironmentVar, string expectedResult)
+        {
+            Environment.SetEnvironmentVariable("DAPR_HOST", hostEnvironmentVar);
+            Environment.SetEnvironmentVariable("DAPR_HTTP_PORT", portEnvironmentVar);
+
+            var defaultHttpEndpoint = DaprDefaults.GetDefaultHttpEndpoint();
+
+            Assert.Equal(expectedResult, defaultHttpEndpoint);
+        }
+
+        [Theory]
+        [InlineData("", "", defaultDaprGrpcEndpoint)]
+        [InlineData(null, null, defaultDaprGrpcEndpoint)]
+        [InlineData(null, "", defaultDaprGrpcEndpoint)]
+        [InlineData("", null, defaultDaprGrpcEndpoint)]
+        [InlineData(notDefaultDaprHost, null, notDefaultDaprHost + ":" + defaultDaprGrpcPort)]
+        [InlineData("", notDefaultDaprGrpcPort, defaultDaprHost + ":" + notDefaultDaprGrpcPort)]
+        [InlineData(notDefaultDaprHost, notDefaultDaprGrpcPort, notDefaultDaprHost + ":" + notDefaultDaprGrpcPort)]
+        [InlineData(notDefaultDaprHost, badDaprGrpcPort, notDefaultDaprHost + ":" + badDaprGrpcPort)]
+        [InlineData(badDaprHost, notDefaultDaprGrpcPort, badDaprHost + ":" + notDefaultDaprGrpcPort)]
+        public void GetDefaultGrpcEndpoint(string hostEnvironmentVar, string portEnvironmentVar, string expectedResult)
+        {
+            Environment.SetEnvironmentVariable("DAPR_HOST", hostEnvironmentVar);
+            Environment.SetEnvironmentVariable("DAPR_GRPC_PORT", portEnvironmentVar);
+
+            var defaultGrpcEndpoint = DaprDefaults.GetDefaultGrpcEndpoint();
+
+            Assert.Equal(expectedResult, defaultGrpcEndpoint);
+        }
+
+        private void SetNonPublicStaticFieldValue(Type type, string fieldName, object valueToSet) 
+        {
+            var field = type.GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic);
+            field?.SetValue(null, valueToSet);
+        }
+    }
+}


### PR DESCRIPTION
# Description

-  retrieve default value of DAPR sidecar host from DAPR_HOST environment variable
-  use localhost instead of 127.0.0.1 as DAPR sidecar host default value if the environment variable is not specified

## Issue reference

This PR will close: #1032 
