### PR TITLE
set dapr-api-token to healthz requests when needed

### DIFF
--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -1743,6 +1743,12 @@ namespace Dapr.Client
         {
             var path = "/v1.0/healthz";
             var request = new HttpRequestMessage(HttpMethod.Get, new Uri(this.httpEndpoint, path));
+
+            if (this.apiTokenHeader is not null)
+            {
+                request.Headers.Add(this.apiTokenHeader.Value.Key, this.apiTokenHeader.Value.Value);
+            }
+
             try
             {
                 using var response = await this.httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
@@ -1759,6 +1765,12 @@ namespace Dapr.Client
         {
             var path = "/v1.0/healthz/outbound";
             var request = new HttpRequestMessage(HttpMethod.Get, new Uri(this.httpEndpoint, path));
+
+            if (this.apiTokenHeader is not null)
+            {
+                request.Headers.Add(this.apiTokenHeader.Value.Key, this.apiTokenHeader.Value.Value);
+            }
+
             try
             {
                 using var response = await this.httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);


### PR DESCRIPTION
# Description

Implements the changes for https://github.com/dapr/dotnet-sdk/issues/1144

I followed the same pattern that is used in `CreateInvokeMethodRequest` which is the only other related to the use of the http client being used for the healthz requests.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1144

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation

I think this changes don't require docs or test changes... existing tests and docs already cover this behaviour