### PR TITLE
Fixed security advisory updates across dependencies (transitive and direct)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
         <PackageVersion Include="Serilog" Version="3.0.1" />
-        <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />
+        <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
         <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageVersion Include="System.Text.Json" Version="6.0.10"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
         <PackageVersion Include="coverlet.msbuild" Version="6.0.2"/>
         <PackageVersion Include="FluentAssertions" Version="5.9.0" />
         <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
@@ -20,7 +21,7 @@
         <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4"  />
         <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
         <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.3.0" />
         <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,13 +10,13 @@
         <PackageVersion Include="FluentAssertions" Version="5.9.0" />
         <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
         <PackageVersion Include="Google.Api.CommonProtos" Version="2.2.0" />
-        <PackageVersion Include="Google.Protobuf" Version="3.21.12" />
-        <PackageVersion Include="Grpc.AspNetCore" Version="2.39.0" />
-        <PackageVersion Include="Grpc.Core.Testing" Version="2.46.3" />
-        <PackageVersion Include="Grpc.Net.Client" Version="2.52.0" />
-        <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.47.0" />
-        <PackageVersion Include="Grpc.Tools" Version="2.47.0"  />
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />
+        <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
+        <PackageVersion Include="Grpc.AspNetCore" Version="2.66.0" />
+        <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
+        <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
+        <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.66.0" />
+        <PackageVersion Include="Grpc.Tools" Version="2.67.0"  />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.35" />
         <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.35" />
         <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4"  />
         <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,40 @@
+<Project>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageVersion Include="coverlet.msbuild" Version="6.0.2"/>
+        <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+        <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
+        <PackageVersion Include="Google.Api.CommonProtos" Version="2.2.0" />
+        <PackageVersion Include="Google.Protobuf" Version="3.21.12" />
+        <PackageVersion Include="Grpc.AspNetCore" Version="2.39.0" />
+        <PackageVersion Include="Grpc.Core.Testing" Version="2.46.3" />
+        <PackageVersion Include="Grpc.Net.Client" Version="2.52.0" />
+        <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.47.0" />
+        <PackageVersion Include="Grpc.Tools" Version="2.47.0"  />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />
+        <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.35" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4"  />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+        <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.3.0" />
+        <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.3.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+        <PackageVersion Include="MinVer" Version="2.3.0"/>
+        <PackageVersion Include="Moq" Version="4.20.70" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.0.123" />
+        <PackageVersion Include="System.Text.Json" Version="6.0.10"/>
+        <PackageVersion Include="xunit" Version="2.8.1" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1"/>
+    </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
 
     <ItemGroup>
         <PackageVersion Include="coverlet.msbuild" Version="6.0.2"/>
-        <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+        <PackageVersion Include="FluentAssertions" Version="5.9.0" />
         <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
         <PackageVersion Include="Google.Api.CommonProtos" Version="2.2.0" />
         <PackageVersion Include="Google.Protobuf" Version="3.21.12" />
@@ -30,11 +30,15 @@
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
         <PackageVersion Include="MinVer" Version="2.3.0"/>
-        <PackageVersion Include="Moq" Version="4.20.70" />
+        <PackageVersion Include="Moq" Version="4.20.72" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.0.123" />
+        <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
+        <PackageVersion Include="Serilog" Version="3.0.1" />
+        <PackageVersion Include="Serilog.AspNetCore" Version="7.0.0" />
+        <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+        <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageVersion Include="System.Text.Json" Version="6.0.10"/>
-        <PackageVersion Include="xunit" Version="2.8.1" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1"/>
+        <PackageVersion Include="xunit" Version="2.9.2" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
     </ItemGroup>
 </Project>

