### PR TITLE
Fix for secret key transformation in multi-value scenarios

### DIFF
--- a/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationProvider.cs
+++ b/src/Dapr.Extensions.Configuration/DaprSecretStoreConfigurationProvider.cs
@@ -227,8 +227,15 @@ namespace Dapr.Extensions.Configuration.DaprSecretStore
                                 $"A duplicate key '{key}' was found in the secret store '{store}'. Please remove any duplicates from your secret store.");
                         }
 
-                        data.Add(normalizeKey ? NormalizeKey(secretDescriptor.SecretName) : secretDescriptor.SecretName,
-                            result[key]);
+                        // The name of the key "as desired" by the user based on the descriptor.
+                        //
+                        // NOTE: This should vary only if a single secret of the same name is returned.
+                        string desiredKey = StringComparer.Ordinal.Equals(key, secretDescriptor.SecretKey) ? secretDescriptor.SecretName : key;
+
+                        // The name of the key normalized based on the configured delimiters.
+                        string normalizedKey = normalizeKey ? NormalizeKey(desiredKey) : desiredKey;
+
+                        data.Add(normalizedKey, result[key]);
                     }
                 }
 

--- a/test/Dapr.Extensions.Configuration.Test/DaprSecretStoreConfigurationProviderTest.cs
+++ b/test/Dapr.Extensions.Configuration.Test/DaprSecretStoreConfigurationProviderTest.cs
@@ -199,6 +199,35 @@ namespace Dapr.Extensions.Configuration.Test
         }
 
         [Fact]
+        public void LoadSecrets_FromSecretStoreThatCanReturnsMultivaluedValues()
+        {
+            var storeName = "store";
+            var parentSecretKey = "connectionStrings";
+            var firstSecretKey = "first_secret";
+            var secondSecretKey = "second_secret";
+            var firstSecretValue = "secret1";
+            var secondSecretValue = "secret2";
+
+            var secretDescriptors = new[]
+            {
+                new DaprSecretDescriptor(parentSecretKey)
+            };
+
+            var daprClient = new Mock<DaprClient>();
+
+            daprClient.Setup(c => c.GetSecretAsync(storeName, parentSecretKey,
+                    It.IsAny<Dictionary<string, string>>(), default))
+                .ReturnsAsync(new Dictionary<string, string> { { firstSecretKey, firstSecretValue }, { secondSecretKey, secondSecretValue } });
+
+            var config = CreateBuilder()
+                .AddDaprSecretStore(storeName, secretDescriptors, daprClient.Object)
+                .Build();
+
+            config[firstSecretKey].Should().Be(firstSecretValue);
+            config[secondSecretKey].Should().Be(secondSecretValue);
+        }
+
+        [Fact]
         public void LoadSecrets_FromSecretStoreWithADifferentSecretKeyAndName()
         {
             var storeName = "store";


### PR DESCRIPTION
# Description

Applies the secret key/name transformation (if specified) only when the returned key name matches the secret key name.  If "sub keys" are returned, for example, the transformation makes no sense and results in duplicate key names.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1249

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
