### PR TITLE
.NET 8 Support

### DIFF
--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['6.0', '7.0']
+        dotnet-version: ['6.0', '7.0', '8.0']
         include:
         - dotnet-version: '6.0'
           display-name: '.NET 6.0'
@@ -31,6 +31,11 @@ jobs:
           framework: 'net7'
           prefix: 'net7'
           install-version: '7.0.x'
+        - dotnet-version: '8.0'
+          display-name: '.NET 8.0'
+          framework: 'net8'
+          prefix: 'net8'
+          install-version: '8.0.x'
     env:
       NUPKG_OUTDIR: bin/Release/nugets
       GOVER: 1.20.3
@@ -101,11 +106,11 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.install-version }}
-      - name: Setup .NET 7.0 # net7 is always required.
+      - name: Setup .NET 8.0 # net8 is always required.
         uses: actions/setup-dotnet@v1
-        if: ${{ matrix.install-version != '7.0.x' }}
+        if: ${{ matrix.install-version != '8.0.x' }}
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Build
         # disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
         run: dotnet build --configuration release /p:GITHUB_ACTIONS=false

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build --configuration release
       - name: Generate Packages
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['6.0', '7.0']
+        dotnet-version: ['6.0', '7.0', '8.0']
         include:
         - dotnet-version: '6.0'
           install-3: false
@@ -56,6 +56,12 @@ jobs:
           framework: 'net7'
           prefix: 'net7'
           install-version: '7.0.x'
+        - dotnet-version: '8.0'
+          install-3: false
+          display-name: '.NET 8.0'
+          framework: 'net8'
+          prefix: 'net8'
+          install-version: '8.0.x'
     steps:
     - uses: actions/checkout@v1
     - name: Parse release version
@@ -64,11 +70,11 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ matrix.install-version }}
-    - name: Setup .NET 7.0 # net7 is always required.
+    - name: Setup .NET 8.0 # net8 is always required.
       uses: actions/setup-dotnet@v1
-      if: ${{ matrix.install-version != '7.0.x' }}
+      if: ${{ matrix.install-version != '8.0.x' }}
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Build
       # disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
       run: dotnet build --configuration release /p:GITHUB_ACTIONS=false

--- a/src/Dapr.Actors.AspNetCore/ActorsEndpointRouteBuilderExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/ActorsEndpointRouteBuilderExtensions.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNetCore.Builder
                         if (header != string.Empty)
                         {
                             // exception case
-                            context.Response.Headers.Add(Constants.ErrorResponseHeaderName, header); // add error header
+                            context.Response.Headers[Constants.ErrorResponseHeaderName] = header; // add error header
                         }
 
                         await context.Response.Body.WriteAsync(body, 0, body.Length); // add response message body
@@ -118,7 +118,7 @@ namespace Microsoft.AspNetCore.Builder
                     {
                         var (header, body) = CreateExceptionResponseMessage(ex);
 
-                        context.Response.Headers.Add(Constants.ErrorResponseHeaderName, header);
+                        context.Response.Headers[Constants.ErrorResponseHeaderName] = header;
                         await context.Response.Body.WriteAsync(body, 0, body.Length);
                     }
                     finally

--- a/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
+++ b/src/Dapr.Actors.AspNetCore/Dapr.Actors.AspNetCore.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <!--

--- a/src/Dapr.Actors/Dapr.Actors.csproj
+++ b/src/Dapr.Actors/Dapr.Actors.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <!-- Additional Nuget package properties. -->
   <PropertyGroup>
     <Description>This package contains the reference assemblies for developing Actor services using Dapr.</Description>

--- a/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
+++ b/src/Dapr.AspNetCore/Dapr.AspNetCore.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <!-- Additional Nuget package properties. -->
   <PropertyGroup>
     <Description>This package contains the reference assemblies for developing services using Dapr and AspNetCore.</Description>

