### PR TITLE
Weakly-typed actors should support polymorphic response and null response

### DIFF
--- a/src/Dapr.Actors/Runtime/ActorManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorManager.cs
@@ -186,7 +186,13 @@ namespace Dapr.Actors.Runtime
             // Serialize result if it has result (return type was not just Task.)
             if (methodInfo.ReturnType.Name != typeof(Task).Name)
             {
-                await JsonSerializer.SerializeAsync(responseBodyStream, result, result.GetType(), jsonSerializerOptions);
+#if NET7_0_OR_GREATER
+                var resultType = methodInfo.ReturnType.GenericTypeArguments[0];
+                await JsonSerializer.SerializeAsync(responseBodyStream, result, resultType, jsonSerializerOptions);
+#else
+                await JsonSerializer.SerializeAsync<object>(responseBodyStream, result, jsonSerializerOptions); 
+#endif
+
             }
         }
 

--- a/test/Dapr.E2E.Test.Actors/WeaklyTypedTesting/DerivedResponse.cs
+++ b/test/Dapr.E2E.Test.Actors/WeaklyTypedTesting/DerivedResponse.cs
@@ -1,0 +1,20 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+namespace Dapr.E2E.Test.Actors.WeaklyTypedTesting
+{
+    public class DerivedResponse : ResponseBase
+    {
+        public string DerivedProperty { get; set; }
+    }
+}

--- a/test/Dapr.E2E.Test.Actors/WeaklyTypedTesting/IWeaklyTypedTestingActor.cs
+++ b/test/Dapr.E2E.Test.Actors/WeaklyTypedTesting/IWeaklyTypedTestingActor.cs
@@ -1,0 +1,25 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Dapr.Actors;
+
+namespace Dapr.E2E.Test.Actors.WeaklyTypedTesting
+{
+    public interface IWeaklyTypedTestingActor : IPingActor, IActor
+    {
+        Task<ResponseBase> GetPolymorphicResponse();
+
+        Task<ResponseBase> GetNullResponse();
+    }
+}

--- a/test/Dapr.E2E.Test.Actors/WeaklyTypedTesting/ResponseBase.cs
+++ b/test/Dapr.E2E.Test.Actors/WeaklyTypedTesting/ResponseBase.cs
@@ -1,0 +1,25 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Dapr.E2E.Test.Actors.WeaklyTypedTesting
+{
+#if NET7_0_OR_GREATER
+    [JsonDerivedType(typeof(DerivedResponse), typeDiscriminator: nameof(DerivedResponse))]
+#endif
+    public class ResponseBase
+    {
+        public string BasePropeprty { get; set; }
+    }
+}

--- a/test/Dapr.E2E.Test.App/Actors/WeaklyTypedTestingActor.cs
+++ b/test/Dapr.E2E.Test.App/Actors/WeaklyTypedTestingActor.cs
@@ -1,0 +1,47 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Dapr.Actors.Runtime;
+
+namespace Dapr.E2E.Test.Actors.WeaklyTypedTesting
+{
+    public class WeaklyTypedTestingActor : Actor, IWeaklyTypedTestingActor
+    {
+        public WeaklyTypedTestingActor(ActorHost host)
+            : base(host)
+        {
+        }
+
+        public Task<ResponseBase> GetNullResponse()
+        {
+            return Task.FromResult<ResponseBase>(null);
+        }
+
+        public Task<ResponseBase> GetPolymorphicResponse()
+        {
+            var response = new DerivedResponse
+            {
+                BasePropeprty = "Base property value",
+                DerivedProperty = "Derived property value"
+            };
+
+            return Task.FromResult<ResponseBase>(response);
+        }
+
+        public Task Ping()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Dapr.E2E.Test.App/Startup.cs
+++ b/test/Dapr.E2E.Test.App/Startup.cs
@@ -19,6 +19,7 @@ namespace Dapr.E2E.Test
     using Dapr.E2E.Test.Actors.State;
     using Dapr.E2E.Test.Actors.ExceptionTesting;
     using Dapr.E2E.Test.Actors.Serialization;
+    using Dapr.E2E.Test.Actors.WeaklyTypedTesting;
     using Dapr.E2E.Test.App.ErrorTesting;
     using Dapr.Workflow;
     using Microsoft.AspNetCore.Authentication;
@@ -106,6 +107,7 @@ namespace Dapr.E2E.Test
                 options.Actors.RegisterActor<ExceptionActor>();
                 options.Actors.RegisterActor<SerializationActor>();
                 options.Actors.RegisterActor<StateActor>();
+                options.Actors.RegisterActor<WeaklyTypedTestingActor>();
             });
         }
 

