### PR TITLE
Move to v4 of the upload/download artifact actions.

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate Packages
         run: dotnet pack --configuration release
       - name: Upload packages
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: ${{ env.NUPKG_OUTDIR }}
@@ -116,7 +116,7 @@ jobs:
     if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
     steps:
     - name: Download release artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: packages
         path: packages


### PR DESCRIPTION
# Description

The handoff between the build step and the publish step of the CI/CD pipeline does not seem to be working.  I noticed that we were using the `master` version of the upload action but the `v2` version of the download action.  The action repos mention that the latest versions (v4) represent significant architectural changes from prior versions, which I speculate may be the reason for the break (i.e. the upload is using the new architecture while the download is using the old).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