--- a/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
+++ b/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
@@ -10,11 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.47.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.AspNetCore" />
+    <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.CommonProtos" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Client/PublishSubscribe/BulkPublishEventExample/BulkPublishEventExample.csproj
+++ b/examples/Client/PublishSubscribe/BulkPublishEventExample/BulkPublishEventExample.csproj
@@ -16,9 +16,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-        <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Google.Api.CommonProtos" />
+        <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/examples/Client/PublishSubscribe/PublishEventExample/PublishEventExample.csproj
+++ b/examples/Client/PublishSubscribe/PublishEventExample/PublishEventExample.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Google.Api.CommonProtos" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/examples/Client/ServiceInvocation/ServiceInvocation.csproj
+++ b/examples/Client/ServiceInvocation/ServiceInvocation.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Google.Api.CommonProtos" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/examples/Client/StateManagement/StateManagement.csproj
+++ b/examples/Client/StateManagement/StateManagement.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Google.Api.CommonProtos" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/examples/Workflow/WorkflowUnitTest/WorkflowUnitTest.csproj
+++ b/examples/Workflow/WorkflowUnitTest/WorkflowUnitTest.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/properties/dapr_managed_netcore.props
+++ b/properties/dapr_managed_netcore.props
@@ -53,7 +53,7 @@
 
   <!-- Use MinVer for assembly, nuget versioning based on git tags -->
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.3.0">
+    <PackageReference Include="MinVer">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Dapr.Actors.Generators/Dapr.Actors.Generators.csproj
+++ b/src/Dapr.Actors.Generators/Dapr.Actors.Generators.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
   <!--

--- a/src/Dapr.Actors/Dapr.Actors.csproj
+++ b/src/Dapr.Actors/Dapr.Actors.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapr.Client/Dapr.Client.csproj
+++ b/src/Dapr.Client/Dapr.Client.csproj
@@ -16,10 +16,10 @@
     <Description>This package contains the reference assemblies for developing services using Dapr.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.15.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
-    <PackageReference Include="Google.Api.CommonProtos" Version="2.2.0" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+    <PackageReference Include="Google.Api.CommonProtos" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dapr.Extensions.Configuration/Dapr.Extensions.Configuration.csproj
+++ b/src/Dapr.Extensions.Configuration/Dapr.Extensions.Configuration.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" Version="1.2.*" />
-    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" Version="1.2.*" />
+    <PackageReference Include="Microsoft.DurableTask.Client.Grpc" />
+    <PackageReference Include="Microsoft.DurableTask.Worker.Grpc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
   </ItemGroup>
 
   <!-- Enable Deterministic Builds for github actions -->

