### PR TITLE
Updating workflow API to no longer point to alpha API

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-workflow/dotnet-workflow-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-workflow/dotnet-workflow-howto.md
@@ -83,7 +83,7 @@ Run the following command to start a workflow.
 {{% codetab %}}
 
 ```bash
-curl -i -X POST http://localhost:3500/v1.0-alpha1/workflows/dapr/OrderProcessingWorkflow/start?instanceID=12345678 \
+curl -i -X POST http://localhost:3500/workflows/dapr/OrderProcessingWorkflow/start?instanceID=12345678 \
   -H "Content-Type: application/json" \
   -d '{"Name": "Paperclips", "TotalCost": 99.95, "Quantity": 1}'
 ```
@@ -93,7 +93,7 @@ curl -i -X POST http://localhost:3500/v1.0-alpha1/workflows/dapr/OrderProcessing
 {{% codetab %}}
 
 ```powershell
-curl -i -X POST http://localhost:3500/v1.0-alpha1/workflows/dapr/OrderProcessingWorkflow/start?instanceID=12345678 `
+curl -i -X POST http://localhost:3500/workflows/dapr/OrderProcessingWorkflow/start?instanceID=12345678 `
   -H "Content-Type: application/json" `
   -d '{"Name": "Paperclips", "TotalCost": 99.95, "Quantity": 1}'
 ```
@@ -111,7 +111,7 @@ If successful, you should see a response like the following:
 Send an HTTP request to get the status of the workflow that was started:
 
 ```bash
-curl -i -X GET http://localhost:3500/v1.0-alpha1/workflows/dapr/12345678
+curl -i -X GET http://localhost:3500/workflows/dapr/12345678
 ```
 
 The workflow is designed to take several seconds to complete. If the workflow hasn't completed when you issue the HTTP request, you'll see the following JSON response (formatted for readability) with workflow status as `RUNNING`:

--- a/examples/Workflow/README.md
+++ b/examples/Workflow/README.md
@@ -49,7 +49,7 @@ For the workflow API option, two identical `curl` commands are shown, one for Li
 Make note of the "1234" in the commands below. This represents the unique identifier for the workflow run and can be replaced with any identifier of your choosing.
 
 ```bash
-curl -i -X POST http://localhost:3500/v1.0-alpha1/workflows/dapr/OrderProcessingWorkflow/start?instanceID=1234 \
+curl -i -X POST http://localhost:3500/workflows/dapr/OrderProcessingWorkflow/start?instanceID=1234 \
   -H "Content-Type: application/json" \
   -d '{"Name": "Paperclips", "TotalCost": 99.95, "Quantity": 1}'
 ```
@@ -57,7 +57,7 @@ curl -i -X POST http://localhost:3500/v1.0-alpha1/workflows/dapr/OrderProcessing
 On Windows (PowerShell):
 
 ```powershell
-curl -i -X POST http://localhost:3500/v1.0-alpha1/workflows/dapr/OrderProcessingWorkflow/start?instanceID=1234 `
+curl -i -X POST http://localhost:3500/workflows/dapr/OrderProcessingWorkflow/start?instanceID=1234 `
   -H "Content-Type: application/json" `
   -d '{"Name": "Paperclips", "TotalCost": 99.95, "Quantity": 1}'
 ```
@@ -71,7 +71,7 @@ If successful, you should see a response like the following:
 Next, send an HTTP request to get the status of the workflow that was started:
 
 ```bash
-curl -i -X GET http://localhost:3500/v1.0-alpha1/workflows/dapr/1234
+curl -i -X GET http://localhost:3500/workflows/dapr/1234
 ```
 
 The workflow is designed to take several seconds to complete. If the workflow hasn't completed yet when you issue the previous command, you should see the following JSON response (formatted for readability):

--- a/examples/Workflow/WorkflowConsoleApp/demo.http
+++ b/examples/Workflow/WorkflowConsoleApp/demo.http
@@ -1,17 +1,17 @@
 ### Start order processing workflow - replace xxx with any id you like
-POST http://localhost:3500/v1.0-alpha1/workflows/dapr/OrderProcessingWorkflow/start?instanceID=xxx
+POST http://localhost:3500/workflows/dapr/OrderProcessingWorkflow/start?instanceID=xxx
 Content-Type: application/json
 
 {"Name": "Paperclips", "TotalCost": 99.95, "Quantity": 1}
 
 ### Start order processing workflow - replace xxx with any id you like
-POST http://localhost:3500/v1.0-alpha1/workflows/dapr/OrderProcessingWorkflow/start?instanceID=xxx
+POST http://localhost:3500/workflows/dapr/OrderProcessingWorkflow/start?instanceID=xxx
 Content-Type: application/json
 
 {"Name": "Cars", "TotalCost": 10000, "Quantity": 30}
 
 ### Query dapr sidecar - replace xxx with id from the workflow you've created above
-GET http://localhost:3500/v1.0-alpha1/workflows/dapr/xxx
+GET http://localhost:3500/workflows/dapr/xxx
 
 ### Terminate the workflow - replace xxx with id from the workflow you've created above
-POST http://localhost:3500/v1.0-alpha1/workflows/dapr/xxx/terminate 
+POST http://localhost:3500/workflows/dapr/xxx/terminate 


### PR DESCRIPTION
# Description

Editted readme and samples for workflow API to no longer reference alpha.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
