### PR TITLE
Added overload to support SDK supplying query string on invoked URL

### DIFF
--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -356,7 +356,7 @@ namespace Dapr.Client
         /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
         public HttpRequestMessage CreateInvokeMethodRequest<TRequest>(string appId, string methodName, TRequest data)
         {
-            return CreateInvokeMethodRequest<TRequest>(HttpMethod.Post, appId, methodName, data);
+            return CreateInvokeMethodRequest(HttpMethod.Post, appId, methodName, data);
         }
 
         /// <summary>

--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -309,6 +309,20 @@ namespace Dapr.Client
         /// <summary>
         /// Creates an <see cref="HttpRequestMessage" /> that can be used to perform service invocation for the
         /// application identified by <paramref name="appId" /> and invokes the method specified by <paramref name="methodName" />
+        /// with the <c>POST</c> HTTP method.
+        /// </summary>
+        /// <param name="appId">The Dapr application id to invoke the method on.</param>
+        /// <param name="methodName">The name of the method to invoke.</param>
+        /// <param name="queryStringParameters">A collection of key/value pairs to populate the query string from.</param>
+        /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
+        public HttpRequestMessage CreateInvokeMethodRequest(string appId, string methodName, IReadOnlyCollection<KeyValuePair<string,string>> queryStringParameters)
+        {
+            return CreateInvokeMethodRequest(HttpMethod.Post, appId, methodName, queryStringParameters);
+        }
+        
+        /// <summary>
+        /// Creates an <see cref="HttpRequestMessage" /> that can be used to perform service invocation for the
+        /// application identified by <paramref name="appId" /> and invokes the method specified by <paramref name="methodName" />
         /// with the HTTP method specified by <paramref name="httpMethod" />.
         /// </summary>
         /// <param name="httpMethod">The <see cref="HttpMethod" /> to use for the invocation request.</param>
@@ -316,6 +330,19 @@ namespace Dapr.Client
         /// <param name="methodName">The name of the method to invoke.</param>
         /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
         public abstract HttpRequestMessage CreateInvokeMethodRequest(HttpMethod httpMethod, string appId, string methodName);
+
+        /// <summary>
+        /// Creates an <see cref="HttpRequestMessage" /> that can be used to perform service invocation for the
+        /// application identified by <paramref name="appId" /> and invokes the method specified by <paramref name="methodName" />
+        /// with the HTTP method specified by <paramref name="httpMethod" />.
+        /// </summary>
+        /// <param name="httpMethod">The <see cref="HttpMethod" /> to use for the invocation request.</param>
+        /// <param name="appId">The Dapr application id to invoke the method on.</param>
+        /// <param name="methodName">The name of the method to invoke.</param>
+        /// <param name="queryStringParameters">A collection of key/value pairs to populate the query string from.</param>
+        /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
+        public abstract HttpRequestMessage CreateInvokeMethodRequest(HttpMethod httpMethod, string appId,
+            string methodName, IReadOnlyCollection<KeyValuePair<string, string>> queryStringParameters);
 
         /// <summary>
         /// Creates an <see cref="HttpRequestMessage" /> that can be used to perform service invocation for the
@@ -346,6 +373,21 @@ namespace Dapr.Client
         /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
         public abstract HttpRequestMessage CreateInvokeMethodRequest<TRequest>(HttpMethod httpMethod, string appId, string methodName, TRequest data);
 
+        /// <summary>
+        /// Creates an <see cref="HttpRequestMessage" /> that can be used to perform service invocation for the
+        /// application identified by <paramref name="appId" /> and invokes the method specified by <paramref name="methodName" />
+        /// with the HTTP method specified by <paramref name="httpMethod" /> and a JSON serialized request body specified by 
+        /// <paramref name="data" />.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of the data that will be JSON serialized and provided as the request body.</typeparam>
+        /// <param name="httpMethod">The <see cref="HttpMethod" /> to use for the invocation request.</param>
+        /// <param name="appId">The Dapr application id to invoke the method on.</param>
+        /// <param name="methodName">The name of the method to invoke.</param>
+        /// <param name="data">The data that will be JSON serialized and provided as the request body.</param>
+        /// <param name="queryStringParameters">A collection of key/value pairs to populate the query string from.</param>
+        /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
+        public abstract HttpRequestMessage CreateInvokeMethodRequest<TRequest>(HttpMethod httpMethod, string appId, string methodName, IReadOnlyCollection<KeyValuePair<string,string>> queryStringParameters, TRequest data);
+        
         /// <summary>
         /// Perform health-check of Dapr sidecar. Return 'true' if sidecar is healthy. Otherwise 'false'.
         /// CheckHealthAsync handle <see cref="HttpRequestException"/> and will return 'false' if error will occur on transport level

