### PR TITLE
[Workflow] Proper workflow retry support in Dapr SDK

### DIFF
--- a/examples/Workflow/WorkflowConsoleApp/Activities/ReserveInventoryActivity.cs
+++ b/examples/Workflow/WorkflowConsoleApp/Activities/ReserveInventoryActivity.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Dapr.Client;
+﻿using Dapr.Client;
 using Dapr.Workflow;
 using Microsoft.Extensions.Logging;
 using WorkflowConsoleApp.Models;
@@ -27,7 +26,7 @@ namespace WorkflowConsoleApp.Activities
                 req.ItemName);
 
             // Ensure that the store has items
-            InventoryItem item = await client.GetStateAsync<InventoryItem>(
+            InventoryItem item = await this.client.GetStateAsync<InventoryItem>(
                 storeName,
                 req.ItemName.ToLowerInvariant());
 

--- a/examples/Workflow/WorkflowConsoleApp/Activities/UpdateInventoryActivity.cs
+++ b/examples/Workflow/WorkflowConsoleApp/Activities/UpdateInventoryActivity.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Dapr.Client;
+﻿using Dapr.Client;
 using Dapr.Workflow;
 using WorkflowConsoleApp.Models;
 using Microsoft.Extensions.Logging;

--- a/examples/Workflow/WorkflowUnitTest/OrderProcessingTests.cs
+++ b/examples/Workflow/WorkflowUnitTest/OrderProcessingTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Dapr.Workflow;
-using Microsoft.DurableTask;
 using Moq;
 using WorkflowConsoleApp.Activities;
 using WorkflowConsoleApp.Models;
@@ -24,7 +23,7 @@ namespace WorkflowUnitTest
             // Mock the call to ReserveInventoryActivity
             Mock<WorkflowContext> mockContext = new();
             mockContext
-                .Setup(ctx => ctx.CallActivityAsync<InventoryResult>(nameof(ReserveInventoryActivity), It.IsAny<InventoryRequest>(), It.IsAny<TaskOptions>()))
+                .Setup(ctx => ctx.CallActivityAsync<InventoryResult>(nameof(ReserveInventoryActivity), It.IsAny<InventoryRequest>(), It.IsAny<WorkflowTaskOptions>()))
                 .Returns(Task.FromResult(inventoryResult));
 
             // Run the workflow directly
@@ -36,17 +35,17 @@ namespace WorkflowUnitTest
 
             // Verify that ReserveInventoryActivity was called with a specific input
             mockContext.Verify(
-                ctx => ctx.CallActivityAsync<InventoryResult>(nameof(ReserveInventoryActivity), expectedInventoryRequest, It.IsAny<TaskOptions>()),
+                ctx => ctx.CallActivityAsync<InventoryResult>(nameof(ReserveInventoryActivity), expectedInventoryRequest, It.IsAny<WorkflowTaskOptions>()),
                 Times.Once());
 
             // Verify that ProcessPaymentActivity was called with a specific input
             mockContext.Verify(
-                ctx => ctx.CallActivityAsync(nameof(ProcessPaymentActivity), expectedPaymentRequest, It.IsAny<TaskOptions>()),
+                ctx => ctx.CallActivityAsync(nameof(ProcessPaymentActivity), expectedPaymentRequest, It.IsAny<WorkflowTaskOptions>()),
                 Times.Once());
 
             // Verify that there were two calls to NotifyActivity
             mockContext.Verify(
-                ctx => ctx.CallActivityAsync(nameof(NotifyActivity), It.IsAny<Notification>(), It.IsAny<TaskOptions>()),
+                ctx => ctx.CallActivityAsync(nameof(NotifyActivity), It.IsAny<Notification>(), It.IsAny<WorkflowTaskOptions>()),
                 Times.Exactly(2));
         }
 
@@ -61,7 +60,7 @@ namespace WorkflowUnitTest
             // Mock the call to ReserveInventoryActivity
             Mock<WorkflowContext> mockContext = new();
             mockContext
