### PR TITLE
Update actor reminder example.

### DIFF
--- a/examples/Actor/ActorClient/Program.cs
+++ b/examples/Actor/ActorClient/Program.cs
@@ -18,7 +18,6 @@ namespace ActorClient
     using System.Threading.Tasks;
     using Dapr.Actors;
     using Dapr.Actors.Client;
-    using Dapr.Actors.Communication;
     using IDemoActorInterface;
 
     /// <summary>
@@ -69,7 +68,7 @@ namespace ActorClient
             }
             catch (ActorMethodInvocationException ex)
             {
-                if (ex.InnerException is NotImplementedException)
+                if (ex.InnerException is ActorInvokeException invokeEx && invokeEx.ActualExceptionType is "System.NotImplementedException")
                 {
                     Console.WriteLine($"Got Correct Exception from actor method invocation.");
                 }
@@ -111,7 +110,7 @@ namespace ActorClient
             await Task.Delay(5000);
             Console.WriteLine("Getting details of the registered reminder");
             reminder = await proxy.GetReminder();
-            Console.WriteLine($"Received reminder is {reminder}.");
+            Console.WriteLine($"Received reminder is {reminder?.ToString() ?? "None"} (expecting None).");
             Console.WriteLine("Registering reminder with ttl and repetitions, i.e. reminder stops when either condition is met - The reminder will repeat 2 times.");
             await proxy.RegisterReminderWithTtlAndRepetitions(TimeSpan.FromSeconds(5), 2);
             Console.WriteLine("Getting details of the registered reminder");

--- a/examples/Actor/DemoActor/DemoActor.cs
+++ b/examples/Actor/DemoActor/DemoActor.cs
@@ -85,9 +85,18 @@ namespace DaprDemoActor
             await this.RegisterReminderAsync("TestReminder", null, TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1), repetitions, ttl);
         }
 
-        public async Task<IActorReminder> GetReminder()
+        public async Task<ActorReminderData> GetReminder()
         {
-            return await this.GetReminderAsync("TestReminder");
+            var reminder = await this.GetReminderAsync("TestReminder");
+
+            return reminder is not null
+                ? new ActorReminderData
+                {
+                    Name = reminder.Name,
+                    Period = reminder.Period,
+                    DueTime = reminder.DueTime
+                }
+                : null;
         }
         
         public Task UnregisterReminder()

--- a/examples/Actor/IDemoActor/IDemoActor.cs
+++ b/examples/Actor/IDemoActor/IDemoActor.cs
@@ -100,7 +100,7 @@ namespace IDemoActorInterface
         /// </summary>
         /// <param name="reminderName">The name of the reminder.</param>
         /// <returns>A task that returns the reminder after completion.</returns>
-        Task<IActorReminder> GetReminder();
+        Task<ActorReminderData> GetReminder();
 
         /// <summary>
         /// Unregisters the registered timer.
@@ -130,6 +130,20 @@ namespace IDemoActorInterface
             var propAValue = this.PropertyA ?? "null";
             var propBValue = this.PropertyB ?? "null";
             return $"PropertyA: {propAValue}, PropertyB: {propBValue}";
+        }
+    }
+
+    public class ActorReminderData
+    {
+        public string Name { get; set; }
+
+        public TimeSpan DueTime { get; set; }
+
+        public TimeSpan Period { get; set; }
+
+        public override string ToString()
+        {
+            return $"Name: {this.Name}, DueTime: {this.DueTime}, Period: {this.Period}";
         }
     }
 }


### PR DESCRIPTION
# Description

Updates the actor reminder example to resolve an unexpected exception. The actor was attempting to directly return an `IActorReminder` instance but the underlying type was not intended to be used outside of the actor and was not designed to be serialized.  Instead, its properties are now copied to a separate type which is returned to the caller.  A couple of other changes were made to the client project to correct assumptions about return types.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1177 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
