### PR TITLE
[Service invocation] Link to non-Dapr endpoint how-to

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-client/_index.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-client/_index.md
@@ -24,6 +24,12 @@ The .NET SDK allows you to interface with all of the [Dapr building blocks]({{< 
 #### HTTP
 You can either use the `DaprClient` or `System.Net.Http.HttpClient` to invoke your services.
 
+{{% alert title="Note" color="primary" %}}
+ You can also [invoke a non-Dapr endpoint using either a named `HTTPEndpoint` or an FQDN URL to the non-Dapr environment]({{< ref "howto-invoke-non-dapr-endpoints.md#using-an-httpendpoint-resource-or-fqdn-url-for-non-dapr-endpoints" >}}).
+
+{{% /alert %}}
+
+
 {{< tabs SDK HTTP>}}
 
 {{% codetab %}}


### PR DESCRIPTION
# Description

Link from client doc to the 'invoke non-Dapr endpoint' how-to. 

## Issue reference

PR will close: dapr/docs#4029

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