-                .Setup(ctx => ctx.CallActivityAsync<InventoryResult>(nameof(ReserveInventoryActivity), It.IsAny<InventoryRequest>(), It.IsAny<TaskOptions>()))
+                .Setup(ctx => ctx.CallActivityAsync<InventoryResult>(nameof(ReserveInventoryActivity), It.IsAny<InventoryRequest>(), It.IsAny<WorkflowTaskOptions>()))
                 .Returns(Task.FromResult(inventoryResult));
 
             // Run the workflow directly
@@ -69,17 +68,17 @@ namespace WorkflowUnitTest
 
             // Verify that ReserveInventoryActivity was called with a specific input
             mockContext.Verify(
-                ctx => ctx.CallActivityAsync<InventoryResult>(nameof(ReserveInventoryActivity), expectedInventoryRequest, It.IsAny<TaskOptions>()),
+                ctx => ctx.CallActivityAsync<InventoryResult>(nameof(ReserveInventoryActivity), expectedInventoryRequest, It.IsAny<WorkflowTaskOptions>()),
                 Times.Once());
 
             // Verify that ProcessPaymentActivity was never called
             mockContext.Verify(
-                ctx => ctx.CallActivityAsync(nameof(ProcessPaymentActivity), It.IsAny<PaymentRequest>(), It.IsAny<TaskOptions>()),
+                ctx => ctx.CallActivityAsync(nameof(ProcessPaymentActivity), It.IsAny<PaymentRequest>(), It.IsAny<WorkflowTaskOptions>()),
                 Times.Never());
 
             // Verify that there were two calls to NotifyActivity
             mockContext.Verify(
-                ctx => ctx.CallActivityAsync(nameof(NotifyActivity), It.IsAny<Notification>(), It.IsAny<TaskOptions>()),
+                ctx => ctx.CallActivityAsync(nameof(NotifyActivity), It.IsAny<Notification>(), It.IsAny<WorkflowTaskOptions>()),
                 Times.Exactly(2));
         }
     }

--- a/src/Dapr.Workflow/DaprWorkflowContext.cs
+++ b/src/Dapr.Workflow/DaprWorkflowContext.cs
@@ -35,14 +35,14 @@ namespace Dapr.Workflow
 
         public override bool IsReplaying => this.innerContext.IsReplaying;
 
-        public override Task CallActivityAsync(string name, object? input = null, TaskOptions? options = null)
+        public override Task CallActivityAsync(string name, object? input = null, WorkflowTaskOptions? options = null)
         {
-            return WrapExceptions(this.innerContext.CallActivityAsync(name, input, options));
+            return WrapExceptions(this.innerContext.CallActivityAsync(name, input, options?.ToDurableTaskOptions()));
         }
 
-        public override Task<T> CallActivityAsync<T>(string name, object? input = null, TaskOptions? options = null)
+        public override Task<T> CallActivityAsync<T>(string name, object? input = null, WorkflowTaskOptions? options = null)
         {
-            return WrapExceptions(this.innerContext.CallActivityAsync<T>(name, input, options));
+            return WrapExceptions(this.innerContext.CallActivityAsync<T>(name, input, options?.ToDurableTaskOptions()));
         }
 
         public override Task CreateTimer(TimeSpan delay, CancellationToken cancellationToken = default)
@@ -75,14 +75,14 @@ namespace Dapr.Workflow
             this.innerContext.SetCustomStatus(customStatus);
         }
 
-        public override Task<TResult> CallChildWorkflowAsync<TResult>(string workflowName, object? input = null, TaskOptions? options = null)
+        public override Task<TResult> CallChildWorkflowAsync<TResult>(string workflowName, object? input = null, ChildWorkflowTaskOptions? options = null)
         {
-            return WrapExceptions(this.innerContext.CallSubOrchestratorAsync<TResult>(workflowName, input, options));
+            return WrapExceptions(this.innerContext.CallSubOrchestratorAsync<TResult>(workflowName, input, options?.ToDurableTaskOptions()));
         }
 
