### PR TITLE
Additional lifecycle registration changes

### DIFF
--- a/src/Dapr.Actors.AspNetCore/ActorsServiceCollectionExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/ActorsServiceCollectionExtensions.cs
@@ -39,9 +39,10 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             ArgumentNullException.ThrowIfNull(services, nameof(services));
 
-            // Routing and health checks are required dependencies.
+            // Routing, health checks and logging are required dependencies.
             services.AddRouting();
             services.AddHealthChecks();
+            services.AddLogging();
 
             var actorRuntimeRegistration = new Func<IServiceProvider, ActorRuntime>(s =>
             {

--- a/src/Dapr.Actors.AspNetCore/ActorsServiceCollectionExtensions.cs
+++ b/src/Dapr.Actors.AspNetCore/ActorsServiceCollectionExtensions.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" />.</param>
         /// <param name="configure">A delegate used to configure actor options and register actor types.</param>
-        public static void AddActors(this IServiceCollection? services, Action<ActorRuntimeOptions>? configure)
+        /// <param name="lifetime">The lifetime of the registered services.</param>
+        public static void AddActors(this IServiceCollection? services, Action<ActorRuntimeOptions>? configure, ServiceLifetime lifetime = ServiceLifetime.Singleton)
         {
             ArgumentNullException.ThrowIfNull(services, nameof(services));
 
@@ -42,9 +43,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddRouting();
             services.AddHealthChecks();
 
-            services.TryAddSingleton<ActorActivatorFactory, DependencyInjectionActorActivatorFactory>();
-            services.TryAddSingleton<ActorRuntime>(s =>
-            {   
+            var actorRuntimeRegistration = new Func<IServiceProvider, ActorRuntime>(s =>
+            {
                 var options = s.GetRequiredService<IOptions<ActorRuntimeOptions>>().Value;
                 ConfigureActorOptions(s, options);
                 
@@ -53,11 +53,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 var proxyFactory = s.GetRequiredService<IActorProxyFactory>();
                 return new ActorRuntime(options, loggerFactory, activatorFactory, proxyFactory);
             });
-
-            services.TryAddSingleton<IActorProxyFactory>(s =>
+            var proxyFactoryRegistration = new Func<IServiceProvider, IActorProxyFactory>(serviceProvider =>
             {
-                var options = s.GetRequiredService<IOptions<ActorRuntimeOptions>>().Value;
-                ConfigureActorOptions(s, options);
+                var options = serviceProvider.GetRequiredService<IOptions<ActorRuntimeOptions>>().Value;
+                ConfigureActorOptions(serviceProvider, options);
 
                 var factory = new ActorProxyFactory() 
                 { 
@@ -72,6 +71,26 @@ namespace Microsoft.Extensions.DependencyInjection
                 return factory;
             });
 
+            switch (lifetime)
+            {
+                case ServiceLifetime.Scoped:
+                    services.TryAddScoped<ActorActivatorFactory, DependencyInjectionActorActivatorFactory>();
+                    services.TryAddScoped<ActorRuntime>(actorRuntimeRegistration);
+                    services.TryAddScoped<IActorProxyFactory>(proxyFactoryRegistration);
+                    break;
+                case ServiceLifetime.Transient:
+                    services.TryAddTransient<ActorActivatorFactory, DependencyInjectionActorActivatorFactory>();
+                    services.TryAddTransient<ActorRuntime>(actorRuntimeRegistration);
+                    services.TryAddTransient<IActorProxyFactory>(proxyFactoryRegistration);
+                    break;
+                default:
+                case ServiceLifetime.Singleton:
+                    services.TryAddSingleton<ActorActivatorFactory, DependencyInjectionActorActivatorFactory>();
+                    services.TryAddSingleton<ActorRuntime>(actorRuntimeRegistration);
+                    services.TryAddSingleton<IActorProxyFactory>(proxyFactoryRegistration);
+                    break;
+            }
+            
             if (configure != null)
             {
                 services.Configure<ActorRuntimeOptions>(configure);

--- a/src/Dapr.Messaging/PublishSubscribe/Extensions/PublishSubscribeServiceCollectionExtensions.cs
+++ b/src/Dapr.Messaging/PublishSubscribe/Extensions/PublishSubscribeServiceCollectionExtensions.cs
@@ -13,15 +13,16 @@ public static class PublishSubscribeServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/>.</param>
     /// <param name="configure">Optionally allows greater configuration of the <see cref="DaprPublishSubscribeClient"/> using injected services.</param>
+    /// <param name="lifetime">The lifetime of the registered services.</param>
     /// <returns></returns>
-    public static IServiceCollection AddDaprPubSubClient(this IServiceCollection services, Action<IServiceProvider, DaprPublishSubscribeClientBuilder>? configure = null)
+    public static IServiceCollection AddDaprPubSubClient(this IServiceCollection services, Action<IServiceProvider, DaprPublishSubscribeClientBuilder>? configure = null, ServiceLifetime lifetime = ServiceLifetime.Singleton)
     {
         ArgumentNullException.ThrowIfNull(services, nameof(services));
 
         //Register the IHttpClientFactory implementation
         services.AddHttpClient();
 
-        services.TryAddSingleton(serviceProvider =>
+        var registration = new Func<IServiceProvider, DaprPublishSubscribeClient>(serviceProvider =>
         {
             var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
 
@@ -32,6 +33,20 @@ public static class PublishSubscribeServiceCollectionExtensions
 
             return builder.Build();
         });
+
+        switch (lifetime)
+        {
+            case ServiceLifetime.Scoped:
+                services.TryAddScoped(registration);
+                break;
+            case ServiceLifetime.Transient:
+                services.TryAddTransient(registration);
+                break;
+            default:
+            case ServiceLifetime.Singleton:
+                services.TryAddSingleton(registration);
+                break;
+        }
 
         return services;
     }

--- a/test/Dapr.Actors.AspNetCore.Test/DaprActorServiceCollectionExtensionsTest.cs
+++ b/test/Dapr.Actors.AspNetCore.Test/DaprActorServiceCollectionExtensionsTest.cs
@@ -1,0 +1,60 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Dapr.Actors.AspNetCore.Test;
+
+public sealed class DaprActorServiceCollectionExtensionsTest
+{
+    [Fact]
+    public void RegisterActorsClient_ShouldRegisterSingleton_WhenLifetimeIsSingleton()
+    {
+        var services = new ServiceCollection();
+
+        services.AddActors(options => { }, ServiceLifetime.Singleton);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var daprClient1 = serviceProvider.GetService<Runtime.ActorRuntime>();
+        var daprClient2 = serviceProvider.GetService<Runtime.ActorRuntime>();
+
+        Assert.NotNull(daprClient1);
+        Assert.NotNull(daprClient2);
+        
+        Assert.Same(daprClient1, daprClient2);
+    }
+
+    [Fact]
+    public async Task RegisterActorsClient_ShouldRegisterScoped_WhenLifetimeIsScoped()
+    {
+        var services = new ServiceCollection();
+
+        services.AddActors(options => { }, ServiceLifetime.Scoped);
+        var serviceProvider = services.BuildServiceProvider();
+
+        await using var scope1 = serviceProvider.CreateAsyncScope();
+        var daprClient1 = scope1.ServiceProvider.GetService<Runtime.ActorRuntime>();
+
+        await using var scope2 = serviceProvider.CreateAsyncScope();
+        var daprClient2 = scope2.ServiceProvider.GetService<Runtime.ActorRuntime>();
+                
+        Assert.NotNull(daprClient1);
+        Assert.NotNull(daprClient2);
+        Assert.NotSame(daprClient1, daprClient2);
+    }
+
+    [Fact]
+    public void RegisterActorsClient_ShouldRegisterTransient_WhenLifetimeIsTransient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddActors(options => { }, ServiceLifetime.Transient);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var daprClient1 = serviceProvider.GetService<Runtime.ActorRuntime>();
+        var daprClient2 = serviceProvider.GetService<Runtime.ActorRuntime>();
+
+        Assert.NotNull(daprClient1);
+        Assert.NotNull(daprClient2);
+        Assert.NotSame(daprClient1, daprClient2);
+    }
+}

--- a/test/Dapr.AspNetCore.Test/DaprServiceCollectionExtensionsTest.cs
+++ b/test/Dapr.AspNetCore.Test/DaprServiceCollectionExtensionsTest.cs
@@ -17,7 +17,6 @@ using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dapr.Client;
-using Dapr.Actors.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 

--- a/test/Dapr.AspNetCore.Test/DaprServiceCollectionExtensionsTest.cs
+++ b/test/Dapr.AspNetCore.Test/DaprServiceCollectionExtensionsTest.cs
@@ -17,66 +17,67 @@ using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dapr.Client;
+using Dapr.Actors.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Dapr.AspNetCore.Test
+namespace Dapr.AspNetCore.Test;
+
+public class DaprServiceCollectionExtensionsTest
 {
-    public class DaprServiceCollectionExtensionsTest
+    [Fact]
+    public void AddDaprClient_RegistersDaprClientOnlyOnce()
     {
-        [Fact]
-        public void AddDaprClient_RegistersDaprClientOnlyOnce()
-        {
-            var services = new ServiceCollection();
+        var services = new ServiceCollection();
 
-            var clientBuilder = new Action<DaprClientBuilder>(
-                builder => builder.UseJsonSerializationOptions(
-                    new JsonSerializerOptions()
-                    {
-                        PropertyNameCaseInsensitive = false
-                    }
-                )
-            );
-
-            // register with JsonSerializerOptions.PropertyNameCaseInsensitive = true (default)
-            services.AddDaprClient();
-
-            // register with PropertyNameCaseInsensitive = false
-            services.AddDaprClient(clientBuilder);
-
-            var serviceProvider = services.BuildServiceProvider();
-
-            DaprClientGrpc? daprClient = serviceProvider.GetService<DaprClient>() as DaprClientGrpc;
-
-            Assert.NotNull(daprClient);
-            Assert.True(daprClient?.JsonSerializerOptions.PropertyNameCaseInsensitive);
-        }
-
-        [Fact]
-        public void AddDaprClient_RegistersUsingDependencyFromIServiceProvider()
-        {
-
-            var services = new ServiceCollection();
-            services.AddSingleton<TestConfigurationProvider>();
-            services.AddDaprClient((provider, builder) =>
-            {
-                var configProvider = provider.GetRequiredService<TestConfigurationProvider>();
-                var caseSensitivity = configProvider.GetCaseSensitivity();
-
-                builder.UseJsonSerializationOptions(new JsonSerializerOptions
+        var clientBuilder = new Action<DaprClientBuilder>(
+            builder => builder.UseJsonSerializationOptions(
+                new JsonSerializerOptions()
                 {
-                    PropertyNameCaseInsensitive = caseSensitivity
-                });
+                    PropertyNameCaseInsensitive = false
+                }
+            )
+        );
+
+        // register with JsonSerializerOptions.PropertyNameCaseInsensitive = true (default)
+        services.AddDaprClient();
+
+        // register with PropertyNameCaseInsensitive = false
+        services.AddDaprClient(clientBuilder);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        DaprClientGrpc? daprClient = serviceProvider.GetService<DaprClient>() as DaprClientGrpc;
+
+        Assert.NotNull(daprClient);
+        Assert.True(daprClient?.JsonSerializerOptions.PropertyNameCaseInsensitive);
+    }
+
+    [Fact]
+    public void AddDaprClient_RegistersUsingDependencyFromIServiceProvider()
+    {
+
+        var services = new ServiceCollection();
+        services.AddSingleton<TestConfigurationProvider>();
+        services.AddDaprClient((provider, builder) =>
+        {
+            var configProvider = provider.GetRequiredService<TestConfigurationProvider>();
+            var caseSensitivity = configProvider.GetCaseSensitivity();
+
+            builder.UseJsonSerializationOptions(new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = caseSensitivity
             });
+        });
 
-            var serviceProvider = services.BuildServiceProvider();
+        var serviceProvider = services.BuildServiceProvider();
 
-            DaprClientGrpc? client = serviceProvider.GetRequiredService<DaprClient>() as DaprClientGrpc;
+        DaprClientGrpc? client = serviceProvider.GetRequiredService<DaprClient>() as DaprClientGrpc;
 
-            //Registers with case-insensitive as true by default, but we set as false above
-            Assert.NotNull(client);
-            Assert.False(client?.JsonSerializerOptions.PropertyNameCaseInsensitive);
-        }
+        //Registers with case-insensitive as true by default, but we set as false above
+        Assert.NotNull(client);
+        Assert.False(client?.JsonSerializerOptions.PropertyNameCaseInsensitive);
+    }
         
     [Fact]
     public void RegisterClient_ShouldRegisterSingleton_WhenLifetimeIsSingleton()
@@ -86,13 +87,13 @@ namespace Dapr.AspNetCore.Test
         services.AddDaprClient(options => { }, ServiceLifetime.Singleton);
         var serviceProvider = services.BuildServiceProvider();
 
-        var daprWorkflowClient1 = serviceProvider.GetService<DaprClient>();
-        var daprWorkflowClient2 = serviceProvider.GetService<DaprClient>();
+        var daprClient1 = serviceProvider.GetService<DaprClient>();
+        var daprClient2 = serviceProvider.GetService<DaprClient>();
 
-        Assert.NotNull(daprWorkflowClient1);
-        Assert.NotNull(daprWorkflowClient2);
+        Assert.NotNull(daprClient1);
+        Assert.NotNull(daprClient2);
         
-        Assert.Same(daprWorkflowClient1, daprWorkflowClient2);
+        Assert.Same(daprClient1, daprClient2);
     }
 
     [Fact]
@@ -104,14 +105,14 @@ namespace Dapr.AspNetCore.Test
         var serviceProvider = services.BuildServiceProvider();
 
         await using var scope1 = serviceProvider.CreateAsyncScope();
-        var daprWorkflowClient1 = scope1.ServiceProvider.GetService<DaprClient>();
+        var daprClient1 = scope1.ServiceProvider.GetService<DaprClient>();
 
         await using var scope2 = serviceProvider.CreateAsyncScope();
-        var daprWorkflowClient2 = scope2.ServiceProvider.GetService<DaprClient>();
+        var daprClient2 = scope2.ServiceProvider.GetService<DaprClient>();
                 
-        Assert.NotNull(daprWorkflowClient1);
-        Assert.NotNull(daprWorkflowClient2);
-        Assert.NotSame(daprWorkflowClient1, daprWorkflowClient2);
+        Assert.NotNull(daprClient1);
+        Assert.NotNull(daprClient2);
+        Assert.NotSame(daprClient1, daprClient2);
     }
 
     [Fact]
@@ -122,12 +123,12 @@ namespace Dapr.AspNetCore.Test
         services.AddDaprClient(options => { }, ServiceLifetime.Transient);
         var serviceProvider = services.BuildServiceProvider();
 
-        var daprWorkflowClient1 = serviceProvider.GetService<DaprClient>();
-        var daprWorkflowClient2 = serviceProvider.GetService<DaprClient>();
+        var daprClient1 = serviceProvider.GetService<DaprClient>();
+        var daprClient2 = serviceProvider.GetService<DaprClient>();
 
-        Assert.NotNull(daprWorkflowClient1);
-        Assert.NotNull(daprWorkflowClient2);
-        Assert.NotSame(daprWorkflowClient1, daprWorkflowClient2);
+        Assert.NotNull(daprClient1);
+        Assert.NotNull(daprClient2);
+        Assert.NotSame(daprClient1, daprClient2);
     }
 
         
@@ -149,9 +150,8 @@ namespace Dapr.AspNetCore.Test
         }
 #endif
 
-        private class TestConfigurationProvider
-        {
-            public bool GetCaseSensitivity() => false;
-        }
+    private class TestConfigurationProvider
+    {
+        public bool GetCaseSensitivity() => false;
     }
 }

--- a/test/Dapr.Messaging.Test/Extensions/PublishSubscribeServiceCollectionExtensionsTests.cs
+++ b/test/Dapr.Messaging.Test/Extensions/PublishSubscribeServiceCollectionExtensionsTests.cs
@@ -1,0 +1,76 @@
+﻿using Dapr.Messaging.PublishSubscribe;
+using Dapr.Messaging.PublishSubscribe.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dapr.Messaging.Test.Extensions;
+
+public sealed class PublishSubscribeServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddDaprPubSubClient_RegistersIHttpClientFactory()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDaprPubSubClient();
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var httpClientFactory = serviceProvider.GetService<IHttpClientFactory>();
+        Assert.NotNull(httpClientFactory);
+
+        var daprPubSubClient = serviceProvider.GetService<DaprPublishSubscribeClient>();
+        Assert.NotNull(daprPubSubClient);
+    }
+    
+    [Fact]
+    public void RegisterPubsubClient_ShouldRegisterSingleton_WhenLifetimeIsSingleton()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDaprPubSubClient(lifetime: ServiceLifetime.Singleton);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var daprPubSubClient1 = serviceProvider.GetService<DaprPublishSubscribeClient>();
+        var daprPubSubClient2 = serviceProvider.GetService<DaprPublishSubscribeClient>();
+
+        Assert.NotNull(daprPubSubClient1);
+        Assert.NotNull(daprPubSubClient2);
+        
+        Assert.Same(daprPubSubClient1, daprPubSubClient2);
+    }
+
+    [Fact]
+    public async Task RegisterPubsubClient_ShouldRegisterScoped_WhenLifetimeIsScoped()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDaprPubSubClient(lifetime: ServiceLifetime.Scoped);
+        var serviceProvider = services.BuildServiceProvider();
+
+        await using var scope1 = serviceProvider.CreateAsyncScope();
+        var daprPubSubClient1 = scope1.ServiceProvider.GetService<DaprPublishSubscribeClient>();
+
+        await using var scope2 = serviceProvider.CreateAsyncScope();
+        var daprPubSubClient2 = scope2.ServiceProvider.GetService<DaprPublishSubscribeClient>();
+                
+        Assert.NotNull(daprPubSubClient1);
+        Assert.NotNull(daprPubSubClient2);
+        Assert.NotSame(daprPubSubClient1, daprPubSubClient2);
+    }
+
+    [Fact]
+    public void RegisterPubsubClient_ShouldRegisterTransient_WhenLifetimeIsTransient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDaprPubSubClient(lifetime: ServiceLifetime.Transient);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var daprPubSubClient1 = serviceProvider.GetService<DaprPublishSubscribeClient>();
+        var daprPubSubClient2 = serviceProvider.GetService<DaprPublishSubscribeClient>();
+
+        Assert.NotNull(daprPubSubClient1);
+        Assert.NotNull(daprPubSubClient2);
+        Assert.NotSame(daprPubSubClient1, daprPubSubClient2);
+    }
+}


### PR DESCRIPTION
# Description

This is a follow up to #1408 that adds lifecycle registration for the following additional clients:
- Dapr.Jobs
- Dapr.Messaging
- Dapr.Actors.AspNetCore

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [N/A] Extended the documentation - Will write documentation as part of a separate PR (likely #1409 )
