### PR TITLE
Optional WF lifecycle change

### DIFF
--- a/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
+++ b/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
@@ -29,25 +29,48 @@ public static class WorkflowServiceCollectionExtensions
     /// </summary>
     /// <param name="serviceCollection">The <see cref="IServiceCollection"/>.</param>
     /// <param name="configure">A delegate used to configure actor options and register workflow functions.</param>
+    /// <param name="lifetime">The lifetime of the registered services.</param>
     public static IServiceCollection AddDaprWorkflow(
         this IServiceCollection serviceCollection,
-        Action<WorkflowRuntimeOptions> configure)
+        Action<WorkflowRuntimeOptions> configure,
+        ServiceLifetime lifetime = ServiceLifetime.Singleton)
     {
         if (serviceCollection == null)
         {
             throw new ArgumentNullException(nameof(serviceCollection));
         }
 
-        serviceCollection.TryAddSingleton<WorkflowRuntimeOptions>();
-        serviceCollection.AddHttpClient();
-
-#pragma warning disable CS0618 // Type or member is obsolete - keeping around temporarily - replaced by DaprWorkflowClient
-        serviceCollection.TryAddSingleton<WorkflowEngineClient>();
-#pragma warning restore CS0618 // Type or member is obsolete
-        serviceCollection.AddHostedService<WorkflowLoggingService>();
-        serviceCollection.TryAddSingleton<DaprWorkflowClient>();
         serviceCollection.AddDaprClient();
-            
+        serviceCollection.AddHttpClient();
+        serviceCollection.AddHostedService<WorkflowLoggingService>();
+        
+        switch (lifetime)
+        {
+            case ServiceLifetime.Singleton:
+#pragma warning disable CS0618 // Type or member is obsolete - keeping around temporarily - replaced by DaprWorkflowClient
+                serviceCollection.TryAddSingleton<WorkflowEngineClient>();
+#pragma warning restore CS0618 // Type or member is obsolete
+                serviceCollection.TryAddSingleton<DaprWorkflowClient>();
+                serviceCollection.TryAddSingleton<WorkflowRuntimeOptions>();
+                break;
+            case ServiceLifetime.Scoped:
+#pragma warning disable CS0618 // Type or member is obsolete - keeping around temporarily - replaced by DaprWorkflowClient
+                serviceCollection.TryAddScoped<WorkflowEngineClient>();
+#pragma warning restore CS0618 // Type or member is obsolete
+                serviceCollection.TryAddScoped<DaprWorkflowClient>();
+                serviceCollection.TryAddScoped<WorkflowRuntimeOptions>();
+                break;
+            case ServiceLifetime.Transient:
+#pragma warning disable CS0618 // Type or member is obsolete - keeping around temporarily - replaced by DaprWorkflowClient
+                serviceCollection.TryAddTransient<WorkflowEngineClient>();
+#pragma warning restore CS0618 // Type or member is obsolete
+                serviceCollection.TryAddTransient<DaprWorkflowClient>();
+                serviceCollection.TryAddTransient<WorkflowRuntimeOptions>();
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, null);
+        }
+        
         serviceCollection.AddOptions<WorkflowRuntimeOptions>().Configure(configure);
             
         //Register the factory and force resolution so the Durable Task client and worker can be registered


### PR DESCRIPTION
# Description

There was a [request in Discord](https://discord.com/channels/778680217417809931/1075836407156850698/1308907688129855499) that indicated it could be useful to be able to specify different service lifetimes during the Workflow client DI registration (they want to inject a transient service and our use of singleton registration broke this).

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
