### PR TITLE
Removed invalid service invocation check when using HttpRequestMessage

### DIFF
--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -423,12 +423,7 @@ namespace Dapr.Client
         public override async Task<HttpResponseMessage> InvokeMethodWithResponseAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
         {
             ArgumentVerifier.ThrowIfNull(request, nameof(request));
-
-            if (!this.httpEndpoint.IsBaseOf(request.RequestUri))
-            {
-                throw new InvalidOperationException("The provided request URI is not a Dapr service invocation URI.");
-            }
-
+            
             // Note: we intentionally DO NOT validate the status code here.
             // This method allows you to 'invoke' without exceptions on non-2xx.
             try


### PR DESCRIPTION
# Description

While building out a repro project to investigate #1352, I was unable to validate that (awaiting further information), but did find a bug in the client when a service invocation involved an `HttpRequestMessage`. It would incorrectly validate the host/port of the destination request with the local HTTP client endpoint for a match before proceeding - this would likely never work unless it were calling an endpoint on its own service.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1311 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [N/A] Created/updated tests - No existing tests to update
* [N/A] Extended the documentation