-        public override Task CallChildWorkflowAsync(string workflowName, object? input = null, TaskOptions? options = null)
+        public override Task CallChildWorkflowAsync(string workflowName, object? input = null, ChildWorkflowTaskOptions? options = null)
         {
-            return WrapExceptions(this.innerContext.CallSubOrchestratorAsync(workflowName, input, options));
+            return WrapExceptions(this.innerContext.CallSubOrchestratorAsync(workflowName, input, options?.ToDurableTaskOptions()));
         }
 
         public override void ContinueAsNew(object? newInput = null, bool preserveUnprocessedEvents = true)

--- a/src/Dapr.Workflow/WorkflowContext.cs
+++ b/src/Dapr.Workflow/WorkflowContext.cs
@@ -16,7 +16,6 @@ namespace Dapr.Workflow
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.DurableTask;
 
     /// <summary>
     /// Context object used by workflow implementations to perform actions such as scheduling activities, durable timers, waiting for
@@ -101,7 +100,7 @@ namespace Dapr.Workflow
         /// The activity failed with an unhandled exception. The details of the failure can be found in the
         /// <see cref="WorkflowTaskFailedException.FailureDetails"/> property.
         /// </exception>
-        public virtual Task CallActivityAsync(string name, object? input = null, TaskOptions? options = null)
+        public virtual Task CallActivityAsync(string name, object? input = null, WorkflowTaskOptions? options = null)
         {
             return this.CallActivityAsync<object>(name, input, options);
         }
@@ -110,7 +109,7 @@ namespace Dapr.Workflow
         /// A task that completes when the activity completes or fails. The result of the task is the activity's return value.
         /// </returns>
         /// <inheritdoc cref="CallActivityAsync"/>
-        public abstract Task<T> CallActivityAsync<T>(string name, object? input = null, TaskOptions? options = null);
+        public abstract Task<T> CallActivityAsync<T>(string name, object? input = null, WorkflowTaskOptions? options = null);
 
         /// <summary>
         /// Creates a durable timer that expires after the specified delay.
@@ -212,8 +211,11 @@ namespace Dapr.Workflow
         /// <typeparam name="TResult">
         /// The type into which to deserialize the child workflow's output.
         /// </typeparam>
-        /// <inheritdoc cref="CallChildWorkflowAsync(string, object?, TaskOptions?)"/>
-        public abstract Task<TResult> CallChildWorkflowAsync<TResult>(string workflowName, object? input = null, TaskOptions? options = null);
+        /// <inheritdoc cref="CallChildWorkflowAsync(string, object?, ChildWorkflowTaskOptions?)"/>
+        public abstract Task<TResult> CallChildWorkflowAsync<TResult>(
+            string workflowName,
+            object? input = null,
+            ChildWorkflowTaskOptions? options = null);
 
         /// <summary>
         /// Executes the specified workflow as a child workflow.
@@ -222,7 +224,8 @@ namespace Dapr.Workflow
         /// <para>
         /// In addition to activities, workflows can schedule other workflows as <i>child workflows</i>.
         /// A child workflow has its own instance ID, history, and status that is independent of the parent workflow
-        /// that started it.
+        /// that started it. You can use <see cref="ChildWorkflowTaskOptions.InstanceId" /> to specify an instance ID
+        /// for the child workflow. Otherwise, the instance ID will be randomly generated.
         /// </para><para>
         /// Child workflows have many benefits:
         /// <list type="bullet">
@@ -237,15 +240,14 @@ namespace Dapr.Workflow
         /// exception. Child workflows also support automatic retry policies.
         /// </para><para>
         /// Because child workflows are independent of their parents, terminating a parent workflow does not affect
-        /// any child workflows. You must terminate each child workflow independently using its instance ID, which is
-        /// specified by supplying <see cref="SubOrchestrationOptions" /> in place of <see cref="TaskOptions" />.
+        /// any child workflows. You must terminate each child workflow independently using its instance ID, which
+        /// is specified by <see cref="ChildWorkflowTaskOptions.InstanceId" />.
         /// </para>
         /// </remarks>
         /// <param name="workflowName">The name of the workflow to call.</param>
         /// <param name="input">The serializable input to pass to the child workflow.</param>
         /// <param name="options">
