### PR TITLE
Actor State TTL

### DIFF
--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -37,11 +37,11 @@ jobs:
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
-      DAPR_CLI_VER: 1.12.0
-      DAPR_RUNTIME_VER: 1.12.0
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/release-1.12/install/install.sh
+      DAPR_CLI_VER: 1.9.1
+      DAPR_RUNTIME_VER: 1.10.5
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/3dacfb672d55f1436c249057aaebbe597e1066f3/install/install.sh
       DAPR_CLI_REF: ''
-      DAPR_REF: '2149fca96cdf11627c387bda26dcc027d1c47354'
+      DAPR_REF: '4181de0edc65fc98a836ae7abc6042c575c8fae5'
     steps:
       - name: Set up Dapr CLI
         run: wget -q ${{ env.DAPR_INSTALL_URL }} -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}

--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -37,11 +37,11 @@ jobs:
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
-      DAPR_CLI_VER: 1.9.1
-      DAPR_RUNTIME_VER: 1.10.5
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/3dacfb672d55f1436c249057aaebbe597e1066f3/install/install.sh
+      DAPR_CLI_VER: 1.12.0
+      DAPR_RUNTIME_VER: 1.12.0
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/release-1.12/install/install.sh
       DAPR_CLI_REF: ''
-      DAPR_REF: '4181de0edc65fc98a836ae7abc6042c575c8fae5'
+      DAPR_REF: '2149fca96cdf11627c387bda26dcc027d1c47354'
     steps:
       - name: Set up Dapr CLI
         run: wget -q ${{ env.DAPR_INSTALL_URL }} -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}

--- a/examples/Actor/ActorClient/Program.cs
+++ b/examples/Actor/ActorClient/Program.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ namespace ActorClient
             var proxy = ActorProxy.Create<IDemoActor>(actorId, "DemoActor");
 
             Console.WriteLine("Making call using actor proxy to save data.");
-            await proxy.SaveData(data);
+            await proxy.SaveData(data, TimeSpan.FromMinutes(10));
             Console.WriteLine("Making call using actor proxy to get data.");
             var receivedData = await proxy.GetData();
             Console.WriteLine($"Received data is {receivedData}.");

--- a/examples/Actor/DemoActor/DemoActor.cs
+++ b/examples/Actor/DemoActor/DemoActor.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/Actor/DemoActor/DemoActor.cs
+++ b/examples/Actor/DemoActor/DemoActor.cs
@@ -41,12 +41,12 @@ namespace DaprDemoActor
             this.bank = bank;
         }
 
-        public async Task SaveData(MyData data, int? ttlInSeconds = null)
+        public async Task SaveData(MyData data, TimeSpan ttl)
         {
             Console.WriteLine($"This is Actor id {this.Id} with data {data}.");
 
             // Set State using StateManager, state is saved after the method execution.
-            await this.StateManager.SetStateAsync<MyData>(StateName, data, ttlInSeconds: ttlInSeconds);
+            await this.StateManager.SetStateAsync<MyData>(StateName, data, ttl);
         }
 
         public Task<MyData> GetData()
@@ -100,7 +100,7 @@ namespace DaprDemoActor
             // This method is invoked when an actor reminder is fired.
             var actorState = await this.StateManager.GetStateAsync<MyData>(StateName);
             actorState.PropertyB = $"Reminder triggered at '{DateTime.Now:yyyy-MM-ddTHH:mm:ss}'";
-            await this.StateManager.SetStateAsync<MyData>(StateName, actorState, ttlInSeconds: 360);
+            await this.StateManager.SetStateAsync<MyData>(StateName, actorState, ttl: TimeSpan.FromMinutes(5));
         }
 
         class TimerParams
@@ -164,7 +164,7 @@ namespace DaprDemoActor
         {
             var state = await this.StateManager.GetStateAsync<MyData>(StateName);
             state.PropertyA = $"Timer triggered at '{DateTime.Now:yyyyy-MM-ddTHH:mm:s}'";
-            await this.StateManager.SetStateAsync<MyData>(StateName, state, ttlInSeconds: 360);
+            await this.StateManager.SetStateAsync<MyData>(StateName, state, ttl: TimeSpan.FromMinutes(5));
             var timerParams = JsonSerializer.Deserialize<TimerParams>(data);
             Console.WriteLine("Timer parameter1: " + timerParams.IntParam);
             Console.WriteLine("Timer parameter2: " + timerParams.StringParam);

--- a/examples/Actor/DemoActor/DemoActor.cs
+++ b/examples/Actor/DemoActor/DemoActor.cs
@@ -41,12 +41,12 @@ namespace DaprDemoActor
             this.bank = bank;
         }
 
-        public async Task SaveData(MyData data)
+        public async Task SaveData(MyData data, int? ttlInSeconds = null)
         {
             Console.WriteLine($"This is Actor id {this.Id} with data {data}.");
 
             // Set State using StateManager, state is saved after the method execution.
-            await this.StateManager.SetStateAsync<MyData>(StateName, data);
+            await this.StateManager.SetStateAsync<MyData>(StateName, data, ttlInSeconds: ttlInSeconds);
         }
 
         public Task<MyData> GetData()
@@ -100,7 +100,7 @@ namespace DaprDemoActor
             // This method is invoked when an actor reminder is fired.
             var actorState = await this.StateManager.GetStateAsync<MyData>(StateName);
             actorState.PropertyB = $"Reminder triggered at '{DateTime.Now:yyyy-MM-ddTHH:mm:ss}'";
-            await this.StateManager.SetStateAsync<MyData>(StateName, actorState);
+            await this.StateManager.SetStateAsync<MyData>(StateName, actorState, ttlInSeconds: 360);
         }
 
         class TimerParams
@@ -164,7 +164,7 @@ namespace DaprDemoActor
         {
             var state = await this.StateManager.GetStateAsync<MyData>(StateName);
             state.PropertyA = $"Timer triggered at '{DateTime.Now:yyyyy-MM-ddTHH:mm:s}'";
-            await this.StateManager.SetStateAsync<MyData>(StateName, state);
+            await this.StateManager.SetStateAsync<MyData>(StateName, state, ttlInSeconds: 360);
             var timerParams = JsonSerializer.Deserialize<TimerParams>(data);
             Console.WriteLine("Timer parameter1: " + timerParams.IntParam);
             Console.WriteLine("Timer parameter2: " + timerParams.StringParam);

--- a/examples/Actor/IDemoActor/IDemoActor.cs
+++ b/examples/Actor/IDemoActor/IDemoActor.cs
@@ -27,9 +27,9 @@ namespace IDemoActorInterface
         /// Method to save data.
         /// </summary>
         /// <param name="data">DAta to save.</param>
-        /// <param name="ttlInSeconds">Optional TTL in seconds.</param>
+        /// <param name="ttl">TTL of state key.</param>
         /// <returns>A task that represents the asynchronous save operation.</returns>
-        Task SaveData(MyData data, int? ttlInSeconds = null);
+        Task SaveData(MyData data, TimeSpan ttl);
 
         /// <summary>
         /// Method to get data.

--- a/examples/Actor/IDemoActor/IDemoActor.cs
+++ b/examples/Actor/IDemoActor/IDemoActor.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,8 +27,9 @@ namespace IDemoActorInterface
         /// Method to save data.
         /// </summary>
         /// <param name="data">DAta to save.</param>
+        /// <param name="ttlInSeconds">Optional TTL in seconds.</param>
         /// <returns>A task that represents the asynchronous save operation.</returns>
-        Task SaveData(MyData data);
+        Task SaveData(MyData data, int? ttlInSeconds = null);
 
         /// <summary>
         /// Method to get data.

--- a/src/Dapr.Actors/Communication/ActorStateResponse.cs
+++ b/src/Dapr.Actors/Communication/ActorStateResponse.cs
@@ -1,0 +1,50 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+namespace Dapr.Actors.Communication
+{
+    using System;
+
+    /// <summary>
+    /// Represents a response from fetching an actor state key.
+    /// </summary>
+    internal class ActorStateResponse<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActorStateResponse{T}"/> class.
+        /// </summary>
+        /// <param name="value">The response value.</param>
+        /// <param name="ttlExpireTime">The time to live expiration time.</param>
+        public ActorStateResponse(T value, DateTime? ttlExpireTime)
+        {
+            this.Value = value;
+            this.TTLExpireTime = ttlExpireTime;
+        }
+
+        /// <summary>
+        /// Gets the response value as a string.
+        /// </summary>
+        /// <value>
+        /// The response value as a string.
+        /// </value>
+        public T Value { get; }
+
+        /// <summary>
+        /// Gets the time to live expiration time.
+        /// </summary>
+        /// <value>
+        /// The time to live expiration time.
+        /// </value>
+        public DateTime? TTLExpireTime { get; }
+    }
+}

