### PR TITLE
adding get actor reminder API in docs

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-howto.md
@@ -81,6 +81,7 @@ Define `IMyActor` interface and `MyData` data object. Paste the following code i
 
 ```csharp
 using Dapr.Actors;
+using Dapr.Actors.Runtime;
 using System.Threading.Tasks;
 
 namespace MyActor.Interfaces
@@ -91,6 +92,7 @@ namespace MyActor.Interfaces
         Task<MyData> GetDataAsync();
         Task RegisterReminder();
         Task UnregisterReminder();
+        Task<IActorReminder> GetReminder();
         Task RegisterTimer();
         Task UnregisterTimer();
     }
@@ -217,6 +219,14 @@ namespace MyActorService
                 null,                      // User state passed to IRemindable.ReceiveReminderAsync()
                 TimeSpan.FromSeconds(5),   // Time to delay before invoking the reminder for the first time
                 TimeSpan.FromSeconds(5));  // Time interval between reminder invocations after the first invocation
+        }
+
+        /// <summary>
+        /// Get MyReminder reminder details with the actor
+        /// </summary>
+        public async Task<IActorReminder> GetReminder()
+        {
+            await this.GetReminderAsync("MyReminder");
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

It adds the get  actor reminder API in docs. The API implementation is merged in release-1.11 in #1103. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