--- a/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.Actors.AspNetCore.IntegrationTest/Dapr.Actors.AspNetCore.IntegrationTest.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"  />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Dapr.Actors.AspNetCore.Test/Dapr.Actors.AspNetCore.Test.csproj
+++ b/test/Dapr.Actors.AspNetCore.Test/Dapr.Actors.AspNetCore.Test.csproj
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.18" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="FluentAssertions"  />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost"  />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Dapr.Actors.Generators.Test/CSharpSourceGeneratorVerifier.cs
+++ b/test/Dapr.Actors.Generators.Test/CSharpSourceGeneratorVerifier.cs
@@ -24,7 +24,9 @@ using Microsoft.CodeAnalysis.Testing.Verifiers;
 internal static class CSharpSourceGeneratorVerifier<TSourceGenerator>
     where TSourceGenerator : ISourceGenerator, new()
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     public class Test : CSharpSourceGeneratorTest<TSourceGenerator, XUnitVerifier>
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         public Test()
         {

--- a/test/Dapr.Actors.Generators.Test/Dapr.Actors.Generators.Test.csproj
+++ b/test/Dapr.Actors.Generators.Test/Dapr.Actors.Generators.Test.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit"  />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />

--- a/test/Dapr.Actors.Generators.Test/Dapr.Actors.Generators.Test.csproj
+++ b/test/Dapr.Actors.Generators.Test/Dapr.Actors.Generators.Test.csproj
@@ -13,17 +13,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
+++ b/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
@@ -20,22 +20,6 @@
     </PackageReference>
   </ItemGroup>
 
-<!--    <ItemGroup>-->
-<!--        <PackageReference Include="coverlet.msbuild" Version="6.0.2">-->
-<!--            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
-<!--            <PrivateAssets>all</PrivateAssets>-->
-<!--        </PackageReference>-->
-<!--        <PackageReference Include="FluentAssertions" Version="5.9.0" />-->
-<!--        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />-->
-<!--        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />-->
-<!--        <PackageReference Include="Moq" Version="4.20.70" />-->
-<!--        <PackageReference Include="xunit" Version="2.8.1" />-->
-<!--        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">-->
-<!--            <PrivateAssets>all</PrivateAssets>-->
-<!--            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
-<!--        </PackageReference>-->
-<!--    </ItemGroup>-->
-
   <ItemGroup>
     <Compile Include="..\Shared\GrpcUtils.cs" />
     <Compile Include="..\Shared\TestClient.cs" />

--- a/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
+++ b/test/Dapr.Actors.Test/Dapr.Actors.Test.csproj
@@ -5,20 +5,36 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+<!--    <ItemGroup>-->
+<!--        <PackageReference Include="coverlet.msbuild" Version="6.0.2">-->
+<!--            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
+<!--            <PrivateAssets>all</PrivateAssets>-->
+<!--        </PackageReference>-->
+<!--        <PackageReference Include="FluentAssertions" Version="5.9.0" />-->
+<!--        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />-->
+<!--        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />-->
+<!--        <PackageReference Include="Moq" Version="4.20.70" />-->
+<!--        <PackageReference Include="xunit" Version="2.8.1" />-->
+<!--        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">-->
+<!--            <PrivateAssets>all</PrivateAssets>-->
+<!--            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
+<!--        </PackageReference>-->
+<!--    </ItemGroup>-->
 
   <ItemGroup>
     <Compile Include="..\Shared\GrpcUtils.cs" />

--- a/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
@@ -15,21 +15,6 @@
         </PackageReference>
       </ItemGroup>
     
-<!--  <ItemGroup>-->
-<!--    <PackageReference Include="coverlet.msbuild" Version="6.0.2">-->
-<!--      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
-<!--      <PrivateAssets>all</PrivateAssets>-->
-<!--    </PackageReference>-->
-<!--    <PackageReference Include="FluentAssertions" Version="5.9.0" />-->
-<!--    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />-->
-<!--    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />-->
-<!--    <PackageReference Include="xunit" Version="2.8.1" />-->
-<!--    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">-->
-<!--      <PrivateAssets>all</PrivateAssets>-->
-<!--      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
-<!--    </PackageReference>-->
-<!--  </ItemGroup>-->
-    
     <PropertyGroup>
         <NoWarn>NU1903</NoWarn>
         <WarningsNotAsErrors>NU1903</WarningsNotAsErrors>

--- a/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
+++ b/test/Dapr.AspNetCore.IntegrationTest/Dapr.AspNetCore.IntegrationTest.csproj
@@ -1,19 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+      <ItemGroup>
+        <PackageReference Include="coverlet.msbuild">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+      </ItemGroup>
+    
+<!--  <ItemGroup>-->
+<!--    <PackageReference Include="coverlet.msbuild" Version="6.0.2">-->
+<!--      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
+<!--      <PrivateAssets>all</PrivateAssets>-->
+<!--    </PackageReference>-->
+<!--    <PackageReference Include="FluentAssertions" Version="5.9.0" />-->
+<!--    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />-->
+<!--    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />-->
+<!--    <PackageReference Include="xunit" Version="2.8.1" />-->
+<!--    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">-->
+<!--      <PrivateAssets>all</PrivateAssets>-->
+<!--      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>-->
+<!--    </PackageReference>-->
+<!--  </ItemGroup>-->
+    
+    <PropertyGroup>
+        <NoWarn>NU1903</NoWarn>
+        <WarningsNotAsErrors>NU1903</WarningsNotAsErrors>
+        <NuGetAudit>false</NuGetAudit>
+        <NuGetAuditMode>direct</NuGetAuditMode>
+    </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />

--- a/test/Dapr.AspNetCore.Test/Dapr.AspNetCore.Test.csproj
+++ b/test/Dapr.AspNetCore.Test/Dapr.AspNetCore.Test.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="FluentAssertions"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Dapr.Client.Test/Dapr.Client.Test.csproj
+++ b/test/Dapr.Client.Test/Dapr.Client.Test.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.15.8" />
-    <PackageReference Include="Grpc.Core.Testing" Version="2.46.3" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="moq" Version="4.20.70" />
-    <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.123" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Core.Testing" />
+    <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="moq" />
+    <PackageReference Include="protobuf-net.Grpc.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="xunit"  />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Dapr.Client.Test/DaprClientTest.InvokeMethodGrpcAsync.cs
+++ b/test/Dapr.Client.Test/DaprClientTest.InvokeMethodGrpcAsync.cs
@@ -197,7 +197,7 @@ namespace Dapr.Client.Test
                 .Setup(m => m.InvokeServiceAsync(It.IsAny<Autogen.Grpc.v1.InvokeServiceRequest>(), It.IsAny<CallOptions>()))
                 .Returns(response);
 
-            FluentActions.Awaiting(async () => await client.DaprClient.InvokeMethodGrpcAsync<Request>("test", "test", request)).Should().NotThrow();
+            FluentActions.Awaiting(async () => await client.DaprClient.InvokeMethodGrpcAsync<Request>("test", "test", request)).Should().NotThrowAsync();
         }
 
         [Fact]

