### PR TITLE
Added missing workflow status branch

### DIFF
--- a/src/Dapr.Workflow/WorkflowState.cs
+++ b/src/Dapr.Workflow/WorkflowState.cs
@@ -84,6 +84,8 @@ namespace Dapr.Workflow
                         return WorkflowRuntimeStatus.Terminated;
                     case OrchestrationRuntimeStatus.Pending:
                         return WorkflowRuntimeStatus.Pending;
+                    case OrchestrationRuntimeStatus.Suspended:
+                        return WorkflowRuntimeStatus.Suspended;
                     default:
                         return WorkflowRuntimeStatus.Unknown;
                 }


### PR DESCRIPTION
# Description

Added a missing branch to switch statement to support `WorkflowRuntimeStatus.Suspended`. Thanks to @cgillum for pointing out [where the error was](https://github.com/dapr/dotnet-sdk/issues/1215#issuecomment-2345069306).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1215

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [N/A] Created/updated tests
* [X] Extended the documentation

Surprising, there's no unit test package for the workflow project. This should be remedied, but isn't particularly necessary for this patch as it's quite a minor add.