--- a/src/Dapr.Actors/Communication/ActorStateResponse.cs
+++ b/src/Dapr.Actors/Communication/ActorStateResponse.cs
@@ -18,7 +18,7 @@ namespace Dapr.Actors.Communication
     /// <summary>
     /// Represents a response from fetching an actor state key.
     /// </summary>
-    class ActorStateResponse<T>
+    public class ActorStateResponse<T>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActorStateResponse{T}"/> class.

--- a/src/Dapr.Actors/Communication/ActorStateResponse.cs
+++ b/src/Dapr.Actors/Communication/ActorStateResponse.cs
@@ -25,7 +25,7 @@ namespace Dapr.Actors.Communication
         /// </summary>
         /// <param name="value">The response value.</param>
         /// <param name="ttlExpireTime">The time to live expiration time.</param>
-        public ActorStateResponse(T value, DateTime? ttlExpireTime)
+        public ActorStateResponse(T value, DateTimeOffset? ttlExpireTime)
         {
             this.Value = value;
             this.TTLExpireTime = ttlExpireTime;
@@ -45,6 +45,6 @@ namespace Dapr.Actors.Communication
         /// <value>
         /// The time to live expiration time.
         /// </value>
-        public DateTime? TTLExpireTime { get; }
+        public DateTimeOffset? TTLExpireTime { get; }
     }
 }

--- a/src/Dapr.Actors/Communication/ActorStateResponse.cs
+++ b/src/Dapr.Actors/Communication/ActorStateResponse.cs
@@ -18,7 +18,7 @@ namespace Dapr.Actors.Communication
     /// <summary>
     /// Represents a response from fetching an actor state key.
     /// </summary>
-    internal class ActorStateResponse<T>
+    class ActorStateResponse<T>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActorStateResponse{T}"/> class.

--- a/src/Dapr.Actors/Constants.cs
+++ b/src/Dapr.Actors/Constants.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ namespace Dapr.Actors
         public const string RequestHeaderName = "X-DaprRequestHeader";
         public const string ErrorResponseHeaderName = "X-DaprErrorResponseHeader";
         public const string ReentrancyRequestHeaderName = "Dapr-Reentrancy-Id";
+        public const string TTLResponseHeaderName = "Metadata.ttlExpireTime";
         public const string Dapr = "dapr";
         public const string Config = "config";
         public const string State = "state";

--- a/src/Dapr.Actors/DaprHttpInteractor.cs
+++ b/src/Dapr.Actors/DaprHttpInteractor.cs
@@ -73,7 +73,7 @@ namespace Dapr.Actors
             using var response = await this.SendAsync(RequestFunc, relativeUrl, cancellationToken);
             var stringResponse = await response.Content.ReadAsStringAsync();
 