--- a/test/Dapr.Client.Test/StateApiTest.cs
+++ b/test/Dapr.Client.Test/StateApiTest.cs
@@ -505,7 +505,7 @@ namespace Dapr.Client.Test
             req1.Request.Etag.Value.Should().Be("testEtag");
             req1.Request.Metadata.Count.Should().Be(1);
             req1.Request.Metadata["a"].Should().Be("b");
-            req1.Request.Options.Concurrency.Should().Be(2);
+            req1.Request.Options.Concurrency.Should().Be(StateConcurrency.ConcurrencyLastWrite);
 
             var req2 = envelope.Operations[1];
             req2.Request.Key.Should().Be("stateKey2");

--- a/test/Dapr.E2E.Test.Actors.Generators/Dapr.E2E.Test.Actors.Generators.csproj
+++ b/test/Dapr.E2E.Test.Actors.Generators/Dapr.E2E.Test.Actors.Generators.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Dapr.E2E.Test.App.Grpc/Dapr.E2E.Test.App.Grpc.csproj
+++ b/test/Dapr.E2E.Test.App.Grpc/Dapr.E2E.Test.App.Grpc.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.39.0" />
+    <PackageReference Include="Grpc.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="Proto/message.proto" />

--- a/test/Dapr.E2E.Test.App/Dapr.E2E.Test.App.csproj
+++ b/test/Dapr.E2E.Test.App/Dapr.E2E.Test.App.csproj
@@ -8,9 +8,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="3.0.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Sinks.Console"/>
+    <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
 </Project>

--- a/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
+++ b/test/Dapr.E2E.Test/Dapr.E2E.Test.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.21.12" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.47.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Net.ClientFactory" />
+    <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
+++ b/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"  />
+    <PackageReference Include="Moq"  />
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
+++ b/test/Dapr.Extensions.Configuration.Test/Dapr.Extensions.Configuration.Test.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_managed_netcore.props" />
 
-  <PropertyGroup>
+  <PropertyGroup>  
     <TargetFrameworks>net6;net7;net8</TargetFrameworks>
-
+      
     <!-- Set Output Path for tests-->
     <OutputPath>$(RepoRoot)bin\$(Configuration)\test\$(MSBuildProjectName)\</OutputPath>
 
@@ -12,6 +12,6 @@
 
   <!-- Used to annotate PR with test failures: https://github.com/Tyrrrz/GitHubActionsTestLogger -->
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.1.2" />
+    <PackageReference Include="GitHubActionsTestLogger" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

.NET 9 replaces the NuGet vulnerability scanner opt-in functionality with a project-wide (including transitive references) scanner by default. For some reason today, my system received this preview and I was utterly unable to build Dapr locally.

At @philliphoff 's suggestion, I've implemented central package management with transient dependency pinning across the solution and then updated all packages to the latest versions compatible with .NET 6 (as it's still supported with 1.15).

There were a few unit tests that needed a tweak because of the package updates, so they're bundled in here as well, but everything builds on my system as it should at this point. Some of the packages were wildly out of date, so this should also lend itself to at least a minor performance boost on the client as well.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [N/A] Extended the documentation
