### PR TITLE
Remove .NET Core 3.1 support and standardize on .NET 6

### DIFF
--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -22,13 +22,11 @@ jobs:
         dotnet-version: ['6.0', '7.0']
         include:
         - dotnet-version: '6.0'
-          install-3: false
           display-name: '.NET 6.0'
           framework: 'net6'
           prefix: 'net6'
           install-version: '6.0.x'
         - dotnet-version: '7.0'
-          install-3: false
           display-name: '.NET 7.0'
           framework: 'net7'
           prefix: 'net7'

--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -19,14 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['3.1', '6.0', '7.0']
+        dotnet-version: ['6.0', '7.0']
         include:
-        - dotnet-version: '3.1'
-          install-3: true
-          display-name: '.NET Core 3.1'
-          framework: 'netcoreapp3.1'
-          prefix: 'netcoreapp31'
-          install-version: '3.1.x' # We always need a new .NET
         - dotnet-version: '6.0'
           install-3: false
           display-name: '.NET 6.0'

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -42,14 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['3.1', '6.0', '7.0']
+        dotnet-version: ['6.0', '7.0']
         include:
-        - dotnet-version: '3.1'
-          install-3: true
-          display-name: '.NET Core 3.1'
-          framework: 'netcoreapp3.1'
-          prefix: 'netcoreapp31'
-          install-version: '3.1.x' # We always need a new .NET
         - dotnet-version: '6.0'
           install-3: false
           display-name: '.NET 6.0'

--- a/examples/Actor/ActorClient/ActorClient.csproj
+++ b/examples/Actor/ActorClient/ActorClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Actor/DemoActor/DemoActor.csproj
+++ b/examples/Actor/DemoActor/DemoActor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Actor/IDemoActor/IDemoActor.csproj
+++ b/examples/Actor/IDemoActor/IDemoActor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/AspNetCore/ControllerSample/ControllerSample.csproj
+++ b/examples/AspNetCore/ControllerSample/ControllerSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/AspNetCore/ControllerSample/README.md
+++ b/examples/AspNetCore/ControllerSample/README.md
@@ -12,7 +12,7 @@ The application also registers for pub/sub with the `deposit`, `multideposit` an
 
 ## Prerequisitess
 