-            var ttlExpireTime = new DateTime();
+            DateTimeOffset? ttlExpireTime = null;
             if (response.Headers.TryGetValues(Constants.TTLResponseHeaderName, out IEnumerable<string> headerValues))
             {
                 var ttlExpireTimeString = headerValues.First();

--- a/src/Dapr.Actors/IDaprInteractor.cs
+++ b/src/Dapr.Actors/IDaprInteractor.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ namespace Dapr.Actors
         /// <param name="keyName">Name of key to get value for.</param>
         /// <param name="cancellationToken">Cancels the operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        Task<string> GetStateAsync(string actorType, string actorId, string keyName, CancellationToken cancellationToken = default);
+        Task<ActorStateResponse<string>> GetStateAsync(string actorType, string actorId, string keyName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Invokes Actor method.

--- a/src/Dapr.Actors/Runtime/ActorStateChange.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateChange.cs
@@ -28,7 +28,7 @@ namespace Dapr.Actors.Runtime
         /// <param name="value">The value associated with given actor state name.</param>
         /// <param name="changeKind">The kind of state change for given actor state name.</param>
         /// <param name="ttlExpireTime">The time to live for the state.</param>
-        public ActorStateChange(string stateName, Type type, object value, StateChangeKind changeKind, DateTime? ttlExpireTime)
+        public ActorStateChange(string stateName, Type type, object value, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime)
         {
             ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
 
@@ -80,7 +80,7 @@ namespace Dapr.Actors.Runtime
         /// <remarks>
         /// If null, the state will not expire.
         /// </remarks>
-        public DateTime? TTLExpireTime { get; }
+        public DateTimeOffset? TTLExpireTime { get; }
 
         /// <summary>
         /// Gets the time to live in seconds for the state.

--- a/src/Dapr.Actors/Runtime/ActorStateChange.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateChange.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ namespace Dapr.Actors.Runtime
         /// <param name="type">The type of value associated with given actor state name.</param>
         /// <param name="value">The value associated with given actor state name.</param>
         /// <param name="changeKind">The kind of state change for given actor state name.</param>
-        public ActorStateChange(string stateName, Type type, object value, StateChangeKind changeKind)
+        /// <param name="ttlExpireTime">The time to live for the state.</param>
+        public ActorStateChange(string stateName, Type type, object value, StateChangeKind changeKind, DateTime? ttlExpireTime)
         {
             ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
 
@@ -35,6 +36,7 @@ namespace Dapr.Actors.Runtime
             this.Type = type;
             this.Value = value;
             this.ChangeKind = changeKind;
+            this.TTLExpireTime = ttlExpireTime;
         }
 
         /// <summary>
@@ -68,5 +70,39 @@ namespace Dapr.Actors.Runtime
         /// The kind of state change for given actor state name.
         /// </value>
         public StateChangeKind ChangeKind { get; }
+
+        /// <summary>
+        /// Gets the time to live for the state.
+        /// </summary>
+        /// <value>
+        /// The time to live for the state.
+        /// </value>
+        /// <remarks>
+        /// If null, the state will not expire.
+        /// </remarks>
+        public DateTime? TTLExpireTime { get; }
+
+        /// <summary>
+        /// Gets the time to live in seconds for the state.
+        /// </summary>
+        /// <value>
+        /// The time to live for the state.
+        /// </value>
+        /// <remarks>
+        /// If null, the state will not expire.
+        /// </remarks>
+        public int? TTLInSeconds {
+            get
+            {
+                if (this.TTLExpireTime.HasValue)
+                {
+                    return (int)Math.Ceiling((this.TTLExpireTime.Value - DateTime.UtcNow).TotalSeconds);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
     }
 }

--- a/src/Dapr.Actors/Runtime/ActorStateChange.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateChange.cs
@@ -81,28 +81,5 @@ namespace Dapr.Actors.Runtime
         /// If null, the state will not expire.
         /// </remarks>
         public DateTimeOffset? TTLExpireTime { get; }
-
-        /// <summary>
-        /// Gets the time to live in seconds for the state.
-        /// </summary>
-        /// <value>
-        /// The time to live for the state.
-        /// </value>
-        /// <remarks>
-        /// If null, the state will not expire.
-        /// </remarks>
-        public int? TTLInSeconds {
-            get
-            {
-                if (this.TTLExpireTime.HasValue)
-                {
-                    return (int)Math.Ceiling((this.TTLExpireTime.Value - DateTime.UtcNow).TotalSeconds);
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
     }
 }

--- a/src/Dapr.Actors/Runtime/ActorStateManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateManager.cs
@@ -145,7 +145,7 @@ namespace Dapr.Actors.Runtime
                 var stateMetadata = stateChangeTracker[stateName];
 
                 // Check if the property was marked as remove in the cache or is expired
-                if (stateMetadata.ChangeKind == StateChangeKind.Remove || stateMetadata.TTLExpireTime <= DateTime.UtcNow)
+                if (stateMetadata.ChangeKind == StateChangeKind.Remove || stateMetadata.TTLExpireTime <= DateTimeOffset.UtcNow)
                 {
                     return new ConditionalValue<T>(false, default);
                 }
@@ -539,7 +539,7 @@ namespace Dapr.Actors.Runtime
                     throw new ArgumentException("Cannot specify both TTLExpireTime and TTL");
                 }
                 if (ttl.HasValue) {
-                    this.TTLExpireTime = DateTime.UtcNow.Add(ttl.Value);
+                    this.TTLExpireTime = DateTimeOffset.UtcNow.Add(ttl.Value);
                 } else {
                     this.TTLExpireTime = ttlExpireTime;
                 }
@@ -553,9 +553,19 @@ namespace Dapr.Actors.Runtime
 
             public DateTimeOffset? TTLExpireTime { get; set; }
 
-            public static StateMetadata Create<T>(T value, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime = null, TimeSpan? ttl = null)
+            public static StateMetadata Create<T>(T value, StateChangeKind changeKind)
             {
-                return new StateMetadata(value, typeof(T), changeKind, ttlExpireTime, ttl);
+                return new StateMetadata(value, typeof(T), changeKind);
+            }
+
+            public static StateMetadata Create<T>(T value, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime)
+            {
+                return new StateMetadata(value, typeof(T), changeKind, ttlExpireTime: ttlExpireTime);
+            }
+
+            public static StateMetadata Create<T>(T value, StateChangeKind changeKind, TimeSpan? ttl)
+            {
+                return new StateMetadata(value, typeof(T), changeKind, ttl: ttl);
             }
 
             public static StateMetadata CreateForRemove()

--- a/src/Dapr.Actors/Runtime/ActorStateManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateManager.cs
@@ -529,7 +529,7 @@ namespace Dapr.Actors.Runtime
 
         private sealed class StateMetadata
         {
-            private StateMetadata(object value, Type type, StateChangeKind changeKind, DateTime? ttlExpireTime = null, int? ttlInSeconds = null)
+            private StateMetadata(object value, Type type, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime = null, int? ttlInSeconds = null)
             {
                 this.Value = value;
                 this.Type = type;
@@ -551,9 +551,9 @@ namespace Dapr.Actors.Runtime
 
             public Type Type { get; }
 
-            public DateTime? TTLExpireTime { get; set; }
+            public DateTimeOffset? TTLExpireTime { get; set; }
 
-            public static StateMetadata Create<T>(T value, StateChangeKind changeKind, DateTime? ttlExpireTime = null, int? ttlInSeconds = null)
+            public static StateMetadata Create<T>(T value, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime = null, int? ttlInSeconds = null)
             {
                 return new StateMetadata(value, typeof(T), changeKind, ttlExpireTime, ttlInSeconds);
             }

--- a/src/Dapr.Actors/Runtime/ConditionalValue.cs
+++ b/src/Dapr.Actors/Runtime/ConditionalValue.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Dapr.Actors/Runtime/DaprStateProvider.cs
+++ b/src/Dapr.Actors/Runtime/DaprStateProvider.cs
@@ -49,7 +49,7 @@ namespace Dapr.Actors.Runtime
             var result = new ConditionalValue<ActorStateResponse<T>>(false, default);
             var response = await this.daprInteractor.GetStateAsync(actorType, actorId, stateName, cancellationToken);
 
-            if (response.Value.Length != 0 && response.TTLExpireTime > DateTime.UtcNow)
+            if (response.Value.Length != 0 && response.TTLExpireTime > DateTimeOffset.UtcNow)
             {
                 T typedResult;
 
@@ -135,7 +135,7 @@ namespace Dapr.Actors.Runtime
                         }
 
                         if (stateChange.TTLExpireTime.HasValue) {
-                            var ttl = (int)Math.Ceiling((stateChange.TTLExpireTime.Value - DateTime.UtcNow).TotalSeconds);
+                            var ttl = (int)Math.Ceiling((stateChange.TTLExpireTime.Value - DateTimeOffset.UtcNow).TotalSeconds);
                             writer.WriteString("ttlInSeconds", ttl.ToString());
                         }
 

--- a/src/Dapr.Actors/Runtime/DaprStateProvider.cs
+++ b/src/Dapr.Actors/Runtime/DaprStateProvider.cs
@@ -49,7 +49,7 @@ namespace Dapr.Actors.Runtime
             var result = new ConditionalValue<ActorStateResponse<T>>(false, default);
             var response = await this.daprInteractor.GetStateAsync(actorType, actorId, stateName, cancellationToken);
 
-            if (response.Value.Length != 0 && response.TTLExpireTime > DateTimeOffset.UtcNow)
+            if (response.Value.Length != 0 && (!response.TTLExpireTime.HasValue || response.TTLExpireTime.Value > DateTimeOffset.UtcNow))
             {
                 T typedResult;
 
@@ -136,7 +136,10 @@ namespace Dapr.Actors.Runtime
 
                         if (stateChange.TTLExpireTime.HasValue) {
                             var ttl = (int)Math.Ceiling((stateChange.TTLExpireTime.Value - DateTimeOffset.UtcNow).TotalSeconds);
+                            writer.WritePropertyName("metadata");
+                            writer.WriteStartObject();
                             writer.WriteString("ttlInSeconds", ttl.ToString());
+                            writer.WriteEndObject();
                         }
 
                         break;

--- a/src/Dapr.Actors/Runtime/DaprStateProvider.cs
+++ b/src/Dapr.Actors/Runtime/DaprStateProvider.cs
@@ -134,10 +134,11 @@ namespace Dapr.Actors.Runtime
                             JsonSerializer.Serialize(writer, stateChange.Value, stateChange.Type, jsonSerializerOptions);
                         }
 
-                        var ttlInSeconds = stateChange.TTLInSeconds;
-                        if (ttlInSeconds.HasValue) {
-                            writer.WriteString("ttlInSeconds", ttlInSeconds.Value.ToString());
+                        if (stateChange.TTLExpireTime.HasValue) {
+                            var ttl = (int)Math.Ceiling((stateChange.TTLExpireTime.Value - DateTime.UtcNow).TotalSeconds);
+                            writer.WriteString("ttlInSeconds", ttl.ToString());
                         }
+
                         break;
                     default:
                         break;

--- a/src/Dapr.Actors/Runtime/DaprStateProvider.cs
+++ b/src/Dapr.Actors/Runtime/DaprStateProvider.cs
@@ -73,7 +73,7 @@ namespace Dapr.Actors.Runtime
         public async Task<bool> ContainsStateAsync(string actorType, string actorId, string stateName, CancellationToken cancellationToken = default)
         {
             var result = await this.daprInteractor.GetStateAsync(actorType, actorId, stateName, cancellationToken);
-            return result.Value.Length != 0;
+            return (result.Value.Length != 0 && (!result.TTLExpireTime.HasValue || result.TTLExpireTime.Value > DateTimeOffset.UtcNow));
         }
 
         public async Task SaveStateAsync(string actorType, string actorId, IReadOnlyCollection<ActorStateChange> stateChanges, CancellationToken cancellationToken = default)

--- a/src/Dapr.Actors/Runtime/IActorStateManager.cs
+++ b/src/Dapr.Actors/Runtime/IActorStateManager.cs
@@ -32,6 +32,27 @@ namespace Dapr.Actors.Runtime
         /// <param name="stateName">Name of the actor state to add.</param>
         /// <param name="value">Value of the actor state to add.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task that represents the asynchronous add operation.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// An actor state with given state name already exists.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">The specified state name is null.</exception>
+        /// <exception cref="OperationCanceledException">The operation was canceled.</exception>
+        /// <remarks>
+        /// The type of state value <typeparamref name="T"/> must be
+        /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
+        /// </remarks>
+        Task AddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds an actor state with given state name.
+        /// </summary>
+        /// <typeparam name="T">Type of value associated with given state name.</typeparam>
+        /// <param name="stateName">Name of the actor state to add.</param>
+        /// <param name="value">Value of the actor state to add.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <returns>
         /// A task that represents the asynchronous add operation.
@@ -45,7 +66,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task AddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
+        Task AddStateAsync<T>(string stateName, T value, int ttlInSeconds, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets an actor state with specified state name.
@@ -75,6 +96,25 @@ namespace Dapr.Actors.Runtime
         /// <typeparam name="T">Type of value associated with given state name.</typeparam>
         /// <param name="stateName">Name of the actor state to set.</param>
         /// <param name="value">Value of the actor state.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task that represents the asynchronous set operation.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">The specified state name is null.</exception>
+        /// <exception cref="OperationCanceledException">The operation was canceled.</exception>
+        /// <remarks>
+        /// The type of state value <typeparamref name="T"/> must be
+        /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
+        /// </remarks>
+        Task SetStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sets an actor state with given state name to specified value.
+        /// If an actor state with specified name does not exist, it is added.
+        /// </summary>
+        /// <typeparam name="T">Type of value associated with given state name.</typeparam>
+        /// <param name="stateName">Name of the actor state to set.</param>
+        /// <param name="value">Value of the actor state.</param>
         /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>
@@ -86,7 +126,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task SetStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
+        Task SetStateAsync<T>(string stateName, T value, int ttlInSeconds, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Removes an actor state with specified state name.
@@ -110,7 +150,6 @@ namespace Dapr.Actors.Runtime
         /// <param name="value">Value of the actor state to add.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.
         /// This is optional and defaults to <see cref="System.Threading.CancellationToken.None" />.</param>
-        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <returns>
         /// A boolean task that represents the asynchronous add operation. Returns true if the
         /// value was successfully added and false if an actor state with the same name already exists.
@@ -123,7 +162,31 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<bool> TryAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
+        Task<bool> TryAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Attempts to add an actor state with given state name and value. Returns false if an actor state with
+        /// the same name already exists.
+        /// </summary>
+        /// <typeparam name="T">Type of value associated with given state name.</typeparam>
+        /// <param name="stateName">Name of the actor state to add.</param>
+        /// <param name="value">Value of the actor state to add.</param>
+        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.
+        /// This is optional and defaults to <see cref="System.Threading.CancellationToken.None" />.</param>
+        /// <returns>
+        /// A boolean task that represents the asynchronous add operation. Returns true if the
+        /// value was successfully added and false if an actor state with the same name already exists.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">The specified state name is null.
+        /// Provide a valid state name string.</exception>
+        /// <exception cref="OperationCanceledException">The request was canceled using the specified
+        /// <paramref name="cancellationToken" />.</exception>
+        /// <remarks>
+        /// The type of state value <typeparamref name="T"/> must be
+        /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
+        /// </remarks>
+        Task<bool> TryAddStateAsync<T>(string stateName, T value, int ttlInSeconds, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Attempts to get an actor state with specified state name.
@@ -178,7 +241,6 @@ namespace Dapr.Actors.Runtime
         /// <param name="stateName">Name of the actor state to get or add.</param>
         /// <param name="value">Value of the actor state to add if it does not exist.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <returns>
         /// A task that represents the asynchronous get or add operation. The value of TResult
         /// parameter contains value of actor state with given state name.
@@ -191,7 +253,30 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<T> GetOrAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
+        Task<T> GetOrAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets an actor state with the given state name if it exists. If it does not
+        /// exist, creates and new state with the specified name and value.
+        /// </summary>
+        /// <typeparam name="T">Type of value associated with given state name.</typeparam>
+        /// <param name="stateName">Name of the actor state to get or add.</param>
+        /// <param name="value">Value of the actor state to add if it does not exist.</param>
+        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task that represents the asynchronous get or add operation. The value of TResult
+        /// parameter contains value of actor state with given state name.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"> The specified state name is null.
+        /// Provide a valid state name string.</exception>
+        /// <exception cref="OperationCanceledException">The request was canceled using the specified
+        /// <paramref name="cancellationToken" />.</exception>
+        /// <remarks>
+        /// The type of state value <typeparamref name="T"/> must be
+        /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
+        /// </remarks>
+        Task<T> GetOrAddStateAsync<T>(string stateName, T value, int ttlInSeconds, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Adds an actor state with given state name, if it does not already exist or updates
@@ -202,7 +287,6 @@ namespace Dapr.Actors.Runtime
         /// <param name="addValue">Value of the actor state to add if it does not exist.</param>
         /// <param name="updateValueFactory">Factory function to generate value of actor state to update if it exists.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <returns>
         /// A task that represents the asynchronous add/update operation. The value of TResult
         /// parameter contains value of actor state that was added/updated.
@@ -213,7 +297,29 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<T> AddOrUpdateStateAsync<T>(string stateName, T addValue, Func<string, T, T> updateValueFactory, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
+        Task<T> AddOrUpdateStateAsync<T>(string stateName, T addValue, Func<string, T, T> updateValueFactory, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Adds an actor state with given state name, if it does not already exist or updates
+        /// the state with specified state name, if it exists.
+        /// </summary>
+        /// <typeparam name="T">Type of value associated with given state name.</typeparam>
+        /// <param name="stateName">Name of the actor state to add or update.</param>
+        /// <param name="addValue">Value of the actor state to add if it does not exist.</param>
+        /// <param name="updateValueFactory">Factory function to generate value of actor state to update if it exists.</param>
+        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task that represents the asynchronous add/update operation. The value of TResult
+        /// parameter contains value of actor state that was added/updated.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"> The specified state name is null.</exception>
+        /// <exception cref="OperationCanceledException">The operation was canceled.</exception>
+        /// <remarks>
+        /// The type of state value <typeparamref name="T"/> must be
+        /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
+        /// </remarks>
+        Task<T> AddOrUpdateStateAsync<T>(string stateName, T addValue, Func<string, T, T> updateValueFactory, int ttlInSeconds, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Clears all the cached actor states and any operation(s) performed on <see cref="IActorStateManager"/>

--- a/src/Dapr.Actors/Runtime/IActorStateManager.cs
+++ b/src/Dapr.Actors/Runtime/IActorStateManager.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ namespace Dapr.Actors.Runtime
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Dapr.Actors.Communication;
 
     /// <summary>
     /// Represents an interface that exposes methods to manage state of an <see cref="Dapr.Actors.Runtime.Actor" />.
@@ -31,6 +32,7 @@ namespace Dapr.Actors.Runtime
         /// <param name="stateName">Name of the actor state to add.</param>
         /// <param name="value">Value of the actor state to add.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <returns>
         /// A task that represents the asynchronous add operation.
         /// </returns>
@@ -43,7 +45,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task AddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default);
+        Task AddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
 
         /// <summary>
         /// Gets an actor state with specified state name.
@@ -73,6 +75,7 @@ namespace Dapr.Actors.Runtime
         /// <typeparam name="T">Type of value associated with given state name.</typeparam>
         /// <param name="stateName">Name of the actor state to set.</param>
         /// <param name="value">Value of the actor state.</param>
+        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// A task that represents the asynchronous set operation.
@@ -83,7 +86,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task SetStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default);
+        Task SetStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
 
         /// <summary>
         /// Removes an actor state with specified state name.
@@ -107,6 +110,7 @@ namespace Dapr.Actors.Runtime
         /// <param name="value">Value of the actor state to add.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.
         /// This is optional and defaults to <see cref="System.Threading.CancellationToken.None" />.</param>
+        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <returns>
         /// A boolean task that represents the asynchronous add operation. Returns true if the
         /// value was successfully added and false if an actor state with the same name already exists.
@@ -119,7 +123,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<bool> TryAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default);
+        Task<bool> TryAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
 
         /// <summary>
         /// Attempts to get an actor state with specified state name.
@@ -174,6 +178,7 @@ namespace Dapr.Actors.Runtime
         /// <param name="stateName">Name of the actor state to get or add.</param>
         /// <param name="value">Value of the actor state to add if it does not exist.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <returns>
         /// A task that represents the asynchronous get or add operation. The value of TResult
         /// parameter contains value of actor state with given state name.
@@ -186,7 +191,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<T> GetOrAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default);
+        Task<T> GetOrAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
 
         /// <summary>
         /// Adds an actor state with given state name, if it does not already exist or updates
@@ -197,6 +202,7 @@ namespace Dapr.Actors.Runtime
         /// <param name="addValue">Value of the actor state to add if it does not exist.</param>
         /// <param name="updateValueFactory">Factory function to generate value of actor state to update if it exists.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
         /// <returns>
         /// A task that represents the asynchronous add/update operation. The value of TResult
         /// parameter contains value of actor state that was added/updated.
@@ -207,7 +213,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<T> AddOrUpdateStateAsync<T>(string stateName, T addValue, Func<string, T, T> updateValueFactory, CancellationToken cancellationToken = default);
+        Task<T> AddOrUpdateStateAsync<T>(string stateName, T addValue, Func<string, T, T> updateValueFactory, CancellationToken cancellationToken = default, int? ttlInSeconds = null);
 
         /// <summary>
         /// Clears all the cached actor states and any operation(s) performed on <see cref="IActorStateManager"/>

--- a/src/Dapr.Actors/Runtime/IActorStateManager.cs
+++ b/src/Dapr.Actors/Runtime/IActorStateManager.cs
@@ -53,7 +53,7 @@ namespace Dapr.Actors.Runtime
         /// <param name="stateName">Name of the actor state to add.</param>
         /// <param name="value">Value of the actor state to add.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
-        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
+        /// <param name="ttl">The time to live for the state.</param>
         /// <returns>
         /// A task that represents the asynchronous add operation.
         /// </returns>
@@ -66,7 +66,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task AddStateAsync<T>(string stateName, T value, int ttlInSeconds, CancellationToken cancellationToken = default);
+        Task AddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets an actor state with specified state name.
@@ -115,7 +115,7 @@ namespace Dapr.Actors.Runtime
         /// <typeparam name="T">Type of value associated with given state name.</typeparam>
         /// <param name="stateName">Name of the actor state to set.</param>
         /// <param name="value">Value of the actor state.</param>
-        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
+        /// <param name="ttl">The time to live for the state.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// A task that represents the asynchronous set operation.
@@ -126,7 +126,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task SetStateAsync<T>(string stateName, T value, int ttlInSeconds, CancellationToken cancellationToken = default);
+        Task SetStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Removes an actor state with specified state name.
@@ -171,7 +171,7 @@ namespace Dapr.Actors.Runtime
         /// <typeparam name="T">Type of value associated with given state name.</typeparam>
         /// <param name="stateName">Name of the actor state to add.</param>
         /// <param name="value">Value of the actor state to add.</param>
-        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
+        /// <param name="ttl">The time to live for the state.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.
         /// This is optional and defaults to <see cref="System.Threading.CancellationToken.None" />.</param>
         /// <returns>
@@ -186,7 +186,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<bool> TryAddStateAsync<T>(string stateName, T value, int ttlInSeconds, CancellationToken cancellationToken = default);
+        Task<bool> TryAddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Attempts to get an actor state with specified state name.
@@ -262,7 +262,7 @@ namespace Dapr.Actors.Runtime
         /// <typeparam name="T">Type of value associated with given state name.</typeparam>
         /// <param name="stateName">Name of the actor state to get or add.</param>
         /// <param name="value">Value of the actor state to add if it does not exist.</param>
-        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
+        /// <param name="ttl">The time to live for the state.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// A task that represents the asynchronous get or add operation. The value of TResult
@@ -276,7 +276,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<T> GetOrAddStateAsync<T>(string stateName, T value, int ttlInSeconds, CancellationToken cancellationToken = default);
+        Task<T> GetOrAddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Adds an actor state with given state name, if it does not already exist or updates
@@ -307,7 +307,7 @@ namespace Dapr.Actors.Runtime
         /// <param name="stateName">Name of the actor state to add or update.</param>
         /// <param name="addValue">Value of the actor state to add if it does not exist.</param>
         /// <param name="updateValueFactory">Factory function to generate value of actor state to update if it exists.</param>
-        /// <param name="ttlInSeconds">The time to live for the state. If null, the state will not expire.</param>
+        /// <param name="ttl">The time to live for the state.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// A task that represents the asynchronous add/update operation. The value of TResult
@@ -319,7 +319,7 @@ namespace Dapr.Actors.Runtime
         /// The type of state value <typeparamref name="T"/> must be
         /// <see href="https://msdn.microsoft.com/library/ms731923.aspx">Data Contract</see> serializable.
         /// </remarks>
-        Task<T> AddOrUpdateStateAsync<T>(string stateName, T addValue, Func<string, T, T> updateValueFactory, int ttlInSeconds, CancellationToken cancellationToken = default);
+        Task<T> AddOrUpdateStateAsync<T>(string stateName, T addValue, Func<string, T, T> updateValueFactory, TimeSpan ttl, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Clears all the cached actor states and any operation(s) performed on <see cref="IActorStateManager"/>

--- a/src/Dapr.Actors/Runtime/IActorStateSerializer.cs
+++ b/src/Dapr.Actors/Runtime/IActorStateSerializer.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Dapr.Client/Protos/dapr/proto/common/v1/common.proto
+++ b/src/Dapr.Client/Protos/dapr/proto/common/v1/common.proto
@@ -77,7 +77,7 @@ message InvokeRequest {
   HTTPExtension http_extension = 4;
 }
 
-// InvokeResponse is the response message inclduing data and its content type
+// InvokeResponse is the response message including data and its content type
 // from app callback.
 // This message is used in InvokeService of Dapr gRPC Service and OnInvoke
 // of AppCallback gRPC service.

--- a/src/Dapr.Client/Protos/dapr/proto/dapr/v1/dapr.proto
+++ b/src/Dapr.Client/Protos/dapr/proto/dapr/v1/dapr.proto
@@ -169,6 +169,26 @@ service Dapr {
   // Raise an event to a running workflow instance
   rpc RaiseEventWorkflowAlpha1 (RaiseEventWorkflowRequest) returns (google.protobuf.Empty) {}
 
+  // Starts a new instance of a workflow
+  rpc StartWorkflowBeta1 (StartWorkflowRequest) returns (StartWorkflowResponse) {}
+
+  // Gets details about a started workflow instance
+  rpc GetWorkflowBeta1 (GetWorkflowRequest) returns (GetWorkflowResponse) {}
+
+  // Purge Workflow
+  rpc PurgeWorkflowBeta1 (PurgeWorkflowRequest) returns (google.protobuf.Empty) {}
+
+  // Terminates a running workflow instance
+  rpc TerminateWorkflowBeta1 (TerminateWorkflowRequest) returns (google.protobuf.Empty) {}
+
+  // Pauses a running workflow instance
+  rpc PauseWorkflowBeta1 (PauseWorkflowRequest) returns (google.protobuf.Empty) {}
+
+  // Resumes a paused workflow instance
+  rpc ResumeWorkflowBeta1 (ResumeWorkflowRequest) returns (google.protobuf.Empty) {}
+
+  // Raise an event to a running workflow instance
+  rpc RaiseEventWorkflowBeta1 (RaiseEventWorkflowRequest) returns (google.protobuf.Empty) {}
   // Shutdown the sidecar
   rpc Shutdown (google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }
@@ -542,6 +562,9 @@ message GetActorStateRequest {
 // GetActorStateResponse is the response conveying the actor's state value.
 message GetActorStateResponse {
   bytes data = 1;
+
+  // The metadata which will be sent to app.
+  map<string, string> metadata = 2;
 }
 
 // ExecuteActorStateTransactionRequest is the message to execute multiple operations on a specified actor.
@@ -580,10 +603,14 @@ message InvokeActorResponse {
 // GetMetadataResponse is a message that is returned on GetMetadata rpc call
 message GetMetadataResponse {
   string id = 1;
-  repeated ActiveActorsCount active_actors_count = 2;
-  repeated RegisteredComponents registered_components = 3;
-  map<string, string> extended_metadata = 4;
-  repeated PubsubSubscription subscriptions = 5;
+  repeated ActiveActorsCount active_actors_count = 2 [json_name = "actors"];
+  repeated RegisteredComponents registered_components = 3 [json_name = "components"];
+  map<string, string> extended_metadata = 4 [json_name = "extended"];
+  repeated PubsubSubscription subscriptions = 5 [json_name = "subscriptions"];
+  repeated MetadataHTTPEndpoint http_endpoints = 6 [json_name = "httpEndpoints"];
+  AppConnectionProperties app_connection_properties = 7 [json_name = "appConnectionProperties"];
+  string runtime_version = 8 [json_name = "runtimeVersion"];
+  repeated string enabled_features = 9 [json_name = "enabledFeatures"];
 }
 
 message ActiveActorsCount {
@@ -598,12 +625,31 @@ message RegisteredComponents {
   repeated string capabilities = 4;
 }
 
+message MetadataHTTPEndpoint {
+  string name = 1 [json_name = "name"];
+}
+
+message AppConnectionProperties {
+  int32 port = 1;
+  string protocol = 2;
+  string channel_address = 3 [json_name = "channelAddress"];
+  int32 max_concurrency = 4 [json_name = "maxConcurrency"];
+  AppConnectionHealthProperties health = 5;
+}
+
+message AppConnectionHealthProperties {
+  string health_check_path = 1 [json_name = "healthCheckPath"];
+  string health_probe_interval = 2 [json_name = "healthProbeInterval"];
+  string health_probe_timeout = 3 [json_name = "healthProbeTimeout"];
+  int32 health_threshold = 4 [json_name = "healthThreshold"];
+}
+
 message PubsubSubscription {
-  string pubsub_name = 1;
-  string topic = 2;
-  map<string,string> metadata = 3;
-  PubsubSubscriptionRules rules = 4;
-  string dead_letter_topic = 5;
+  string pubsub_name = 1 [json_name = "pubsubname"];
+  string topic = 2 [json_name = "topic"];
+  map<string,string> metadata = 3 [json_name = "metadata"];
+  PubsubSubscriptionRules rules = 4 [json_name = "rules"];
+  string dead_letter_topic = 5 [json_name = "deadLetterTopic"];
 }
 
 message PubsubSubscriptionRules {
@@ -900,7 +946,7 @@ message EncryptRequest {
   // Request details. Must be present in the first message only.
   EncryptRequestOptions options = 1;
   // Chunk of data of arbitrary size.
-  // common.v1.StreamPayload payload = 2; // TODO: Commented out since it was causing an issue
+  common.v1.StreamPayload payload = 2;
 }
 
 // EncryptRequestOptions contains options for the first message in the EncryptAlpha1 request.
@@ -928,7 +974,7 @@ message EncryptRequestOptions {
 // EncryptResponse is the response for EncryptAlpha1.
 message EncryptResponse {
   // Chunk of data.
-  // common.v1.StreamPayload payload = 1; // TODO: Commented out since it was causing an issue
+  common.v1.StreamPayload payload = 1;
 }
 
 // DecryptRequest is the request for DecryptAlpha1.
@@ -936,7 +982,7 @@ message DecryptRequest {
   // Request details. Must be present in the first message only.
   DecryptRequestOptions options = 1;
   // Chunk of data of arbitrary size.
-  // common.v1.StreamPayload payload = 2; // TODO: Commented out since it was causing an issue
+  common.v1.StreamPayload payload = 2;
 }
 
 // DecryptRequestOptions contains options for the first message in the DecryptAlpha1 request.
@@ -952,10 +998,10 @@ message DecryptRequestOptions {
 // DecryptResponse is the response for DecryptAlpha1.
 message DecryptResponse {
   // Chunk of data.
-  // common.v1.StreamPayload payload = 1; // TODO: Commented out since it was causing an issue
+  common.v1.StreamPayload payload = 1;
 }
 
-// GetWorkflowRequest is the request for GetWorkflowAlpha1.
+// GetWorkflowRequest is the request for GetWorkflowBeta1.
 message GetWorkflowRequest {
   // ID of the workflow instance to query.
   string instance_id  = 1 [json_name = "instanceID"];
@@ -963,7 +1009,7 @@ message GetWorkflowRequest {
   string workflow_component = 2 [json_name = "workflowComponent"];
 }
 
-// GetWorkflowResponse is the response for GetWorkflowAlpha1.
+// GetWorkflowResponse is the response for GetWorkflowBeta1.
 message GetWorkflowResponse {
   // ID of the workflow instance.
   string instance_id = 1 [json_name = "instanceID"];
@@ -979,7 +1025,7 @@ message GetWorkflowResponse {
   map<string, string> properties = 6;
 }
 
-// StartWorkflowRequest is the request for StartWorkflowAlpha1.
+// StartWorkflowRequest is the request for StartWorkflowBeta1.
 message StartWorkflowRequest {
   // The ID to assign to the started workflow instance. If empty, a random ID is generated.
   string instance_id = 1 [json_name = "instanceID"];
@@ -993,13 +1039,13 @@ message StartWorkflowRequest {
   bytes input = 5;
 }
 
-// StartWorkflowResponse is the response for StartWorkflowAlpha1.
+// StartWorkflowResponse is the response for StartWorkflowBeta1.
 message StartWorkflowResponse {
   // ID of the started workflow instance.
   string instance_id = 1 [json_name = "instanceID"];
 }
 
-// TerminateWorkflowRequest is the request for TerminateWorkflowAlpha1.
+// TerminateWorkflowRequest is the request for TerminateWorkflowBeta1.
 message TerminateWorkflowRequest {
   // ID of the workflow instance to terminate.
   string instance_id = 1 [json_name = "instanceID"];
@@ -1007,7 +1053,7 @@ message TerminateWorkflowRequest {
   string workflow_component = 2 [json_name = "workflowComponent"];
 }
 
-// PauseWorkflowRequest is the request for PauseWorkflowAlpha1.
+// PauseWorkflowRequest is the request for PauseWorkflowBeta1.
 message PauseWorkflowRequest {
   // ID of the workflow instance to pause.
   string instance_id = 1 [json_name = "instanceID"];
@@ -1015,7 +1061,7 @@ message PauseWorkflowRequest {
   string workflow_component = 2 [json_name = "workflowComponent"];
 }
 
-// ResumeWorkflowRequest is the request for ResumeWorkflowAlpha1.
+// ResumeWorkflowRequest is the request for ResumeWorkflowBeta1.
 message ResumeWorkflowRequest {
   // ID of the workflow instance to resume.
   string instance_id = 1 [json_name = "instanceID"];
@@ -1023,7 +1069,7 @@ message ResumeWorkflowRequest {
   string workflow_component = 2 [json_name = "workflowComponent"];
 }
 
-// RaiseEventWorkflowRequest is the request for RaiseEventWorkflowAlpha1.
+// RaiseEventWorkflowRequest is the request for RaiseEventWorkflowBeta1.
 message RaiseEventWorkflowRequest {
   // ID of the workflow instance to raise an event for.
   string instance_id = 1 [json_name = "instanceID"];
@@ -1035,7 +1081,7 @@ message RaiseEventWorkflowRequest {
   bytes event_data = 4;
 }
 
-// PurgeWorkflowRequest is the request for PurgeWorkflowAlpha1.
+// PurgeWorkflowRequest is the request for PurgeWorkflowBeta1.
 message PurgeWorkflowRequest {
   // ID of the workflow instance to purge.
   string instance_id = 1 [json_name = "instanceID"];

--- a/test/Dapr.Actors.Test/ActorCodeBuilderTests.cs
+++ b/test/Dapr.Actors.Test/ActorCodeBuilderTests.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Dapr.Actors.Test/ActorStateManagerTest.cs
+++ b/test/Dapr.Actors.Test/ActorStateManagerTest.cs
@@ -1,0 +1,199 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+namespace Dapr.Actors.Test
+{
+    using System;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Security;
+    using System.Security.Authentication;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using Xunit;
+    using Dapr.Actors.Communication;
+    using Dapr.Actors.Runtime;
+    using Moq;
+
+    /// <summary>
+    /// Contains tests for ActorStateManager.
+    /// </summary>
+    public class ActorStateManagerTest
+    {
+        [Fact]
+        public async Task SetGet()
+        {
+            var interactor = new Mock<TestDaprInteractor>();
+            var host = ActorHost.CreateForTest<TestActor>();
+            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+            var mngr = new ActorStateManager(new TestActor(host));
+            var token = new CancellationToken();
+
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+            await mngr.AddStateAsync("key1", "value1", token);
+            await mngr.AddStateAsync("key2", "value2", token);
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key1", "value3", token));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key2", "value4", token));
+
+            await mngr.SetStateAsync("key1", "value5", token);
+            await mngr.SetStateAsync("key2", "value6", token);
+            Assert.Equal("value5", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value6", await mngr.GetStateAsync<string>("key2", token));
+        }
+
+        [Fact]
+        public async Task StateWithTTL()
+        {
+            var interactor = new Mock<TestDaprInteractor>();
+            var host = ActorHost.CreateForTest<TestActor>();
+            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+            var mngr = new ActorStateManager(new TestActor(host));
+            var token = new CancellationToken();
+
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+            await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
+            await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
+
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
+
+            // Should be able to add state again after expiry and should not expire.
+            await mngr.AddStateAsync("key1", "value1", token);
+            await mngr.AddStateAsync("key2", "value2", token);
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+        }
+
+        [Fact]
+        public async Task StateRemoveAddTTL()
+        {
+            var interactor = new Mock<TestDaprInteractor>();
+            var host = ActorHost.CreateForTest<TestActor>();
+            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+            var mngr = new ActorStateManager(new TestActor(host));
+            var token = new CancellationToken();
+
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+            await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
+            await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+            await mngr.SetStateAsync("key1", "value1", token);
+            await mngr.SetStateAsync("key2", "value2", token);
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+            // TTL is removed so state should not expire.
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+            // Adding TTL back should expire state.
+            await mngr.SetStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
+            await mngr.SetStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
+        }
+
+        [Fact]
+        public async Task StateDaprdExpireTime()
+        {
+            var interactor = new Mock<TestDaprInteractor>();
+            var host = ActorHost.CreateForTest<TestActor>();
+            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+            var mngr = new ActorStateManager(new TestActor(host));
+            var token = new CancellationToken();
+
+            // Existing key which has an expiry time.
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("\"value1\"", DateTime.UtcNow.AddSeconds(1))));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key1", "value3", token));
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+
+            // No longer return the value from the state provider.
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+            // Key should be expired after 1 seconds.
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.RemoveStateAsync("key1", token));
+            await mngr.AddStateAsync("key1", "value2", TimeSpan.FromSeconds(1), token);
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key1", token));
+        }
+
+        [Fact]
+        public async Task RemoveState()
+        {
+            var interactor = new Mock<TestDaprInteractor>();
+            var host = ActorHost.CreateForTest<TestActor>();
+            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+            var mngr = new ActorStateManager(new TestActor(host));
+            var token = new CancellationToken();
+
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.RemoveStateAsync("key1", token));
+
+            await mngr.AddStateAsync("key1", "value1", token);
+            await mngr.AddStateAsync("key2", "value2", token);
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+            await mngr.RemoveStateAsync("key1", token);
+            await mngr.RemoveStateAsync("key2", token);
+
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
+
+            // Should be able to add state again after removal.
+            await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
+            await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
+            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+        }
+    }
+}

--- a/test/Dapr.Actors.Test/DaprStateProviderTest.cs
+++ b/test/Dapr.Actors.Test/DaprStateProviderTest.cs
@@ -1,0 +1,125 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2023 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+namespace Dapr.Actors.Test
+{
+    using System;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Security;
+    using System.Security.Authentication;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using Xunit;
+    using Dapr.Actors.Communication;
+    using Dapr.Actors.Runtime;
+    using Moq;
+
+    /// <summary>
+    /// Contains tests for DaprStateProvider.
+    /// </summary>
+    public class DaprStateProviderTest
+    {
+        [Fact]
+        public async Task SaveStateAsync()
+        {
+            var interactor = new Mock<TestDaprInteractor>();
+            var provider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+            var token = new CancellationToken();
+
+            var stateChangeList = new List<ActorStateChange>();
+            stateChangeList.Add(
+                new ActorStateChange("key1", typeof(string), "value1", StateChangeKind.Add, DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(2))));
+            stateChangeList.Add(
+                new ActorStateChange("key2", typeof(string), "value2", StateChangeKind.Add, null));
+
+            string content = null;
+            interactor
+              .Setup(d => d.SaveStateTransactionallyAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+              .Callback<string, string, string, CancellationToken>((actorType, actorId, data, token) => content = data)
+              .Returns(Task.FromResult(true));
+
+            await provider.SaveStateAsync("actorType", "actorId", stateChangeList, token);
+            Assert.Equal(
+              "[{\"operation\":\"upsert\",\"request\":{\"key\":\"key1\",\"value\":\"value1\",\"metadata\":{\"ttlInSeconds\":\"2\"}}},{\"operation\":\"upsert\",\"request\":{\"key\":\"key2\",\"value\":\"value2\"}}]",
+              content
+            );
+        }
+
+        [Fact]
+        public async Task ContainsStateAsync()
+        {
+            var interactor = new Mock<TestDaprInteractor>();
+            var provider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+            var token = new CancellationToken();
+
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+            Assert.False(await provider.ContainsStateAsync("actorType", "actorId", "key", token));
+
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("\"value\"", null)));
+            Assert.True(await provider.ContainsStateAsync("actorType", "actorId", "key", token));
+        }
+
+        [Fact]
+        public async Task TryLoadStateAsync()
+        {
+            var interactor = new Mock<TestDaprInteractor>();
+            var provider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+            var token = new CancellationToken();
+
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+            var resp = await provider.TryLoadStateAsync<string>("actorType", "actorId", "key", token);
+            Assert.False(resp.HasValue);
+
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("\"value\"", null)));
+            resp = await provider.TryLoadStateAsync<string>("actorType", "actorId", "key", token);
+            Assert.True(resp.HasValue);
+            Assert.Equal("value", resp.Value.Value);
+            Assert.False(resp.Value.TTLExpireTime.HasValue);
+
+            var ttl = DateTime.UtcNow.AddSeconds(1);
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("\"value\"", ttl)));
+            resp = await provider.TryLoadStateAsync<string>("actorType", "actorId", "key", token);
+            Assert.True(resp.HasValue);
+            Assert.Equal("value", resp.Value.Value);
+            Assert.True(resp.Value.TTLExpireTime.HasValue);
+            Assert.Equal(ttl, resp.Value.TTLExpireTime.Value);
+
+            ttl = DateTime.UtcNow.AddSeconds(-1);
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("\"value\"", ttl)));
+            resp = await provider.TryLoadStateAsync<string>("actorType", "actorId", "key", token);
+            Assert.False(resp.HasValue);
+        }
+    }
+}

--- a/test/Dapr.Actors.Test/DaprStateProviderTest.cs
+++ b/test/Dapr.Actors.Test/DaprStateProviderTest.cs
@@ -81,6 +81,18 @@ namespace Dapr.Actors.Test
               .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
               .Returns(Task.FromResult(new ActorStateResponse<string>("\"value\"", null)));
             Assert.True(await provider.ContainsStateAsync("actorType", "actorId", "key", token));
+
+            var ttl = DateTime.UtcNow.AddSeconds(1);
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("\"value\"", ttl)));
+            Assert.True(await provider.ContainsStateAsync("actorType", "actorId", "key", token));
+
+            ttl = DateTime.UtcNow.AddSeconds(-1);
+            interactor
+              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult(new ActorStateResponse<string>("\"value\"", ttl)));
+            Assert.False(await provider.ContainsStateAsync("actorType", "actorId", "key", token));
         }
 
         [Fact]

--- a/test/Dapr.Actors.Test/Runtime/ActorTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorTests.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Dapr.Actors.Test/TestDaprInteractor.cs
+++ b/test/Dapr.Actors.Test/TestDaprInteractor.cs
@@ -67,10 +67,10 @@ namespace Dapr.Actors
         /// <param name="data">JSON data with state changes as per the Dapr spec for transaction state update.</param>
         /// <param name="cancellationToken">Cancels the operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public Task SaveStateTransactionallyAsync(string actorType, string actorId, string data,
+        public virtual async Task SaveStateTransactionallyAsync(string actorType, string actorId, string data,
             CancellationToken cancellationToken = default)
         {
-            throw new System.NotImplementedException();
+            await _testDaprInteractor.SaveStateTransactionallyAsync(actorType, actorId, data);
         }
 
         /// <summary>
@@ -81,9 +81,9 @@ namespace Dapr.Actors
         /// <param name="keyName">Name of key to get value for.</param>
         /// <param name="cancellationToken">Cancels the operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public Task<ActorStateResponse<string>> GetStateAsync(string actorType, string actorId, string keyName, CancellationToken cancellationToken = default)
+        public virtual async Task<ActorStateResponse<string>> GetStateAsync(string actorType, string actorId, string keyName, CancellationToken cancellationToken = default)
         {
-            throw new System.NotImplementedException();
+            return await _testDaprInteractor.GetStateAsync(actorType, actorId, keyName);
         }
 
         /// <summary>

--- a/test/Dapr.Actors.Test/TestDaprInteractor.cs
+++ b/test/Dapr.Actors.Test/TestDaprInteractor.cs
@@ -81,7 +81,7 @@ namespace Dapr.Actors
         /// <param name="keyName">Name of key to get value for.</param>
         /// <param name="cancellationToken">Cancels the operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public Task<string> GetStateAsync(string actorType, string actorId, string keyName, CancellationToken cancellationToken = default)
+        public Task<ActorStateResponse<string>> GetStateAsync(string actorType, string actorId, string keyName, CancellationToken cancellationToken = default)
         {
             throw new System.NotImplementedException();
         }

--- a/test/Dapr.Client.Test/StateApiTest.cs
+++ b/test/Dapr.Client.Test/StateApiTest.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Dapr.E2E.Test.Actors/Reminders/IReminderActor.cs
+++ b/test/Dapr.E2E.Test.Actors/Reminders/IReminderActor.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Dapr.E2E.Test.Actors/State/IStateActor.cs
+++ b/test/Dapr.E2E.Test.Actors/State/IStateActor.cs
@@ -18,5 +18,9 @@ using Dapr.Actors;
 namespace Dapr.E2E.Test.Actors.State
 {
     public interface IStateActor : IPingActor, IActor
-    { }
+    {
+        Task<string> GetState(string key);
+
+        Task SetState(string key, string value, TimeSpan? ttl);
+    }
 }

--- a/test/Dapr.E2E.Test.Actors/State/IStateActor.cs
+++ b/test/Dapr.E2E.Test.Actors/State/IStateActor.cs
@@ -1,0 +1,22 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Dapr.Actors;
+
+namespace Dapr.E2E.Test.Actors.State
+{
+    public interface IStateActor : IPingActor, IActor
+    { }
+}

--- a/test/Dapr.E2E.Test.App.ReentrantActor/Actors/ReentrantActor.cs
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/Actors/ReentrantActor.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Dapr.E2E.Test.App/Actors/ReminderActor.cs
+++ b/test/Dapr.E2E.Test.App/Actors/ReminderActor.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Dapr.E2E.Test.App/Actors/StateActor.cs
+++ b/test/Dapr.E2E.Test.App/Actors/StateActor.cs
@@ -18,11 +18,16 @@ using Dapr.Actors.Runtime;
 
 namespace Dapr.E2E.Test.Actors.State
 {
-    public class StateActor : Actor
+    public class StateActor : Actor, IStateActor
     {
         public StateActor(ActorHost host)
             : base(host)
         {
+        }
+
+        public Task Ping()
+        {
+            return Task.CompletedTask;
         }
 
         public Task<string> GetState(string key)
@@ -30,9 +35,13 @@ namespace Dapr.E2E.Test.Actors.State
             return this.StateManager.GetStateAsync<string>(key);
         }
 
-        public Task<string> SetState(string key, string value, TimeSpan? ttl)
+        public Task SetState(string key, string value, TimeSpan? ttl)
         {
-            return this.StateManager.SetStateAsync<string>(key, value, ttl: ttl);
+            if (ttl.HasValue)
+            {
+                return this.StateManager.SetStateAsync<String>(key, value, ttl: ttl.Value);
+            }
+            return this.StateManager.SetStateAsync<String>(key, value);
         }
     }
 }

--- a/test/Dapr.E2E.Test.App/Actors/StateActor.cs
+++ b/test/Dapr.E2E.Test.App/Actors/StateActor.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Dapr.Actors.Runtime;
+
+namespace Dapr.E2E.Test.Actors.State
+{
+    public class StateActor : Actor
+    {
+        public StateActor(ActorHost host)
+            : base(host)
+        {
+        }
+
+        public Task<string> GetState(string key)
+        {
+            return this.StateManager.GetStateAsync<string>(key);
+        }
+
+        public Task<string> SetState(string key, string value, int? ttlInSeconds)
+        {
+            return this.StateManager.SetStateAsync<string>(key, value, ttlInSeconds = ttlInSeconds);
+        }
+    }
+}

--- a/test/Dapr.E2E.Test.App/Actors/StateActor.cs
+++ b/test/Dapr.E2E.Test.App/Actors/StateActor.cs
@@ -30,9 +30,9 @@ namespace Dapr.E2E.Test.Actors.State
             return this.StateManager.GetStateAsync<string>(key);
         }
 
-        public Task<string> SetState(string key, string value, int? ttlInSeconds)
+        public Task<string> SetState(string key, string value, TimeSpan? ttl)
         {
-            return this.StateManager.SetStateAsync<string>(key, value, ttlInSeconds = ttlInSeconds);
+            return this.StateManager.SetStateAsync<string>(key, value, ttl: ttl);
         }
     }
 }

--- a/test/Dapr.E2E.Test.App/Actors/TimerActor.cs
+++ b/test/Dapr.E2E.Test.App/Actors/TimerActor.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
 // Copyright 2021 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/Dapr.E2E.Test.App/Startup.cs
+++ b/test/Dapr.E2E.Test.App/Startup.cs
@@ -16,6 +16,7 @@ namespace Dapr.E2E.Test
     using Dapr.E2E.Test.Actors.Reentrancy;
     using Dapr.E2E.Test.Actors.Reminders;
     using Dapr.E2E.Test.Actors.Timers;
+    using Dapr.E2E.Test.Actors.State;
     using Dapr.E2E.Test.Actors.ExceptionTesting;
     using Dapr.E2E.Test.Actors.Serialization;
     using Dapr.E2E.Test.App.ErrorTesting;

--- a/test/Dapr.E2E.Test.App/Startup.cs
+++ b/test/Dapr.E2E.Test.App/Startup.cs
@@ -98,6 +98,7 @@ namespace Dapr.E2E.Test
                 options.Actors.RegisterActor<Regression762Actor>();
                 options.Actors.RegisterActor<ExceptionActor>();
                 options.Actors.RegisterActor<SerializationActor>();
+                options.Actors.RegisterActor<StateActor>();
             });
         }
 

--- a/test/Dapr.E2E.Test/Actors/E2ETests.StateTests.cs
+++ b/test/Dapr.E2E.Test/Actors/E2ETests.StateTests.cs
@@ -37,8 +37,11 @@ namespace Dapr.E2E.Test
 
             await Task.Delay(TimeSpan.FromSeconds(2));
 
-            resp = await proxy.GetState("key");
-            Assert.Null(resp);
+            // Assert key no longer exists.
+            try {
+                await proxy.GetState("key");
+                Assert.True(false, "Expected exception");
+            } catch (Exception) { }
 
             await proxy.SetState("key", "new-value", null);
             resp = await proxy.GetState("key");

--- a/test/Dapr.E2E.Test/Actors/E2ETests.StateTests.cs
+++ b/test/Dapr.E2E.Test/Actors/E2ETests.StateTests.cs
@@ -1,0 +1,44 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+namespace Dapr.E2E.Test
+{
+    using System;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Dapr.Actors;
+    using Dapr.E2E.Test.Actors.State;
+    using Xunit;
+
+    public partial class E2ETests : IAsyncLifetime
+    {
+        [Fact]
+        public async Task ActorCanSaveStateWithTTL()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var proxy = this.ProxyFactory.CreateActorProxy<IStateActor>(ActorId.CreateRandom(), "StateActor");
+
+            await WaitForActorRuntimeAsync(proxy, cts.Token);
+
+            await proxy.SaveState("key", "value", 2, cts.Token);
+
+            state = await.proxy.GetState("key", cts.Token);
+            Assert.Equal("value", state.Value);
+
+            await Task.Delay(TimeSpan.FromSeconds(2), cts.Token);
+
+            state = await.proxy.GetState("key", cts.Token);
+            Assert.Null(state.Value);
+        }
+    }
+}

--- a/test/Dapr.E2E.Test/Actors/E2ETests.StateTests.cs
+++ b/test/Dapr.E2E.Test/Actors/E2ETests.StateTests.cs
@@ -30,15 +30,19 @@ namespace Dapr.E2E.Test
 
             await WaitForActorRuntimeAsync(proxy, cts.Token);
 
-            await proxy.SaveState("key", "value", 2, cts.Token);
+            await proxy.SetState("key", "value", TimeSpan.FromSeconds(2));
 
-            state = await.proxy.GetState("key", cts.Token);
-            Assert.Equal("value", state.Value);
+            var resp = await proxy.GetState("key");
+            Assert.Equal("value", resp);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), cts.Token);
+            await Task.Delay(TimeSpan.FromSeconds(2));
 
