### PR TITLE
Managed the invocation of remote multi-parameter actor methods withou…

### DIFF
--- a/src/Dapr.Actors/Runtime/ActorManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorManager.cs
@@ -154,6 +154,13 @@ namespace Dapr.Actors.Runtime
                 {
                     awaitable = methodInfo.Invoke(actor, parameters.Length == 0 ? null : new object[] { ct });
                 }
+                else if (parameters.Length == 1 || (parameters.Length == 2 && parameters[1].ParameterType == typeof(CancellationToken)))
+                {
+                    // deserialize using stream.
+                    var type = parameters[0].ParameterType;
+                    var deserializedType = await JsonSerializer.DeserializeAsync(requestBodyStream, type, jsonSerializerOptions);
+                    awaitable = methodInfo.Invoke(actor, parameters.Length == 1 ? new object[] { deserializedType } : new object[] { deserializedType, ct });
+                }
                 else
                 {
 #if NET8_0_OR_GREATER


### PR DESCRIPTION
…t remoting

# Description

- Managed the invocation of remote multi-parameter actor methods without remoting, used in the actor example.
- Remove from the code base the exception `System.ArgumentException: Method xxx has more than one parameter and can't be invoked through http` introduced in: #249, #252 
- Added some UnitTests to check the new behavior

## Issue reference

#1305 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
