### PR TITLE
cleanup: Removed Serilog nuget from Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,49 +1,47 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-        <PackageVersion Include="coverlet.msbuild" Version="6.0.2"/>
-        <PackageVersion Include="FluentAssertions" Version="5.9.0" />
-        <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
-        <PackageVersion Include="Google.Api.CommonProtos" Version="2.2.0" />
-        <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
-        <PackageVersion Include="Grpc.AspNetCore" Version="2.66.0" />
-        <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
-        <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
-        <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.66.0" />
-        <PackageVersion Include="Grpc.Tools" Version="2.67.0"  />
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.35" />
-        <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.35" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4"  />
-        <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-        <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.3.0" />
-        <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.3.0" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0"/>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-        <PackageVersion Include="MinVer" Version="2.3.0"/>
-        <PackageVersion Include="Moq" Version="4.20.72" />
-        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
-        <PackageVersion Include="Serilog" Version="3.0.1" />
-        <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
-        <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
-        <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
-        <PackageVersion Include="System.Text.Json" Version="6.0.10"/>
-        <PackageVersion Include="xunit" Version="2.9.2" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageVersion Include="FluentAssertions" Version="5.9.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
+    <PackageVersion Include="Google.Api.CommonProtos" Version="2.2.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.66.0" />
+    <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.66.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.67.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.35" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.35" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="MinVer" Version="2.3.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,47 +1,47 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
-    <PackageVersion Include="FluentAssertions" Version="5.9.0" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
-    <PackageVersion Include="Google.Api.CommonProtos" Version="2.2.0" />
-    <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.66.0" />
-    <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.66.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.67.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.35" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.35" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="MinVer" Version="2.3.0" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+        <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+        <PackageVersion Include="FluentAssertions" Version="5.9.0" />
+        <PackageVersion Include="GitHubActionsTestLogger" Version="1.1.2" />
+        <PackageVersion Include="Google.Api.CommonProtos" Version="2.2.0" />
+        <PackageVersion Include="Google.Protobuf" Version="3.28.2" />
+        <PackageVersion Include="Grpc.AspNetCore" Version="2.66.0" />
+        <PackageVersion Include="Grpc.Core.Testing" Version="2.46.6" />
+        <PackageVersion Include="Grpc.Net.Client" Version="2.66.0" />
+        <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.66.0" />
+        <PackageVersion Include="Grpc.Tools" Version="2.67.0" />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.35" />
+        <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.35" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+        <PackageVersion Include="Microsoft.DurableTask.Client.Grpc" Version="1.3.0" />
+        <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.3.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+        <PackageVersion Include="MinVer" Version="2.3.0" />
+        <PackageVersion Include="Moq" Version="4.20.72" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
+        <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
+        <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+        <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+        <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
+        <PackageVersion Include="System.Text.Json" Version="6.0.10" />
+        <PackageVersion Include="xunit" Version="2.9.2" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    </ItemGroup>
 </Project>

--- a/test/Dapr.E2E.Test.App/Dapr.E2E.Test.App.csproj
+++ b/test/Dapr.E2E.Test.App/Dapr.E2E.Test.App.csproj
@@ -8,9 +8,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.AspNetCore" />
-    <PackageReference Include="Serilog.Sinks.Console"/>
+    <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

Removed `Serilog` nuget from `DirectoryPackages.props` because it can be handled as a transient dependency so you don't have to update it manually.

## Issue reference

-

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
