### PR TITLE
[Workflow] Fix issue with ignored external event payload

### DIFF
--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -105,16 +105,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Parse release version
         run: python ./.github/scripts/get_release_version.py
-      - name: Install Local kafka using docker-compose
-        run: |
-          docker-compose -f test/Dapr.E2E.Test/deploy/local-test-kafka.yml up -d
-          docker ps
-      - name: Install Local Hashicorp Vault using docker-compose
-        run: |
-          docker-compose -f test/Dapr.E2E.Test/deploy/local-test-vault.yml up -d
-          docker ps
-      - name: Setup Vault's test token
-        run: echo myroot > /tmp/.hashicorp_vault_token
       - name: Setup ${{ matrix.display-name }}
         uses: actions/setup-dotnet@v1
         with:

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -7,7 +7,7 @@
     <PackageId>Dapr.Workflow</PackageId>
     <Title>Dapr Workflow Authoring SDK</Title>
     <Description>Dapr Workflow SDK for building workflows as code with Dapr</Description>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.0" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.0" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.0.*" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dapr.Workflow/DaprWorkflowClient.cs
+++ b/src/Dapr.Workflow/DaprWorkflowClient.cs
@@ -135,7 +135,7 @@ namespace Dapr.Workflow
         /// <inheritdoc cref="WaitForWorkflowStartAsync(string, bool, CancellationToken)"/>
         public async Task<WorkflowState> WaitForWorkflowCompletionAsync(
             string instanceId,
-            bool getInputsAndOutputs = false,
+            bool getInputsAndOutputs = true,
             CancellationToken cancellation = default)
         {
             OrchestrationMetadata metadata = await this.innerClient.WaitForInstanceCompletionAsync(
@@ -218,7 +218,7 @@ namespace Dapr.Workflow
             object? eventPayload = null,
             CancellationToken cancellation = default)
         {
-            return this.innerClient.RaiseEventAsync(instanceId, eventName, cancellation);
+            return this.innerClient.RaiseEventAsync(instanceId, eventName, eventPayload, cancellation);
         }
 
         /// <summary>

--- a/src/Dapr.Workflow/DaprWorkflowClient.cs
+++ b/src/Dapr.Workflow/DaprWorkflowClient.cs
@@ -70,9 +70,9 @@ namespace Dapr.Workflow
         /// <param name="instanceId">The unique ID of the workflow instance to fetch.</param>
         /// <param name="getInputsAndOutputs">
         /// Specify <c>true</c> to fetch the workflow instance's inputs, outputs, and custom status, or <c>false</c> to
-        /// omit them. Defaults to false.
+        /// omit them. Defaults to true.
         /// </param>
-        public async Task<WorkflowState> GetWorkflowStateAsync(string instanceId, bool getInputsAndOutputs = false)
+        public async Task<WorkflowState> GetWorkflowStateAsync(string instanceId, bool getInputsAndOutputs = true)
         {
             OrchestrationMetadata? metadata = await this.innerClient.GetInstancesAsync(
                 instanceId,
@@ -94,7 +94,7 @@ namespace Dapr.Workflow
         /// <param name="instanceId">The unique ID of the workflow instance to wait for.</param>
         /// <param name="getInputsAndOutputs">
         /// Specify <c>true</c> to fetch the workflow instance's inputs, outputs, and custom status, or <c>false</c> to
-        /// omit them. The default value is <c>false</c> to minimize the network bandwidth, serialization, and memory costs
+        /// omit them. Setting this value to <c>false</c> can help minimize the network bandwidth, serialization, and memory costs
         /// associated with fetching the instance metadata.
         /// </param>
         /// <param name="cancellation">A <see cref="CancellationToken"/> that can be used to cancel the wait operation.</param>
@@ -104,7 +104,7 @@ namespace Dapr.Workflow
         /// </returns>
         public async Task<WorkflowState> WaitForWorkflowStartAsync(
             string instanceId,
-            bool getInputsAndOutputs = false,
+            bool getInputsAndOutputs = true,
             CancellationToken cancellation = default)
         {
             OrchestrationMetadata metadata = await this.innerClient.WaitForInstanceStartAsync(


### PR DESCRIPTION
# Description

In https://github.com/dapr/dapr/issues/6614, a user observed that the `RaiseEventAsync` method was always resulting in a null payload in the workflow code. This PR fixes the issue, which is isolated to the Dapr Workflow SDK.

I also made a couple other small changes as part of this PR:

* Bumped the Durable Task SDK dependency to the latest patch release.
* Changed the default `getInputsAndOutputs` to `true` for the workflow status query APIs (I decided to do this to improve usability after some frustration while setting up the local repro for the raise event issue)

I also updated the Workflow SDK nuget version to `0.3.0`.

## Issue reference

Closes https://github.com/dapr/dapr/issues/6614

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