--- a/src/Dapr.Client/DaprClient.cs
+++ b/src/Dapr.Client/DaprClient.cs
@@ -356,23 +356,9 @@ namespace Dapr.Client
         /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
         public HttpRequestMessage CreateInvokeMethodRequest<TRequest>(string appId, string methodName, TRequest data)
         {
-            return CreateInvokeMethodRequest(HttpMethod.Post, appId, methodName, data);
+            return CreateInvokeMethodRequest(HttpMethod.Post, appId, methodName, new List<KeyValuePair<string, string>>(), data);
         }
-
-        /// <summary>
-        /// Creates an <see cref="HttpRequestMessage" /> that can be used to perform service invocation for the
-        /// application identified by <paramref name="appId" /> and invokes the method specified by <paramref name="methodName" />
-        /// with the HTTP method specified by <paramref name="httpMethod" /> and a JSON serialized request body specified by 
-        /// <paramref name="data" />.
-        /// </summary>
-        /// <typeparam name="TRequest">The type of the data that will be JSON serialized and provided as the request body.</typeparam>
-        /// <param name="httpMethod">The <see cref="HttpMethod" /> to use for the invocation request.</param>
-        /// <param name="appId">The Dapr application id to invoke the method on.</param>
-        /// <param name="methodName">The name of the method to invoke.</param>
-        /// <param name="data">The data that will be JSON serialized and provided as the request body.</param>
-        /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
-        public abstract HttpRequestMessage CreateInvokeMethodRequest<TRequest>(HttpMethod httpMethod, string appId, string methodName, TRequest data);
-
+        
         /// <summary>
         /// Creates an <see cref="HttpRequestMessage" /> that can be used to perform service invocation for the
         /// application identified by <paramref name="appId" /> and invokes the method specified by <paramref name="methodName" />
@@ -568,7 +554,7 @@ namespace Dapr.Client
             TRequest data,
             CancellationToken cancellationToken = default)
         {
-            var request = CreateInvokeMethodRequest<TRequest>(httpMethod, appId, methodName, data);
+            var request = CreateInvokeMethodRequest<TRequest>(httpMethod, appId, methodName, new List<KeyValuePair<string, string>>(), data);
             return InvokeMethodAsync(request, cancellationToken);
         }
 
@@ -662,7 +648,7 @@ namespace Dapr.Client
             TRequest data,
             CancellationToken cancellationToken = default)
         {
-            var request = CreateInvokeMethodRequest<TRequest>(httpMethod, appId, methodName, data);
+            var request = CreateInvokeMethodRequest<TRequest>(httpMethod, appId, methodName, new List<KeyValuePair<string, string>>(), data);
             return InvokeMethodAsync<TResponse>(request, cancellationToken);
         }
 

--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -382,7 +382,7 @@ namespace Dapr.Client
             // This approach avoids some common pitfalls that could lead to undesired encoding.
             var path = $"/v1.0/invoke/{appId}/method/{methodName.TrimStart('/')}";
             var request = new HttpRequestMessage(httpMethod, new Uri(this.httpEndpoint, path));
-            request.AddQueryParameters(queryStringParameters);
+            request.RequestUri = request.RequestUri.AddQueryParameters(queryStringParameters);
 
             request.Options.Set(new HttpRequestOptionsKey<string>(AppIdKey), appId);
             request.Options.Set(new HttpRequestOptionsKey<string>(MethodNameKey), methodName);

--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -381,9 +381,9 @@ namespace Dapr.Client
             //
             // This approach avoids some common pitfalls that could lead to undesired encoding.
             var path = $"/v1.0/invoke/{appId}/method/{methodName.TrimStart('/')}";
-            var request = new HttpRequestMessage(httpMethod, new Uri(this.httpEndpoint, path));
-            request.RequestUri = request.RequestUri.AddQueryParameters(queryStringParameters);
-
+            var requestUri = new Uri(this.httpEndpoint, path).AddQueryParameters(queryStringParameters);
+            var request = new HttpRequestMessage(httpMethod, requestUri);
+            
             request.Options.Set(new HttpRequestOptionsKey<string>(AppIdKey), appId);
             request.Options.Set(new HttpRequestOptionsKey<string>(MethodNameKey), methodName);
 
@@ -393,23 +393,6 @@ namespace Dapr.Client
             }
 
             return request;
