### PR TITLE
Added option to override GrpcChannelOptions when adding DaprWorkflow (#7218)

### DIFF
--- a/src/Dapr.Workflow/WorkflowRuntimeOptions.cs
+++ b/src/Dapr.Workflow/WorkflowRuntimeOptions.cs
@@ -11,6 +11,8 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
+using Grpc.Net.Client;
+
 namespace Dapr.Workflow
 {
     using System;
@@ -29,6 +31,11 @@ namespace Dapr.Workflow
         /// </summary>
         readonly Dictionary<string, Action<DurableTaskRegistry>> factories = new();
 
+        /// <summary>
+        /// Override GrpcChannelOptions.
+        /// </summary>
+        internal GrpcChannelOptions? GrpcChannelOptions { get; private set; }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="WorkflowRuntimeOptions"/> class.
         /// </summary>
@@ -116,6 +123,15 @@ namespace Dapr.Workflow
                 });
                 WorkflowLoggingService.LogActivityName(name);
             });
+        }
+        
+        /// <summary>
+        /// Uses the provided <paramref name="grpcChannelOptions" /> for creating the <see cref="GrpcChannel" />.
+        /// </summary>
+        /// <param name="grpcChannelOptions">The <see cref="GrpcChannelOptions" /> to use for creating the <see cref="GrpcChannel" />.</param>
+        public void UseGrpcChannelOptions(GrpcChannelOptions grpcChannelOptions)
+        {
+            this.GrpcChannelOptions = grpcChannelOptions;
         }
 
         /// <summary>

--- a/test/Dapr.E2E.Test/DaprTestApp.cs
+++ b/test/Dapr.E2E.Test/DaprTestApp.cs
@@ -58,6 +58,7 @@ namespace Dapr.E2E.Test
                 "--components-path", componentsPath,
                 "--config", configPath,
                 "--log-level", "debug",
+                "--dapr-http-max-request-size", "32",
 
             };
 


### PR DESCRIPTION
# Description

You can now use custom GrpcChannelOptions when using DaprWorkflow, in the same manner as was already the case when creating the DaprClient:

```
builder.Services.AddDaprWorkflow(options =>
{
    options.UseGrpcChannelOptions(new GrpcChannelOptions
    {
        MaxReceiveMessageSize = 32 * 1024 * 1024,
        MaxSendMessageSize = 32 * 1024 * 1024
    });
});
```

## Issue reference

See issue: GRPC data receive limits ([#7218](https://github.com/dapr/dapr/issues/7218))