### PR TITLE
Updating actor serialization documentation

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-serialization.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-serialization.md
@@ -83,6 +83,9 @@ require specifying that you intend the attribute to apply to a property and not 
 public record Thingy(string Name, [property: JsonPropertyName("count")] int Count);
 ```
 
+If `[property: ]` is applied to the `[JsonPropertyName]` attribute where it's not necessary, it will not negatively impact serialization or deserialization as the operation will
+proceed normally as though it were a property (as it typically would if not marked as such).
+
 ### Enumeration types
 Enumerations, including flat enumerations are serializable to JSON, but the value persisted may surprise you. Again, it's not expected that the developer should ever engage
 with the serialized data independently of Dapr, but the following information may at least help in diagnosing why a seemingly mild version migration isn't working as expected.

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-serialization.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-serialization.md
@@ -47,6 +47,7 @@ The default property names can be overridden by applying the `[JsonPropertyName]
 Generally, this isn't going to be necessary for types you're persisting to the actor state as you're not intended to read or write them independent of Dapr-associated functionality, but
 the following is provided just to clearly illustrate that it's possible.
 
+#### Override Property Names on Classes
 Here's an example demonstrating the use of `JsonPropertyName` to change the name for the first property following serialization. Note that the last usage of `JsonPropertyName` on the `Count` property 
 matches what it would be expected to serialize to. This is largely just to demonstrate that applying this attribute won't negatively impact anything - in fact, it might be preferable if you later 
 decide to change the default serialization options but still need to consistently access the properties previously serialized before that change as `JsonPropertyName` will override those options.
@@ -66,6 +67,20 @@ This would serialize to the following:
 
 ```json
 {"identifier": "a06ced64-4f42-48ad-84dd-46ae6a7e333d", "name": "DoodadName", "count": 5}
+```
+
+#### Override Property Names on Records
+Let's try doing the same thing with a record from C# 12 or later:
+
+```csharp
+public record Thingy(string Name, [JsonPropertyName("count")] int Count); 
+```
+
+Because the argument passed in a primary constructor (introduced in C# 12) can be applied to either a property or field within a record, using the `[JsonPropertyName]` attribute may
+require specifying that you intend the attribute to apply to a property and not a field in some ambiguous cases. Should this be necessary, you'd indicate as much in the primary constructor with:
+
+```csharp
+public record Thingy(string Name, [property: JsonPropertyName("count")] int Count);
 ```
 
 ### Enumeration types


### PR DESCRIPTION
# Description

Updated the actor serialization documentation to reflect the differences between the JSON serialization and the Data Contract serialization approaches used in the Dapr.Actors SDK, how they relate to the different actor client types and some examples of how to properly use each of them.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

This addresses a comment left at https://github.com/dapr/dotnet-sdk/pull/1073#issuecomment-1952420285 and occasionally seen in Discord though doesn't have an open issue that I see.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [N/A] Code compiles correctly
* [N/A] Created/updated tests
* [X] Extended the documentation
