### PR TITLE
Updated docs to register actor endpoint via top-level registrations

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-howto.md
@@ -319,11 +319,8 @@ namespace MyActorService
 
             app.UseRouting();
 
-            app.UseEndpoints(endpoints =>
-            {
-                // Register actors handlers that interface with the Dapr runtime.
-                endpoints.MapActorsHandlers();
-            });
+            // Register actors handlers that interface with the Dapr runtime.
+            app.MapActorsHandlers();
         }
     }
 }


### PR DESCRIPTION
# Description

With the release of .NET 8, a warning for [ASP0014](https://learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0014?view=aspnetcore-8.0) was added that suggests that routes shouldn't be registered via `app.UseEndpoints` and longer and should rather be registered directly from the built web application.

This requires no changes to the SDK itself, but the documentation should be updated to reflect the change and this PR corrects this as was pointed out by the issue in #1256.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1256

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly (not applicable, no code changes made)
* [ ] Created/updated tests (not applicable, no code changes made)
* [X] Extended the documentation