-            state = await.proxy.GetState("key", cts.Token);
-            Assert.Null(state.Value);
+            resp = await proxy.GetState("key");
+            Assert.Null(resp);
+
+            await proxy.SetState("key", "new-value", null);
+            resp = await proxy.GetState("key");
+            Assert.Equal("new-value", resp);
         }
     }
 }

--- a/test/Dapr.E2E.Test/Actors/E2ETests.StateTests.cs
+++ b/test/Dapr.E2E.Test/Actors/E2ETests.StateTests.cs
@@ -35,7 +35,7 @@ namespace Dapr.E2E.Test
             var resp = await proxy.GetState("key");
             Assert.Equal("value", resp);
 
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await Task.Delay(TimeSpan.FromSeconds(2.5));
 
             // Assert key no longer exists.
             await Assert.ThrowsAsync<ActorMethodInvocationException>(() => proxy.GetState("key"));
@@ -95,7 +95,7 @@ namespace Dapr.E2E.Test
             var resp = await proxy.GetState("key");
             Assert.Equal("value", resp);
             await proxy.SetState("key", "value", TimeSpan.FromSeconds(2));
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await Task.Delay(TimeSpan.FromSeconds(2.5));
             await Assert.ThrowsAsync<ActorMethodInvocationException>(() => proxy.GetState("key"));
         }
 