--- a/test/Dapr.E2E.Test/Actors/E2ETests.WeaklyTypedTests.cs
+++ b/test/Dapr.E2E.Test/Actors/E2ETests.WeaklyTypedTests.cs
@@ -1,0 +1,68 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+namespace Dapr.E2E.Test
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Dapr.Actors;
+    using Dapr.E2E.Test.Actors.WeaklyTypedTesting;
+    using FluentAssertions;
+    using Xunit;
+
+    public partial class E2ETests : IAsyncLifetime
+    {
+#if NET8_0_OR_GREATER
+        [Fact]
+        public async Task WeaklyTypedActorCanReturnPolymorphicResponse()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var pingProxy = this.ProxyFactory.CreateActorProxy<IWeaklyTypedTestingActor>(ActorId.CreateRandom(), "WeaklyTypedTestingActor");
+            var proxy = this.ProxyFactory.Create(ActorId.CreateRandom(), "WeaklyTypedTestingActor");
+
+            await WaitForActorRuntimeAsync(pingProxy, cts.Token);
+
+            var result = await proxy.InvokeMethodAsync<ResponseBase>(nameof(IWeaklyTypedTestingActor.GetPolymorphicResponse));
+
+            result.Should().BeOfType<DerivedResponse>().Which.DerivedProperty.Should().NotBeNullOrWhiteSpace();
+        }
+#else
+        [Fact]
+        public async Task WeaklyTypedActorCanReturnDerivedResponse()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var pingProxy = this.ProxyFactory.CreateActorProxy<IWeaklyTypedTestingActor>(ActorId.CreateRandom(), "WeaklyTypedTestingActor");
+            var proxy = this.ProxyFactory.Create(ActorId.CreateRandom(), "WeaklyTypedTestingActor");
+
+            await WaitForActorRuntimeAsync(pingProxy, cts.Token);
+
+            var result = await proxy.InvokeMethodAsync<DerivedResponse>(nameof(IWeaklyTypedTestingActor.GetPolymorphicResponse));
+
+            result.Should().BeOfType<DerivedResponse>().Which.DerivedProperty.Should().NotBeNullOrWhiteSpace();
+        }
+#endif
+        [Fact]
+        public async Task WeaklyTypedActorCanReturnNullResponse()
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            var pingProxy = this.ProxyFactory.CreateActorProxy<IWeaklyTypedTestingActor>(ActorId.CreateRandom(), "WeaklyTypedTestingActor");
+            var proxy = this.ProxyFactory.Create(ActorId.CreateRandom(), "WeaklyTypedTestingActor");
+
+            await WaitForActorRuntimeAsync(pingProxy, cts.Token);
+
+            var result = await proxy.InvokeMethodAsync<ResponseBase>(nameof(IWeaklyTypedTestingActor.GetNullResponse));
+
+            result.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
In .NET 7.0 or later an operation on an actor invoked using a weakly-typed actor client should support a polymorphic response. The response json should include a type discriminator property to allow for polymorphic deserialization by the actor client. The weakly-typed actor client must polymorphically deserialize the response when invoking `InvokeMethodAsync<ResponseBase>` on the weakly-typed actor client. This should yield a `DerivedResponse` instance. Note that invoking `InvokeMethodAsync<DerivedResponse>` is not polymorphic deserialization.

While System.Text.Json support polymorphic deserialization from .NET 7, the Dapr .NET Actors SDK only builds .NET 6 and .NET 8, but not .NET 7. The E2E tests on the other hand do still build .NET 6, .NET 7 and .NET 8. As a consequence the .NET 7 build of the E2E tests uses the .NET 6 build of the .NET Actors SDK and does not run the polymorphic response test. Instead it runs a non-polymorphic test that directly deserializes to the derived class.

An operation on an actor invoked using a weakly-typed actor client should support a null response. 

The problem was in the `ActorManager.DispatchWithoutRemotingAsync` method that serializes the response using `result.GetType()`. This throws a null reference exception when the result is null. To support polymorphic deserialization in .NET 7 or later the serializer should use the declared return type on the interface instead of the runtime type.

Closes #1213 

