### PR TITLE
Enable `CancellationToken` for non-remoting actor implementations

### DIFF
--- a/src/Dapr.Actors.AspNetCore/ActorsEndpointRouteBuilderExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/ActorsEndpointRouteBuilderExtensions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Builder
 
                     try
                     {
-                        var (header, body) = await runtime.DispatchWithRemotingAsync(actorTypeName, actorId, methodName, daprActorheader, context.Request.Body);
+                        var (header, body) = await runtime.DispatchWithRemotingAsync(actorTypeName, actorId, methodName, daprActorheader, context.Request.Body, context.RequestAborted);
 
                         // Item 1 is header , Item 2 is body
                         if (header != string.Empty)
@@ -112,14 +112,14 @@ namespace Microsoft.AspNetCore.Builder
                             context.Response.Headers[Constants.ErrorResponseHeaderName] = header; // add error header
                         }
 
-                        await context.Response.Body.WriteAsync(body, 0, body.Length); // add response message body
+                        await context.Response.Body.WriteAsync(body, 0, body.Length, context.RequestAborted); // add response message body
                     }
                     catch (Exception ex)
                     {
                         var (header, body) = CreateExceptionResponseMessage(ex);
 
                         context.Response.Headers[Constants.ErrorResponseHeaderName] = header;
-                        await context.Response.Body.WriteAsync(body, 0, body.Length);
+                        await context.Response.Body.WriteAsync(body, 0, body.Length, context.RequestAborted);
                     }
                     finally
                     {
@@ -130,7 +130,7 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     try
                     {
-                        await runtime.DispatchWithoutRemotingAsync(actorTypeName, actorId, methodName, context.Request.Body, context.Response.Body);
+                        await runtime.DispatchWithoutRemotingAsync(actorTypeName, actorId, methodName, context.Request.Body, context.Response.Body, context.RequestAborted);
                     }
                     finally
                     {

--- a/src/Dapr.Actors/Runtime/ActorManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorManager.cs
@@ -152,6 +152,10 @@ namespace Dapr.Actors.Runtime
                 {
                     awaitable = methodInfo.Invoke(actor, null);
                 }
+                else if (parameters.Length == 1 && parameters[0].ParameterType == typeof(CancellationToken))
+                {
+                    awaitable = methodInfo.Invoke(actor, new object[] { ct });
+                }
                 else if (parameters.Length == 1)
                 {
                     // deserialize using stream.

--- a/test/Dapr.Actors.Test/Runtime/ActorRuntimeTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorRuntimeTests.cs
@@ -115,6 +115,10 @@ namespace Dapr.Actors.Test
             Task NoArgumentsAsync();
 
             Task NoArgumentsWithCancellationAsync(CancellationToken cancellationToken = default);
+
+            Task SingleArgumentAsync(bool arg);
+
+            Task SingleArgumentWithCancellationAsync(bool arg, CancellationToken cancellationToken = default);
         }
 
         public sealed class NotRemotedActor : Actor, INotRemotedActor
@@ -130,6 +134,16 @@ namespace Dapr.Actors.Test
             }
 
             public Task NoArgumentsWithCancellationAsync(CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SingleArgumentAsync(bool arg)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task SingleArgumentWithCancellationAsync(bool arg, CancellationToken cancellationToken = default)
             {
                 return Task.CompletedTask;
             }
@@ -160,6 +174,44 @@ namespace Dapr.Actors.Test
 
             using var output = new MemoryStream();
             await runtime.DispatchWithoutRemotingAsync(actorType.Name, ActorId.CreateRandom().ToString(), nameof(INotRemotedActor.NoArgumentsWithCancellationAsync), new MemoryStream(), output);
+        }
+
+        [Fact]
+        public async Task NoRemotingMethodWithSingleArgument()
+        {
+            var actorType = typeof(NotRemotedActor);
+
+            var options = new ActorRuntimeOptions();
+            options.Actors.RegisterActor<NotRemotedActor>();
+            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
+
+            using var input = new MemoryStream();
+
+            JsonSerializer.Serialize(input, true);
+
+            input.Seek(0, SeekOrigin.Begin);
+
+            using var output = new MemoryStream();
+            await runtime.DispatchWithoutRemotingAsync(actorType.Name, ActorId.CreateRandom().ToString(), nameof(INotRemotedActor.SingleArgumentAsync), input, output);
+        }
+
+        [Fact]
+        public async Task NoRemotingMethodWithSingleArgumentWithCancellation()
+        {
+            var actorType = typeof(NotRemotedActor);
+
+            var options = new ActorRuntimeOptions();
+            options.Actors.RegisterActor<NotRemotedActor>();
+            var runtime = new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
+
+            using var input = new MemoryStream();
+
+            JsonSerializer.Serialize(input, true);
+
+            input.Seek(0, SeekOrigin.Begin);
+
+            using var output = new MemoryStream();
+            await runtime.DispatchWithoutRemotingAsync(actorType.Name, ActorId.CreateRandom().ToString(), nameof(INotRemotedActor.SingleArgumentWithCancellationAsync), input, output);
         }
 
         [Fact]


### PR DESCRIPTION
# Description

Enable use of `CancellationToken` in actor interfaces/implementations when clients use the non-remoting proxy.  This, when combined with #1158, would enable both clients and implementations to use the same interface definition.

Also ensures that the `CancellationToken` from the HTTP request is pushed down into the handling and actor logic.

> :warning: When using this capability, clients cannot use the remoting-based proxy for method invocation.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1201 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