--- a/src/Dapr.AspNetCore/DaprAuthenticationHandler.cs
+++ b/src/Dapr.AspNetCore/DaprAuthenticationHandler.cs
@@ -25,6 +25,14 @@ namespace Dapr.AspNetCore
     {
         const string DaprApiToken = "Dapr-Api-Token";
 
+#if NET8_0_OR_GREATER
+        public DaprAuthenticationHandler(
+            IOptionsMonitor<DaprAuthenticationOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder) : base(options, logger, encoder)
+        {
+        }
+#else
         public DaprAuthenticationHandler(
             IOptionsMonitor<DaprAuthenticationOptions> options,
             ILoggerFactory logger,
@@ -32,6 +40,7 @@ namespace Dapr.AspNetCore
             ISystemClock clock) : base(options, logger, encoder, clock)
         {
         }
+#endif
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {

--- a/src/Dapr.Client/Dapr.Client.csproj
+++ b/src/Dapr.Client/Dapr.Client.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\Shared\ArgumentVerifier.cs" />
     <Compile Include="..\Shared\DaprDefaults.cs" />

--- a/src/Dapr.Client/DaprApiException.cs
+++ b/src/Dapr.Client/DaprApiException.cs
@@ -92,6 +92,9 @@ namespace Dapr
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo" /> object that contains serialized object data of the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext" /> object that contains contextual information about the source or destination. The context parameter is reserved for future use and can be null.</param>
+#if NET8_0_OR_GREATER
+    [Obsolete(DiagnosticId = "SYSLIB0051")] // add this attribute to the serialization ctor
+#endif
         protected DaprApiException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -115,6 +118,9 @@ namespace Dapr
         public bool IsTransient { get; } = false;
 
         /// <inheritdoc />
+#if NET8_0_OR_GREATER
+    [Obsolete(DiagnosticId = "SYSLIB0051")] // add this attribute to GetObjectData
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/Dapr.Client/DaprException.cs
+++ b/src/Dapr.Client/DaprException.cs
@@ -47,6 +47,9 @@ namespace Dapr
         /// </summary>
         /// <param name="info">The <see cref="SerializationInfo" /> object that contains serialized object data of the exception being thrown.</param>
         /// <param name="context">The <see cref="StreamingContext" /> object that contains contextual information about the source or destination. The context parameter is reserved for future use and can be null.</param>
+#if NET8_0_OR_GREATER
+    [Obsolete(DiagnosticId = "SYSLIB0051")] // add this attribute to GetObjectData
+#endif
         protected DaprException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Dapr.Extensions.Configuration/Dapr.Extensions.Configuration.csproj
+++ b/src/Dapr.Extensions.Configuration/Dapr.Extensions.Configuration.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -2,7 +2,8 @@
 
   <!-- NuGet configuration -->
   <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
+    <!-- NOTE: Workflows targeted .NET 7 (whereas other packages did not, so we must continue until .NET 7 EOL). -->
+    <TargetFrameworks>net6;net7;net8</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageId>Dapr.Workflow</PackageId>
     <Title>Dapr Workflow Authoring SDK</Title>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_nuget.props" />
 
   <PropertyGroup>
+    <TargetFrameworks>net6;net8</TargetFrameworks>
     <OutputPath>$(RepoRoot)bin\$(Configuration)\prod\$(MSBuildProjectName)\</OutputPath>
 
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>

--- a/test/Dapr.Actors.AspNetCore.IntegrationTest.App/Dapr.Actors.AspNetCore.IntegrationTest.App.csproj
+++ b/test/Dapr.Actors.AspNetCore.IntegrationTest.App/Dapr.Actors.AspNetCore.IntegrationTest.App.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapr.Actors.AspNetCore\Dapr.Actors.AspNetCore.csproj" />
   </ItemGroup>

--- a/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
@@ -1,8 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Dapr.Actors.AspNetCore.Test/Dapr.Actors.AspNetCore.Test.csproj
+++ b/test/Dapr.Actors.AspNetCore.Test/Dapr.Actors.AspNetCore.Test.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
     <BaseNamespace>Dapr.Actors.AspNetCore</BaseNamespace>
   </PropertyGroup>
 

--- a/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
+++ b/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
     <RootNamespace>Dapr.Actors</RootNamespace>
     <DefineConstants>$(DefineConstants);ACTORS</DefineConstants>
   </PropertyGroup>

--- a/test/Dapr.AspNetCore.IntegrationTest.App/Dapr.AspNetCore.IntegrationTest.App.csproj
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/Dapr.AspNetCore.IntegrationTest.App.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
   </ItemGroup>

--- a/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/test/Dapr.AspNetCore.Test/Dapr.AspNetCore.Test.csproj
+++ b/test/Dapr.AspNetCore.Test/Dapr.AspNetCore.Test.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/test/Dapr.Client.Test/Dapr.Client.Test.csproj
+++ b/test/Dapr.Client.Test/Dapr.Client.Test.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/test/Dapr.E2E.Test.Actors/Dapr.E2E.Test.Actors.csproj
+++ b/test/Dapr.E2E.Test.Actors/Dapr.E2E.Test.Actors.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapr.Actors\Dapr.Actors.csproj" />
   </ItemGroup>

--- a/test/Dapr.E2E.Test.App.Grpc/Dapr.E2E.Test.App.Grpc.csproj
+++ b/test/Dapr.E2E.Test.App.Grpc/Dapr.E2E.Test.App.Grpc.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.39.0" />
   </ItemGroup>

--- a/test/Dapr.E2E.Test.App.ReentrantActor/Dapr.E2E.Test.App.ReentrantActors.csproj
+++ b/test/Dapr.E2E.Test.App.ReentrantActor/Dapr.E2E.Test.App.ReentrantActors.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
-
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Dapr.E2E.Test.App.ReentrantActor' " />
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />

--- a/test/Dapr.E2E.Test.App/Dapr.E2E.Test.App.csproj
+++ b/test/Dapr.E2E.Test.App/Dapr.E2E.Test.App.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Dapr.Actors.AspNetCore\Dapr.Actors.AspNetCore.csproj" />

--- a/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
+++ b/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Google.Protobuf" Version="3.21.12" />

--- a/test/Dapr.E2E.Test/DaprTestApp.cs
+++ b/test/Dapr.E2E.Test/DaprTestApp.cs
@@ -132,16 +132,14 @@ namespace Dapr.E2E.Test
         private static string GetTargetFrameworkName()
         {
             var targetFrameworkName = ((TargetFrameworkAttribute)Assembly.GetExecutingAssembly().GetCustomAttributes(typeof(TargetFrameworkAttribute), false).FirstOrDefault()).FrameworkName;
-            string frameworkMoniker;
-            if (targetFrameworkName == ".NETCoreApp,Version=v6.0")
+
+            return targetFrameworkName switch
             {
-                frameworkMoniker = "net6";
-            }
-            else
-            {
-                frameworkMoniker = "net7";
-            }
-            return frameworkMoniker;
+                ".NETCoreApp,Version=v6.0" => "net6",
+                ".NETCoreApp,Version=v7.0" => "net7",
+                ".NETCoreApp,Version=v8.0" => "net8",
+                _ => throw new InvalidOperationException($"Unsupported target framework: {targetFrameworkName}")
+            };
         }
 
         private static (int, int, int, int) GetFreePorts()

--- a/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
+++ b/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net6;net7</TargetFrameworks>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.9.0">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,6 +2,8 @@
   <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_managed_netcore.props" />
 
   <PropertyGroup>
+    <TargetFrameworks>net6;net7;net8</TargetFrameworks>
+
     <!-- Set Output Path for tests-->
     <OutputPath>$(RepoRoot)bin\$(Configuration)\test\$(MSBuildProjectName)\</OutputPath>
 


### PR DESCRIPTION
# Description

Add explicit .NET 8 targets to Dapr .NET SDK NuGet packages.

Currently, the Dapr .NET SDK NuGet packages target only .NET 6 (except for Workflow, which also targets .NET 7).  With this change, the packages will additionally target .NET 8.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1187 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