@@ -115,7 +115,7 @@ namespace Dapr.E2E.Test
             resp = await proxy2.GetState("key");
             Assert.Equal("value", resp);
 
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await Task.Delay(TimeSpan.FromSeconds(2.5));
             await Assert.ThrowsAsync<ActorMethodInvocationException>(() => proxy1.GetState("key"));
             await Assert.ThrowsAsync<ActorMethodInvocationException>(() => proxy2.GetState("key"));
         }

--- a/test/Dapr.E2E.Test/configuration/featureconfig.yaml
+++ b/test/Dapr.E2E.Test/configuration/featureconfig.yaml
@@ -12,3 +12,5 @@ spec:
       enabled: true
     - name: "proxy.grpc"
       enabled: true
+    - name: "ActorStateTTL"
+      enabled: true


### PR DESCRIPTION
Dapr Actor state TTL is a feature that was added in Dapr 1.12.

Adds support for Actor State TTL. TTL of actor state is set by using the `ttlInSeconds` metadata option when saving actor state. The actor state cache uses the `ttlExpireTime` return metadata field to determine whether the key is still valid, which is important as the cache may become populated with `TTL` keys which were not created by the current manager.

SDK developers are encouraged to use TTLs when storing any actor state in order to prevent stale data accumulating in the actor state store over time.

Closes https://github.com/dapr/dotnet-sdk/pull/1164