-- [.NET Core 3.1 or .NET 5+](https://dotnet.microsoft.com/download) installed
+- [.NET 6+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
+++ b/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
   </PropertyGroup>
 

--- a/examples/AspNetCore/GrpcServiceSample/README.md
+++ b/examples/AspNetCore/GrpcServiceSample/README.md
@@ -11,7 +11,7 @@ The application also registers for pub/sub with the `deposit` and `withdraw` top
 
 ## Prerequisitess
 
-- [.NET Core 3.1 or .NET 5+](https://dotnet.microsoft.com/download) installed
+- [.NET 6+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/AspNetCore/RoutingSample/README.md
+++ b/examples/AspNetCore/RoutingSample/README.md
@@ -12,7 +12,7 @@ The application also registers for pub/sub with the `deposit`, `multideposit`, a
 
 ## Prerequisites
 
-- [.NET Core 3.1 or .NET 5+](https://dotnet.microsoft.com/download) installed
+- [.NET 6+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/AspNetCore/SecretStoreConfigurationProviderSample/README.md
+++ b/examples/AspNetCore/SecretStoreConfigurationProviderSample/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET Core 3.1 or .NET 5+](https://dotnet.microsoft.com/download) installed
+- [.NET 6+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/AspNetCore/SecretStoreConfigurationProviderSample/SecretStoreConfigurationProviderSample.csproj
+++ b/examples/AspNetCore/SecretStoreConfigurationProviderSample/SecretStoreConfigurationProviderSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Client/ConfigurationApi/ConfigurationApi.csproj
+++ b/examples/Client/ConfigurationApi/ConfigurationApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
 

--- a/examples/Client/ConfigurationApi/README.md
+++ b/examples/Client/ConfigurationApi/README.md
@@ -9,7 +9,7 @@ It demonstrates the following APIs:
 
 ## Prerequisites
 
-- [.NET Core 3.1 or .NET 5+](https://dotnet.microsoft.com/download) installed
+- [.NET 6+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/DistributedLock/DistributedLock.csproj
+++ b/examples/Client/DistributedLock/DistributedLock.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
 

--- a/examples/Client/DistributedLock/README.md
+++ b/examples/Client/DistributedLock/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET Core 3.1 or .NET 5+](https://dotnet.microsoft.com/download) installed
+- [.NET 6+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/PublishSubscribe/BulkPublishEventExample/BulkPublishEventExample.csproj
+++ b/examples/Client/PublishSubscribe/BulkPublishEventExample/BulkPublishEventExample.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6</TargetFramework>
         <RootNamespace>Samples.Client</RootNamespace>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Client/PublishSubscribe/PublishEventExample/PublishEventExample.csproj
+++ b/examples/Client/PublishSubscribe/PublishEventExample/PublishEventExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Client/ServiceInvocation/README.md
+++ b/examples/Client/ServiceInvocation/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET Core 3.1 or .NET 5+](https://dotnet.microsoft.com/download) installed
+- [.NET 6+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/ServiceInvocation/ServiceInvocation.csproj
+++ b/examples/Client/ServiceInvocation/ServiceInvocation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Client/StateManagement/README.md
+++ b/examples/Client/StateManagement/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET Core 3.1 or .NET 5+](https://dotnet.microsoft.com/download) installed
+- [.NET 6+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/StateManagement/StateManagement.csproj
+++ b/examples/Client/StateManagement/StateManagement.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/properties/IsExternalInit.cs
+++ b/properties/IsExternalInit.cs
@@ -13,6 +13,5 @@ namespace System.Runtime.CompilerServices
     internal static class IsExternalInit
     {
     }
-
-    // This is a polyfill for init only properties in netcoreapp3.1
+    
 }

--- a/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
+++ b/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Dapr.Actors/Communication/ActorInvokeException.cs
+++ b/src/Dapr.Actors/Communication/ActorInvokeException.cs
@@ -93,7 +93,7 @@ namespace Dapr.Actors
             catch (Exception e)
             {
                 // swallowing the exception
-                logger?.LogWarning("RemoteException", "DeSerialization failed : Reason  {0}", e);
+                logger?.LogWarning("RemoteException: DeSerialization failed : Reason {0}", e);
             }
 
             result = null;

--- a/src/Dapr.Actors/Dapr.Actors.csproj
+++ b/src/Dapr.Actors/Dapr.Actors.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <!-- Additional Nuget package properties. -->

--- a/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
+++ b/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <!-- Additional Nuget package properties. -->

--- a/src/Dapr.Client/Dapr.Client.csproj
+++ b/src/Dapr.Client/Dapr.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -352,14 +352,10 @@ namespace Dapr.Client
             //
             // This approach avoids some common pitfalls that could lead to undesired encoding.
             var path = $"/v1.0/invoke/{appId}/method/{methodName.TrimStart('/')}";
-            var request = new HttpRequestMessage(httpMethod, new Uri(this.httpEndpoint, path))
-            {
-                Properties =
-                {
-                    { AppIdKey, appId },
-                    { MethodNameKey, methodName },
-                }
-            };
+            var request = new HttpRequestMessage(httpMethod, new Uri(this.httpEndpoint, path));
+            
+            request.Options.Set(new HttpRequestOptionsKey<string>(AppIdKey), appId);
+            request.Options.Set(new HttpRequestOptionsKey<string>(MethodNameKey), methodName);
 
             if (this.apiTokenHeader is not null)
             {
@@ -399,8 +395,8 @@ namespace Dapr.Client
             {
                 // Our code path for creating requests places these keys in the request properties. We don't want to fail
                 // if they are not present.
-                request.Properties.TryGetValue(AppIdKey, out var appId);
-                request.Properties.TryGetValue(MethodNameKey, out var methodName);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(AppIdKey), out var appId);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(MethodNameKey), out var methodName);
 
                 throw new InvocationException(
                     appId: appId as string,
@@ -423,8 +419,8 @@ namespace Dapr.Client
             {
                 // Our code path for creating requests places these keys in the request properties. We don't want to fail
                 // if they are not present.
-                request.Properties.TryGetValue(AppIdKey, out var appId);
-                request.Properties.TryGetValue(MethodNameKey, out var methodName);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(AppIdKey), out var appId);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(MethodNameKey), out var methodName);
 
                 throw new InvocationException(
                     appId: appId as string,
@@ -447,8 +443,8 @@ namespace Dapr.Client
             {
                 // Our code path for creating requests places these keys in the request properties. We don't want to fail
                 // if they are not present.
-                request.Properties.TryGetValue(AppIdKey, out var appId);
-                request.Properties.TryGetValue(MethodNameKey, out var methodName);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(AppIdKey), out var appId);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(MethodNameKey), out var methodName);
 
                 throw new InvocationException(
                     appId: appId as string,
@@ -465,8 +461,8 @@ namespace Dapr.Client
             {
                 // Our code path for creating requests places these keys in the request properties. We don't want to fail
                 // if they are not present.
-                request.Properties.TryGetValue(AppIdKey, out var appId);
-                request.Properties.TryGetValue(MethodNameKey, out var methodName);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(AppIdKey), out var appId);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(MethodNameKey), out var methodName);
 
                 throw new InvocationException(
                     appId: appId as string,
@@ -476,8 +472,8 @@ namespace Dapr.Client
             }
             catch (JsonException ex)
             {
-                request.Properties.TryGetValue(AppIdKey, out var appId);
-                request.Properties.TryGetValue(MethodNameKey, out var methodName);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(AppIdKey), out var appId);
+                request.Options.TryGetValue(new HttpRequestOptionsKey<string>(MethodNameKey), out var methodName);
 
                 throw new InvocationException(
                     appId: appId as string,

--- a/src/Dapr.Client/InvocationHandler.cs
+++ b/src/Dapr.Client/InvocationHandler.cs
@@ -117,7 +117,7 @@ namespace Dapr.Client
         }
 
         // Internal for testing
-        internal bool TryRewriteUri(Uri uri, [NotNullWhen(true)] out Uri? rewritten)
+        internal bool TryRewriteUri(Uri? uri, [NotNullWhen(true)] out Uri? rewritten)
         {
             // For now the only invalid cases are when the request URI is missing or just silly.
             // We may support additional cases for validation in the future (like an allow-list of App-Ids).

--- a/src/Dapr.Extensions.Configuration/Dapr.Extensions.Configuration.csproj
+++ b/src/Dapr.Extensions.Configuration/Dapr.Extensions.Configuration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -2,7 +2,7 @@
 
   <!-- NuGet configuration -->
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageId>Dapr.Workflow</PackageId>
     <Title>Dapr Workflow Authoring SDK</Title>

--- a/test/Dapr.Actors.AspNetCore.IntegrationTest.App/Dapr.Actors.AspNetCore.IntegrationTest.App.csproj
+++ b/test/Dapr.Actors.AspNetCore.IntegrationTest.App/Dapr.Actors.AspNetCore.IntegrationTest.App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.Actors.AspNetCore.Test/Dapr.Actors.AspNetCore.Test.csproj
+++ b/test/Dapr.Actors.AspNetCore.Test/Dapr.Actors.AspNetCore.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
     <BaseNamespace>Dapr.Actors.AspNetCore</BaseNamespace>
   </PropertyGroup>
 

--- a/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
+++ b/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
     <RootNamespace>Dapr.Actors</RootNamespace>
     <DefineConstants>$(DefineConstants);ACTORS</DefineConstants>
   </PropertyGroup>

--- a/test/Dapr.AspNetCore.IntegrationTest.App/Dapr.AspNetCore.IntegrationTest.App.csproj
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/Dapr.AspNetCore.IntegrationTest.App.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.AspNetCore.Test/Dapr.AspNetCore.Test.csproj
+++ b/test/Dapr.AspNetCore.Test/Dapr.AspNetCore.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.Client.Test/Dapr.Client.Test.csproj
+++ b/test/Dapr.Client.Test/Dapr.Client.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.E2E.Test.Actors/Dapr.E2E.Test.Actors.csproj
+++ b/test/Dapr.E2E.Test.Actors/Dapr.E2E.Test.Actors.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.E2E.Test.App.Grpc/Dapr.E2E.Test.App.Grpc.csproj
+++ b/test/Dapr.E2E.Test.App.Grpc/Dapr.E2E.Test.App.Grpc.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.39.0" />

--- a/test/Dapr.E2E.Test.App.ReentrantActor/Dapr.E2E.Test.App.ReentrantActors.csproj
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/Dapr.E2E.Test.App.ReentrantActors.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Dapr.E2E.Test.App.ReentrantActor' " />

--- a/test/Dapr.E2E.Test.App/Dapr.E2E.Test.App.csproj
+++ b/test/Dapr.E2E.Test.App/Dapr.E2E.Test.App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
+++ b/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />

--- a/test/Dapr.E2E.Test/DaprTestApp.cs
+++ b/test/Dapr.E2E.Test/DaprTestApp.cs
@@ -128,11 +128,7 @@ namespace Dapr.E2E.Test
         {
             var targetFrameworkName = ((TargetFrameworkAttribute)Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(TargetFrameworkAttribute), false).FirstOrDefault()).FrameworkName;
             string frameworkMoniker;
-            if (targetFrameworkName == ".NETCoreApp,Version=v3.1")
-            {
-                frameworkMoniker = "netcoreapp3.1";
-            }
-            else if (targetFrameworkName == ".NETCoreApp,Version=v5.0")
+            if (targetFrameworkName == ".NETCoreApp,Version=v5.0")
             {
                 frameworkMoniker = "net5";
             }

--- a/test/Dapr.E2E.Test/DaprTestApp.cs
+++ b/test/Dapr.E2E.Test/DaprTestApp.cs
@@ -128,11 +128,7 @@ namespace Dapr.E2E.Test
         {
             var targetFrameworkName = ((TargetFrameworkAttribute)Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(TargetFrameworkAttribute), false).FirstOrDefault()).FrameworkName;
             string frameworkMoniker;
-            if (targetFrameworkName == ".NETCoreApp,Version=v5.0")
-            {
-                frameworkMoniker = "net5";
-            }
-            else if (targetFrameworkName == ".NETCoreApp,Version=v6.0")
+            if (targetFrameworkName == ".NETCoreApp,Version=v6.0")
             {
                 frameworkMoniker = "net6";
             }

--- a/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
+++ b/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

Remove .NET Core 3.1 support and standardize on .NET 6

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: https://github.com/dapr/dotnet-sdk/issues/1036

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
