### PR TITLE
Adding in new test for parallel raise events in workflow

### DIFF
--- a/test/Dapr.E2E.Test.App/Startup.cs
+++ b/test/Dapr.E2E.Test.App/Startup.cs
@@ -70,6 +70,11 @@ namespace Dapr.E2E.Test
 
                     var itemToPurchase = input;
 
+                    // There are 5 of the same event to test that multiple similarly-named events can be raised in parallel
+                    await context.WaitForExternalEventAsync<string>("ChangePurchaseItem");
+                    await context.WaitForExternalEventAsync<string>("ChangePurchaseItem");
+                    await context.WaitForExternalEventAsync<string>("ChangePurchaseItem");
+                    await context.WaitForExternalEventAsync<string>("ChangePurchaseItem");
                     itemToPurchase = await context.WaitForExternalEventAsync<string>("ChangePurchaseItem");
 
                     // In real life there are other steps related to placing an order, like reserving

--- a/test/Dapr.E2E.Test/Workflows/WorkflowTest.cs
+++ b/test/Dapr.E2E.Test/Workflows/WorkflowTest.cs
@@ -15,7 +15,9 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Client;
+using Dapr.Workflow;
 using FluentAssertions;
+using Google.Api;
 using Xunit;
 
 namespace Dapr.E2E.Test
@@ -93,8 +95,16 @@ namespace Dapr.E2E.Test
                 input: input,
                 workflowOptions: workflowOptions);
 
-            // RAISE EVENT TEST
-            await daprClient.RaiseWorkflowEventAsync(instanceId2, workflowComponent, "ChangePurchaseItem", "computers");
+            // PARALLEL RAISE EVENT TEST
+            var event1 = daprClient.RaiseWorkflowEventAsync(instanceId2, workflowComponent, "ChangePurchaseItem", "computers");
+            var event2 = daprClient.RaiseWorkflowEventAsync(instanceId2, workflowComponent, "ChangePurchaseItem", "computers");
+            var event3 = daprClient.RaiseWorkflowEventAsync(instanceId2, workflowComponent, "ChangePurchaseItem", "computers");
+            var event4 = daprClient.RaiseWorkflowEventAsync(instanceId2, workflowComponent, "ChangePurchaseItem", "computers");
+            var event5 = daprClient.RaiseWorkflowEventAsync(instanceId2, workflowComponent, "ChangePurchaseItem", "computers");
+
+            var externalEvents = Task.WhenAll(event1, event2, event3, event4, event5);
+            var winner = await Task.WhenAny(externalEvents, Task.Delay(TimeSpan.FromSeconds(30)));
+            externalEvents.IsCompletedSuccessfully.Should().BeTrue($"Unsuccessful at raising events. Status of events: {externalEvents.IsCompletedSuccessfully}");
             
             // Wait up to 30 seconds for the workflow to complete and check the output
             using var cts = new CancellationTokenSource(delay: TimeSpan.FromSeconds(30));

--- a/test/Dapr.E2E.Test/Workflows/WorkflowTest.cs
+++ b/test/Dapr.E2E.Test/Workflows/WorkflowTest.cs
@@ -15,9 +15,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Client;
-using Dapr.Workflow;
 using FluentAssertions;
-using Google.Api;
 using Xunit;
 
 namespace Dapr.E2E.Test


### PR DESCRIPTION
# Description

Previously, raising multiple events of the same name in parallel in workflow led to a series of events being incomplete. A change was made to durable task framework in the .NET SDK to fix this issue. This PR adds in a test to ensure that the fix works in this SDK as well.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[[1129](https://github.com/dapr/dotnet-sdk/issues/1129)]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ X] Created/updated tests
* [ ] Extended the documentation