-        }
-
-        /// <summary>
-        /// Creates an <see cref="HttpRequestMessage" /> that can be used to perform service invocation for the
-        /// application identified by <paramref name="appId" /> and invokes the method specified by <paramref name="methodName" />
-        /// with the HTTP method specified by <paramref name="httpMethod" /> and a JSON serialized request body specified by 
-        /// <paramref name="data" />.
-        /// </summary>
-        /// <typeparam name="TRequest">The type of the data that will be JSON serialized and provided as the request body.</typeparam>
-        /// <param name="httpMethod">The <see cref="HttpMethod" /> to use for the invocation request.</param>
-        /// <param name="appId">The Dapr application id to invoke the method on.</param>
-        /// <param name="methodName">The name of the method to invoke.</param>
-        /// <param name="data">The data that will be JSON serialized and provided as the request body.</param>
-        /// <returns>An <see cref="HttpRequestMessage" /> for use with <c>SendInvokeMethodRequestAsync</c>.</returns>
-        public override HttpRequestMessage CreateInvokeMethodRequest<TRequest>(HttpMethod httpMethod, string appId, string methodName, TRequest data)
-        {
-            return CreateInvokeMethodRequest(httpMethod, appId, methodName, new List<KeyValuePair<string,string>>(), data);
         }
 
         /// <summary>

--- a/src/Dapr.Client/Extensions/EnumExtensions.cs
+++ b/src/Dapr.Client/Extensions/EnumExtensions.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
+#nullable enable
 using System;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -27,12 +28,14 @@ namespace Dapr.Client
         /// <returns></returns>
         public static string GetValueFromEnumMember<T>(this T value) where T : Enum
         {
+            ArgumentNullException.ThrowIfNull(value, nameof(value));
+
             var memberInfo = typeof(T).GetMember(value.ToString(), BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly);
             if (memberInfo.Length <= 0)
                 return value.ToString();
 
             var attributes = memberInfo[0].GetCustomAttributes(typeof(EnumMemberAttribute), false);
-            return attributes.Length > 0 ? ((EnumMemberAttribute)attributes[0]).Value : value.ToString();
+            return (attributes.Length > 0 ? ((EnumMemberAttribute)attributes[0]).Value : value.ToString()) ?? value.ToString();
         }
     }
 }

--- a/src/Dapr.Client/Extensions/HttpExtensions.cs
+++ b/src/Dapr.Client/Extensions/HttpExtensions.cs
@@ -14,7 +14,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Text;
 
 namespace Dapr.Client
@@ -22,21 +21,21 @@ namespace Dapr.Client
     /// <summary>
     /// Provides extensions specific to HTTP types.
     /// </summary>
-    public static class HttpExtensions
+    internal static class HttpExtensions
     {
         /// <summary>
         /// Appends key/value pairs to the query string on an HttpRequestMessage.
         /// </summary>
-        /// <param name="message">The message to append the query string parameters to.</param>
+        /// <param name="uri">The uri to append the query string parameters to.</param>
         /// <param name="queryStringParameters">The key/value pairs to populate the query string with.</param>
-        public static void AddQueryParameters(this HttpRequestMessage? message,
+        public static Uri AddQueryParameters(this Uri? uri,
             IReadOnlyCollection<KeyValuePair<string, string>>? queryStringParameters)
         {
-            ArgumentNullException.ThrowIfNull(message, nameof(message));
-            if (queryStringParameters is null || message.RequestUri is null)
-                return;
+            ArgumentNullException.ThrowIfNull(uri, nameof(uri));
+            if (queryStringParameters is null)
+                return uri;
 
-            var uriBuilder = new UriBuilder(message.RequestUri);
+            var uriBuilder = new UriBuilder(uri);
             var qsBuilder = new StringBuilder(uriBuilder.Query);
             foreach (var kvParam in queryStringParameters)
             {
@@ -46,7 +45,7 @@ namespace Dapr.Client
             }
 
             uriBuilder.Query = qsBuilder.ToString();
-            message.RequestUri = uriBuilder.Uri;
+            return uriBuilder.Uri;
         }
     }
 }

