### PR TITLE
Conversation builder consistency changes

### DIFF
--- a/examples/AI/ConversationalAI/Program.cs
+++ b/examples/AI/ConversationalAI/Program.cs
@@ -3,7 +3,7 @@ using Dapr.AI.Conversation.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddDaprAiConversation();
+builder.Services.AddDaprConversationClient();
 
 var app = builder.Build();
 

--- a/src/Dapr.AI/Conversation/Extensions/DaprAiConversationBuilderExtensions.cs
+++ b/src/Dapr.AI/Conversation/Extensions/DaprAiConversationBuilderExtensions.cs
@@ -26,7 +26,7 @@ public static class DaprAiConversationBuilderExtensions
     /// Registers the necessary functionality for the Dapr AI conversation functionality.
     /// </summary>
     /// <returns></returns>
-    public static IDaprAiConversationBuilder AddDaprAiConversation(this IServiceCollection services, Action<IServiceProvider, DaprConversationClientBuilder>? configure = null, ServiceLifetime lifetime = ServiceLifetime.Singleton)
+    public static IDaprAiConversationBuilder AddDaprConversationClient(this IServiceCollection services, Action<IServiceProvider, DaprConversationClientBuilder>? configure = null, ServiceLifetime lifetime = ServiceLifetime.Singleton)
     {
         ArgumentNullException.ThrowIfNull(services, nameof(services));
         

--- a/test/Dapr.Jobs.Test/Extensions/DaprJobsServiceCollectionExtensionsTests.cs
+++ b/test/Dapr.Jobs.Test/Extensions/DaprJobsServiceCollectionExtensionsTests.cs
@@ -89,7 +89,7 @@ public class DaprJobsServiceCollectionExtensionsTest
         services.AddDaprJobsClient((provider, builder) =>
         {
             var configProvider = provider.GetRequiredService<TestSecretRetriever>();
-            var apiToken = TestSecretRetriever.GetApiTokenValue();
+            var apiToken = configProvider.GetApiTokenValue();
             builder.UseDaprApiToken(apiToken);
         });
 
@@ -114,7 +114,7 @@ public class DaprJobsServiceCollectionExtensionsTest
     {
         var services = new ServiceCollection();
 
-        services.AddDaprJobsClient((serviceProvider, options) => { }, ServiceLifetime.Singleton);
+        services.AddDaprJobsClient((_, _) => { }, ServiceLifetime.Singleton);
         var serviceProvider = services.BuildServiceProvider();
 
         var daprJobsClient1 = serviceProvider.GetService<DaprJobsClient>();
@@ -131,7 +131,7 @@ public class DaprJobsServiceCollectionExtensionsTest
     {
         var services = new ServiceCollection();
 
-        services.AddDaprJobsClient((serviceProvider, options) => { }, ServiceLifetime.Scoped);
+        services.AddDaprJobsClient((_, _) => { }, ServiceLifetime.Scoped);
         var serviceProvider = services.BuildServiceProvider();
 
         await using var scope1 = serviceProvider.CreateAsyncScope();
@@ -150,7 +150,7 @@ public class DaprJobsServiceCollectionExtensionsTest
     {
         var services = new ServiceCollection();
 
-        services.AddDaprJobsClient((serviceProvider, options) => { }, ServiceLifetime.Transient);
+        services.AddDaprJobsClient((_, _) => { }, ServiceLifetime.Transient);
         var serviceProvider = services.BuildServiceProvider();
 
         var daprJobsClient1 = serviceProvider.GetService<DaprJobsClient>();
@@ -163,6 +163,6 @@ public class DaprJobsServiceCollectionExtensionsTest
 
     private class TestSecretRetriever
     {
-        public static string GetApiTokenValue() => "abcdef";
+        public string GetApiTokenValue() => "abcdef";
     }
 }


### PR DESCRIPTION
# Description

While writing up the documentation for each, I realized that the conversation builder had an inconsistency naming convention. This fixes that, the associated unit tests and example and also fixes another unit test that was incorrect in the Jobs API.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