-        /// Additional options that control the execution and processing of the child workflow. Callers can choose to
-        /// supply the derived type <see cref="SubOrchestrationOptions" />.
+        /// Additional options that control the execution and processing of the child workflow.
         /// </param>
         /// <returns>A task that completes when the child workflow completes or fails.</returns>
         /// <exception cref="ArgumentException">The specified workflow does not exist.</exception>
@@ -256,7 +258,10 @@ namespace Dapr.Workflow
         /// The child workflow failed with an unhandled exception. The details of the failure can be found in the
         /// <see cref="WorkflowTaskFailedException.FailureDetails"/> property.
         /// </exception>
-        public virtual Task CallChildWorkflowAsync(string workflowName, object? input = null, TaskOptions? options = null)
+        public virtual Task CallChildWorkflowAsync(
+            string workflowName,
+            object? input = null,
+            ChildWorkflowTaskOptions? options = null)
         {
             return this.CallChildWorkflowAsync<object>(workflowName, input, options);
         }

--- a/src/Dapr.Workflow/WorkflowRetryPolicy.cs
+++ b/src/Dapr.Workflow/WorkflowRetryPolicy.cs
@@ -1,0 +1,104 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+using System;
+using System.Threading;
+using Microsoft.DurableTask;
+
+namespace Dapr.Workflow
+{
+    /// <summary>
+    /// A declarative retry policy that can be configured for activity or child workflow calls.
+    /// </summary>
+    public class WorkflowRetryPolicy
+    {
+        readonly RetryPolicy durableRetryPolicy;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkflowRetryPolicy"/> class.
+        /// </summary>
+        /// <param name="maxNumberOfAttempts">The maximum number of task invocation attempts. Must be 1 or greater.</param>
+        /// <param name="firstRetryInterval">The amount of time to delay between the first and second attempt.</param>
+        /// <param name="backoffCoefficient">
+        /// The exponential back-off coefficient used to determine the delay between subsequent retries. Must be 1.0 or greater.
+        /// </param>
+        /// <param name="maxRetryInterval">
+        /// The maximum time to delay between attempts, regardless of<paramref name="backoffCoefficient"/>.
+        /// </param>
+        /// <param name="retryTimeout">The overall timeout for retries.</param>
+        /// <remarks>
+        /// The value <see cref="Timeout.InfiniteTimeSpan"/> can be used to specify an unlimited timeout for
+        /// <paramref name="maxRetryInterval"/> or <paramref name="retryTimeout"/>.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if any of the following are true:
+        /// <list type="bullet">
+        ///   <item>The value for <paramref name="maxNumberOfAttempts"/> is less than or equal to zero.</item>
+        ///   <item>The value for <paramref name="firstRetryInterval"/> is less than or equal to <see cref="TimeSpan.Zero"/>.</item>
+        ///   <item>The value for <paramref name="backoffCoefficient"/> is less than 1.0.</item>
+        ///   <item>The value for <paramref name="maxRetryInterval"/> is less than <paramref name="firstRetryInterval"/>.</item>
+        ///   <item>The value for <paramref name="retryTimeout"/> is less than <paramref name="firstRetryInterval"/>.</item>
+        /// </list>
+        /// </exception>
+        public WorkflowRetryPolicy(
+            int maxNumberOfAttempts,
+            TimeSpan firstRetryInterval,
+            double backoffCoefficient = 1.0,
+            TimeSpan? maxRetryInterval = null,
+            TimeSpan? retryTimeout = null)
+        {
+            this.durableRetryPolicy = new RetryPolicy(
+                maxNumberOfAttempts,
+                firstRetryInterval,
+                backoffCoefficient,
+                maxRetryInterval,
+                retryTimeout);
+        }
+
+        /// <summary>
+        /// Gets the max number of attempts for executing a given task.
+        /// </summary>
+        public int MaxNumberOfAttempts => this.durableRetryPolicy.MaxNumberOfAttempts;
+
+        /// <summary>
+        /// Gets the amount of time to delay between the first and second attempt.
+        /// </summary>
+        public TimeSpan FirstRetryInterval => this.durableRetryPolicy.FirstRetryInterval;
+
+        /// <summary>
+        /// Gets the exponential back-off coefficient used to determine the delay between subsequent retries.
+        /// </summary>
+        /// <value>
+        /// Defaults to 1.0 for no back-off.
+        /// </value>
+        public double BackoffCoefficient => this.durableRetryPolicy.BackoffCoefficient;
+
+        /// <summary>
+        /// Gets the maximum time to delay between attempts.
+        /// </summary>
+        /// <value>
+        /// Defaults to 1 hour.
+        /// </value>
+        public TimeSpan MaxRetryInterval => this.durableRetryPolicy.MaxRetryInterval;
+
+        /// <summary>
+        /// Gets the overall timeout for retries. No further attempts will be made at executing a task after this retry
+        /// timeout expires.
+        /// </summary>
+        /// <value>
+        /// Defaults to <see cref="Timeout.InfiniteTimeSpan"/>.
+        /// </value>
+        public TimeSpan RetryTimeout => this.durableRetryPolicy.RetryTimeout;
+
+        internal RetryPolicy GetDurableRetryPolicy() => this.durableRetryPolicy;
+    }
+}