--- a/src/Dapr.Client/Extensions/HttpExtensions.cs
+++ b/src/Dapr.Client/Extensions/HttpExtensions.cs
@@ -1,0 +1,52 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2024 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace Dapr.Client
+{
+    /// <summary>
+    /// Provides extensions specific to HTTP types.
+    /// </summary>
+    public static class HttpExtensions
+    {
+        /// <summary>
+        /// Appends key/value pairs to the query string on an HttpRequestMessage.
+        /// </summary>
+        /// <param name="message">The message to append the query string parameters to.</param>
+        /// <param name="queryStringParameters">The key/value pairs to populate the query string with.</param>
+        public static void AddQueryParameters(this HttpRequestMessage? message,
+            IReadOnlyCollection<KeyValuePair<string, string>>? queryStringParameters)
+        {
+            ArgumentNullException.ThrowIfNull(message, nameof(message));
+            if (queryStringParameters is null || message.RequestUri is null)
+                return;
+
+            var uriBuilder = new UriBuilder(message.RequestUri);
+            var qsBuilder = new StringBuilder(uriBuilder.Query);
+            foreach (var kvParam in queryStringParameters)
+            {
+                if (qsBuilder.Length > 0)
+                    qsBuilder.Append('&');
+                qsBuilder.Append($"{Uri.EscapeDataString(kvParam.Key)}={Uri.EscapeDataString(kvParam.Value)}");
+            }
+
+            uriBuilder.Query = qsBuilder.ToString();
+            message.RequestUri = uriBuilder.Uri;
+        }
+    }
+}

--- a/test/Dapr.Client.Test/Extensions/EnumExtensionTest.cs
+++ b/test/Dapr.Client.Test/Extensions/EnumExtensionTest.cs
@@ -1,7 +1,7 @@
 ﻿using System.Runtime.Serialization;
 using Xunit;
 