--- a/src/Dapr.Workflow/WorkflowTaskOptions.cs
+++ b/src/Dapr.Workflow/WorkflowTaskOptions.cs
@@ -1,0 +1,68 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Microsoft.DurableTask;
+
+namespace Dapr.Workflow
+{
+    /// <summary>
+    /// Options that can be used to control the behavior of workflow task execution.
+    /// </summary>
+    /// <param name="RetryPolicy">The workflow retry policy.</param>
+    public record WorkflowTaskOptions(WorkflowRetryPolicy? RetryPolicy = null)
+    {
+        internal TaskOptions ToDurableTaskOptions()
+        {
+            TaskRetryOptions? retryOptions = null;
+            if (this.RetryPolicy is not null)
+            {
+                retryOptions = this.RetryPolicy.GetDurableRetryPolicy();
+            }
+
+            return new TaskOptions(retryOptions);
+        }
+    }
+
+    /// <summary>
+    /// Options for controlling the behavior of child workflow execution.
+    /// </summary>
+    public record ChildWorkflowTaskOptions : WorkflowTaskOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChildWorkflowTaskOptions"/> record.
+        /// </summary>
+        /// <param name="instanceId">The instance ID to use for the child workflow.</param>
+        /// <param name="retryPolicy">The child workflow's retry policy.</param>
+        public ChildWorkflowTaskOptions(string? instanceId = null, WorkflowRetryPolicy ? retryPolicy = null)
+            : base(retryPolicy)
+        {
+            this.InstanceId = instanceId;
+        }
+
+        /// <summary>
+        /// Gets the instance ID to use when creating a child workflow.
+        /// </summary>
+        public string? InstanceId { get; init; }
+
+        internal new SubOrchestrationOptions ToDurableTaskOptions()
+        {
+            TaskRetryOptions? retryOptions = null;
+            if (this.RetryPolicy is not null)
+            {
+                retryOptions = this.RetryPolicy.GetDurableRetryPolicy();
+            }
+
+            return new SubOrchestrationOptions(retryOptions, this.InstanceId);
+        }
+    }
+}


### PR DESCRIPTION
# Description

The Dapr Workflows SDK didn't have its own types for managing workflow retry policies. Instead, it relied on types defined in the underlying Durable Task SDK. This was bad/confusing because we want to keep the Durable Task SDK an internal implementation detail as much as possible.

With this change, we can now properly document how to implement retry policies for workflows using the .NET SDK.

A few notes about the feature:

* Retry policies can be applied to activities or child workflows
* Workflow task retry policies are durable and survive process crashes. For example, if you have a policy to retry only 3 times, and your workflow crashes after the second retry, when it comes back up, it will do only one more retry before giving up.
* Workflow retry policies are not at all related to Dapr Resiliency policies, but you can compose the two together if you want.
* Retry policies allow you to specify the following:
  * Max number of attempts
  * First retry interval
  * Backoff coefficient
  * Max retry interval
  * Total retry timeout

FYI @nyemade-uversky @DeepanshuA @halspang 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