-namespace Dapr.Client.Test
+namespace Dapr.Client.Test.Extensions
 {
     public class EnumExtensionTest
     {
@@ -29,9 +29,9 @@ namespace Dapr.Client.Test
 
     public enum TestEnum
     {
-        [EnumMember(Value="red")]
+        [EnumMember(Value = "red")]
         Red,
-        [EnumMember(Value="YELLOW")]
+        [EnumMember(Value = "YELLOW")]
         Yellow,
         Blue
     }

--- a/test/Dapr.Client.Test/Extensions/HttpExtensionTest.cs
+++ b/test/Dapr.Client.Test/Extensions/HttpExtensionTest.cs
@@ -11,8 +11,8 @@ namespace Dapr.Client.Test.Extensions
         {
             const string uri = "https://localhost/mypath";
             var httpRq = new HttpRequestMessage(HttpMethod.Get, uri);
-            httpRq.AddQueryParameters(null);
-            Assert.Equal(uri, httpRq.RequestUri.AbsoluteUri);
+            var updatedUri = httpRq.RequestUri.AddQueryParameters(null);
+            Assert.Equal(uri, updatedUri.AbsoluteUri);
         }
 
         [Fact]
@@ -20,44 +20,44 @@ namespace Dapr.Client.Test.Extensions
         {
             const string uri = "https://localhost/mypath?a=0&b=1";
             var httpRq = new HttpRequestMessage(HttpMethod.Get, uri);
-            httpRq.AddQueryParameters(null);
-            Assert.Equal(uri, httpRq.RequestUri.AbsoluteUri);
+            var updatedUri = httpRq.RequestUri.AddQueryParameters(null);
+            Assert.Equal(uri, updatedUri.AbsoluteUri);
         }
 
         [Fact]
         public void AddQueryParameters_BuildsQueryString()
         {
             var httpRq = new HttpRequestMessage(HttpMethod.Get, "https://localhost/mypath?a=0");
-            httpRq.AddQueryParameters(new List<KeyValuePair<string,string>>
+            var updatedUri = httpRq.RequestUri.AddQueryParameters(new List<KeyValuePair<string,string>>
             {
                 new("test", "value")
             });
-            Assert.Equal("https://localhost/mypath?a=0&test=value", httpRq.RequestUri.AbsoluteUri);
+            Assert.Equal("https://localhost/mypath?a=0&test=value", updatedUri.AbsoluteUri);
         }
 
         [Fact]
         public void AddQueryParameters_BuildQueryStringWithDuplicateKeys()
         {
             var httpRq = new HttpRequestMessage(HttpMethod.Get, "https://localhost/mypath");
-            httpRq.AddQueryParameters(new List<KeyValuePair<string,string>>
+            var updatedUri = httpRq.RequestUri.AddQueryParameters(new List<KeyValuePair<string,string>>
             {
                 new("test", "1"),
                 new("test", "2"),
                 new("test", "3")
             });
-            Assert.Equal("https://localhost/mypath?test=1&test=2&test=3", httpRq.RequestUri.AbsoluteUri);
+            Assert.Equal("https://localhost/mypath?test=1&test=2&test=3", updatedUri.AbsoluteUri);
         }
 
         [Fact]
         public void AddQueryParameters_EscapeSpacesInValues()
         {
             var httpRq = new HttpRequestMessage(HttpMethod.Get, "https://localhost/mypath");
-            httpRq.AddQueryParameters(new List<KeyValuePair<string,string>>
+            var updatedUri = httpRq.RequestUri.AddQueryParameters(new List<KeyValuePair<string,string>>
             {
                 new("name1", "John Doe"),
                 new("name2", "Jane Doe")
             });
-            Assert.Equal("https://localhost/mypath?name1=John%20Doe&name2=Jane%20Doe", httpRq.RequestUri.AbsoluteUri);
+            Assert.Equal("https://localhost/mypath?name1=John%20Doe&name2=Jane%20Doe", updatedUri.AbsoluteUri);
         }
     }
 }

--- a/test/Dapr.Client.Test/Extensions/HttpExtensionTest.cs
+++ b/test/Dapr.Client.Test/Extensions/HttpExtensionTest.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using Xunit;
+
+namespace Dapr.Client.Test.Extensions
+{
+    public class HttpExtensionTest
+    {
+        [Fact]
+        public void AddQueryParameters_ReturnsEmptyQueryStringWithNullParameters()
+        {
+            const string uri = "https://localhost/mypath";
+            var httpRq = new HttpRequestMessage(HttpMethod.Get, uri);
+            httpRq.AddQueryParameters(null);
+            Assert.Equal(uri, httpRq.RequestUri.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddQueryParameters_ReturnsOriginalQueryStringWithNullParameters()
+        {
+            const string uri = "https://localhost/mypath?a=0&b=1";
+            var httpRq = new HttpRequestMessage(HttpMethod.Get, uri);
+            httpRq.AddQueryParameters(null);
+            Assert.Equal(uri, httpRq.RequestUri.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddQueryParameters_BuildsQueryString()
+        {
+            var httpRq = new HttpRequestMessage(HttpMethod.Get, "https://localhost/mypath?a=0");
+            httpRq.AddQueryParameters(new List<KeyValuePair<string,string>>
+            {
+                new("test", "value")
+            });
+            Assert.Equal("https://localhost/mypath?a=0&test=value", httpRq.RequestUri.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddQueryParameters_BuildQueryStringWithDuplicateKeys()
+        {
+            var httpRq = new HttpRequestMessage(HttpMethod.Get, "https://localhost/mypath");
+            httpRq.AddQueryParameters(new List<KeyValuePair<string,string>>
+            {
+                new("test", "1"),
+                new("test", "2"),
+                new("test", "3")
+            });
+            Assert.Equal("https://localhost/mypath?test=1&test=2&test=3", httpRq.RequestUri.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AddQueryParameters_EscapeSpacesInValues()
+        {
+            var httpRq = new HttpRequestMessage(HttpMethod.Get, "https://localhost/mypath");
+            httpRq.AddQueryParameters(new List<KeyValuePair<string,string>>
+            {
+                new("name1", "John Doe"),
+                new("name2", "Jane Doe")
+            });
+            Assert.Equal("https://localhost/mypath?name1=John%20Doe&name2=Jane%20Doe", httpRq.RequestUri.AbsoluteUri);
+        }
+    }
+}


### PR DESCRIPTION
# Description
When a method is invoked via the Dapr service invocation building block, a query string can be passed through on the invocation URL without issue. However, when using the .NET SDK, this behavior isn't exposed anywhere. Existing overloads allow the app ID to be specified, the method named, the payload to be provided, but that's it - it's up to the developer to realize that a query string is supported, then augment the `RequestUri` property of the returned `HttpRequestMessage` to append their query string values, and proceed with the invocation.

This PR provides overloads to the invocation methods to allow an `IReadOnlyCollection<KeyValuePair<string,string>>` to be provided as the collection of key/value pairs to build/supplement the query string with. This uses a static extension method I've contributed (and added tests for) that appends the encoded key/value pairs provided in the collection to build a standards-matching query string so developers don't have to maintain the same on their own.

Why an `IReadOnlyCollection` instead of a `Dictionary<string,string>`? Because identical keys [can exist more than once in a query string](https://url.spec.whatwg.org/#example-searchparams-sort) with different values, so this needs to be more of a collection and less of a mapping. And because at the end of the day, this is being written to a string-based URI, these methods expect string-based keys and values, leaving it to the developer to figure out how to serialize accordingly before calling this.

Finally, I had the existing concrete implementations point to the new overloads and pass empty collections so as to avoid code duplication.

## Issue reference
Please reference the issue this PR will close: #1303 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation

Documentation PR extended here, though generically and not in a C#-specific way: [https://github.com/dapr/docs/pull/4217](https://github.com/dapr/docs/pull/4217)