### PR TITLE
Improving E2E testing

### DIFF
--- a/.github/workflows/example-e2e-tests.json
+++ b/.github/workflows/example-e2e-tests.json
@@ -2,16 +2,88 @@
   "projects":[
     {
       "project": "Cryptography.csproj",
-      "tests": {
-        "name": "Encrypt & Decrypt String",
-        "arguments": "0",
-        "expected_std_output": [
-          "== APP == Original string value: 'This is the value we're going to encrypt today'",
-          "== APP == Encrypted bytes: '",
-          "== APP == Decrypted string: 'This is the value we're going to encrypt today'"
-        ],
-        "expectation_type": "startswith"
-      }
+      "tests": [
+        {
+          "name": "Encrypt & Decrypt String",
+          "arguments": "0",
+          "expected_std_output": [
+            "== APP == Original string value: 'This is the value we're going to encrypt today'",
+            "== APP == Encrypted bytes: '",
+            "== APP == Decrypted string: 'This is the value we're going to encrypt today'"
+          ],
+          "expectation_type": "startswith"
+        },
+        {
+          "name": "Encrypt & Decrypt Small File Stream",
+          "arguments": "1",
+          "expected_std_output": [
+            "== APP == Original file contents:",
+            "== APP == # The Road Not Taken",
+            "== APP == ## By Robert Lee Frost",
+            "== APP == ",
+            "== APP == Two roads diverged in a yellow wood,",
+            "== APP == And sorry I could not travel both",
+            "== APP == And be one traveler, long I stood",
+            "== APP == And looked down one as far as I could",
+            "== APP == To where it bent in the undergrowth;",
+            "== APP == ",
+            "== APP == Then took the other, as just as fair",
+            "== APP == And having perhaps the better claim,",
+            "== APP == Because it was grassy and wanted wear;",
+            "== APP == Though as for that, the passing there",
+            "== APP == Had worn them really about the same,",
+            "== APP == ",
+            "== APP == And both that morning equally lay",
+            "== APP == In leaves no step had trodden black",
+            "== APP == Oh, I kept the first for another day!",
+            "== APP == Yet knowing how way leads on to way,",
+            "== APP == I doubted if I should ever come back.",
+            "== APP == ",
+            "== APP == I shall be telling this with a sigh",
+            "== APP == Somewhere ages and ages hence:",
+            "== APP == Two roads diverged in a wood, and I,",
+            "== APP == I took the one less traveled by,",
+            "== APP == And that has made all the difference.",
+            "== APP == ",
+            "== APP == Encrypted bytes: ZGFwci5pby9lbmMvdjEKeyJrdyI6NSwid2ZrIjoiVHRRUnNneVkyMDlQZGxaZkNxcW11UC9OQlRra1plajZ2c2tGbG1nN21uSUFtZlZ3R3YxYVhVajlyMGdCb1Q4UWh3SWZJNzNUdVc0WkFjQmlhK2V1QStPelBQQkdYbWpZYmhFQlZLandTTkNRa3l1TFVWZ0d4ZUJwbm03cDA2bHFFUkV6MGpRL0NiNnFPN0ZKc1Z0ZVh6dmF4dDFBK0dtSEVEd0ZLYmtydGZOaU",
+            "1aeHF2bS85Y0pOTVBpNm9Zcms1eGJkK1kwcmc5bU9vZ1hmL1RidW5IUWRvc3lhSGpzc082U0l3TVUzdVdIMEdIZEFzNU95ZEhCRDdhd0kvSFFXdzEya3c4ZGNOQzd4enFPd0RGSUh1NXc3cmx1aGZmZHZCeVBoWDNwMEdBQzR6eWtvY2dUOWdBcGF0VjV4ekFjRXBGVGdycUxGdXhDSWI1dG9veUZxZ25ESnVYYktLWWxSU2hkclhBeGJnbFVBOVQxVmFMUC9hakhGaEYwTEFwajhYM2dYUXo2RDhhSUE",
+            "zRlM4VEJPYTUrSDR5cXkyQzk4dzhZMUFFcS9vSzI4dVB3NFROUEttUUxwb0xUeFE3VzRya3drbDRLcy9ZdExXYnRpU2pUSUN1ODNYaXB4T1JsU0w4SmQwQjU0MG14dDlqTDJOZlBJK09QV0l0VzdtWTJVcWh1bGxWWGNoODNscCs0V01OZ2tVRjJraElGRVFlSkhEakpkdTJRZGRGQXdZVDd5S3RPem5MdktYRHFQRXgwMk5mODU3NlpNS0VCb0ZXdDZuU084ZGxXSEFPMCtsbFZEbUZrRnIyRTVUMVpl",
+            "UlppSGJMd21zanpzNlU5SkoxTENDaUg3VWk4WGNkN1gzZEgzaDV0LzJTWWRCSStWUENiZW42dDFJYlJxVVNMOXc9IiwiY3BoIjoxLCJucCI6Ik9NUTFRcHJHUHc9PSJ9Cnh0YzBGalluaEdRMmo2eXJLVTI3aEtBbTJtTkJaZCtwb1hUZTUwLzRiYW89CkIYDF5TkccFoiifujAE/TTDwaJCj3s1HQv2uaGpvg2+8xUwIgvfBD4C+Qxk6UObPNkGFSgUx+jhQcNt7zaBoAGw+x2bUmNHrxy0HjIk/nPKa",
+            "LasVRWyoNvNaqAHrn2yaxRzG7TggigJP6IenC1p40CvIZRPnr7RpjxoZrTeD5DKzrYB7IjCNF3PJ7lye3sw7F65/1HzF0nCGjZPZAfZUIItd8Q5jblh2y5RSrdCxZyLIMgsoHKDSSa+G1WHI9V4oYnduHFGt9c+uAsl103+/Q1JrPzZiMtvI1AVYl364CuhflUaqw/SQ4wrpfnjIZNNVhfItFAQcuNUxsQWz4rGyJDLwagLReCyP9dFJWCsUjuNK/9y+c+W2oK0xhmn0EOw7aMGpslsTb2jL+bClJAzme",
+            "/mVRpM294B97AabFhydlPUGV1ZTmQOo8q1ApuKfzIyG8ucMTYnssTbjW0V6038QTCIPpP97H1BGON3JjYBCtOQNI6FUhEHLfyrBcx0eWZ/QhxB0tywD7d+DWtnSx3Y4OBE7KjvLrEyaOQAlOspk4rhZBpub/g+yjc7T1q+HY+mBR6sHfSuLrFmyMEcOqgxBVaJPD0dWizhB/dTW6cVLVmXWWi9jJglMDF92wUi68c/5spEyNRJRabv1sEq4VJ2OJtRJlCvzWFfqrrw9ZjJSEoaLMqZjiLU9HyXB2VFTLM",
+            "PrzJFSdZO3ajViWbnrSqNZy/CBTEnKmGsr1E8LRSfXm/PpGrvo0OL3VZC+P8IxuCK43Qug1Qoymkc1K0i6UbzeLvyMuv3J11KKhQCss9+/O8GKqkRCWa/D2TCJ6RiG20+N/bBdv0T6AQK0RcAMj6RQt3WJlnFQ4OtrVTHKNnZCoQZbBid0u0UvccFWAbkm/Tk0IVUbMcEv5pFS64h7ePkbHo5ZEaoobXwpmzXrx6a+P41OkNokIcE28A06RIqMmRUpE4uA9vje+M0xv5fpB64qoUqSW0DXFwDCVDW21O12kl1PJcU4aLdc9FOk7T5cA/PdYLJSjAo6P4J5VEIRv8xakH5X4a8hYz+BWcfH3pdcfZRLnZsU9UGMIcaiLZsB/I=",
+            "== APP == ",
+            "== APP == Decrypted value: ",
+            "== APP == # The Road Not Taken",
+            "== APP == ## By Robert Lee Frost",
+            "== APP == ",
+            "== APP == Two roads diverged in a yellow wood,",
+            "== APP == And sorry I could not travel both",
+            "== APP == And be one traveler, long I stood",
+            "== APP == And looked down one as far as I could",
+            "== APP == To where it bent in the undergrowth;",
+            "== APP == ",
+            "== APP == Then took the other, as just as fair",
+            "== APP == And having perhaps the better claim,",
+            "== APP == Because it was grassy and wanted wear;",
+            "== APP == Though as for that, the passing there",
+            "== APP == Had worn them really about the same,",
+            "== APP == ",
+            "== APP == And both that morning equally lay",
+            "== APP == In leaves no step had trodden black",
+            "== APP == Oh, I kept the first for another day!",
+            "== APP == Yet knowing how way leads on to way,",
+            "== APP == I doubted if I should ever come back.",
+            "== APP == ",
+            "== APP == I shall be telling this with a sigh",
+            "== APP == Somewhere ages and ages hence:",
+            "== APP == Two roads diverged in a wood, and I,",
+            "== APP == I took the one less traveled by,",
+            "== APP == And that has made all the difference."
+          ],
+          "expectation_type": "startswith"
+        }
+      ]
     }
   ]
 }

--- a/.github/workflows/example-e2e-tests.json
+++ b/.github/workflows/example-e2e-tests.json
@@ -1,0 +1,17 @@
+{
+  "projects":[
+    {
+      "project": "Cryptography.csproj",
+      "tests": {
+        "name": "Encrypt & Decrypt String",
+        "arguments": "0",
+        "expected_std_output": [
+          "== APP == Original string value: 'This is the value we're going to encrypt today'",
+          "== APP == Encrypted bytes: '",
+          "== APP == Decrypted string: 'This is the value we're going to encrypt today'"
+        ],
+        "expectation_type": "startswith"
+      }
+    }
+  ]
+}

--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -14,12 +14,14 @@ on:
       - release-*
 
 jobs:
-  build:
+  build-and-test:
     name: run example-based integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         dotnet-version: ['8.0', '9.0']
         include:
         - dotnet-version: '8.0'
@@ -32,6 +34,7 @@ jobs:
           framework: 'net9'
           prefix: 'net9'
           install-version: '9.0.x'
+          
     env:
       NUPKG_OUTDIR: bin/Release/nugets
       GOVER: 1.20.0
@@ -116,13 +119,65 @@ jobs:
           dotnet-quality: 'ga'
       - name: Install dependencies
         run: dotnet restore
+      - name: Check test coverage
+        run: |
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+            sudo apt-get install jq
+          else
+            choco install jq
+          fi
+          # Find all .csproj files in the ./examples directory
+          all_projects=$(find ./examples -name '*.csproj' -exec basename {} \; | sed 's/.csproj//')
+          # Get the list of projects from the 'example-e2e-tests.json' file
+          tested_projects=$(jq -r '.projects[].project' example-e2e-tests.json | sed s/.csproj//')
+          # Compare the lists and find projects without tests
+          for project in $all_projects; do
+            if ! echo "$tested_projects" | grep -q "$project"; then
+              echo "Project $project does not have any tests in example-e2e-test.json"
+            fi
+          done
       - name: Build & test projects
         # disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
         run: |
-          for project in $(find . -name '*.csproj'); do
-            echo "Building and testing $project with .NET ${{matrix.dotnet-version}}"
-            dotnet build $project --configuration Release /p:GITHUB_ACTIONS=false
-            dotnet run --project $project -- 0
+          projects=$(jq -c '.projects[]' example-e2e-tests.json)
+          for project in $projects; do
+            project_name=$(echo $project | jq -r '.project')
+          
+            # Find the .csproj file in the ./examples directory
+            csproj_path=$(find ./examples -name "$project_name")
+            
+            tests=$(echo $project | jq -c '.tests[]')
+            for test in $tests; do
+              test_name=$(echo $test | jq -r '.name')
+              args=$(echo $test | jq -r '.arguments')
+              expectedOutputs=$(echo $test | jq -r '.expected_std_output[]')
+              expectation_type=$(echo $test | jq -r '.expectation_type')
+                        
+              echo "Building and testing $project with .NET ${{matrix.dotnet-version}}"
+              dotnet build $csproj_path --configuration Release /p:GITHUB_ACTIONS=false
+              output=$(dotnet run --project $csproj_path -- $args)
+          
+              for expected in $expectedOutputs; do
+                if [[ "$expectation_type" == "startswith" ]]; then
+                  if [[ "$output" != "$expected"* ]]; then 
+                    echo "Test failed for $csproj_path with .NET ${{ matrix.dotnet-version }}: Expected '$expected' not found in output"
+                    exit 1
+                  fi
+                elif [[ "$expectation_type" == "equals" ]]; then
+                  if [[ "$output" != "$expected" ]]; then
+                    echo "Test failed for $csproj_path with .NET ${{matrix.dotnet-version }}: Expected '$expected' not found in output"
+                    exit 1
+                  fi
+                else
+                  if [[ "$output" != *"$expected"* ]]; then
+                    echo "Test failed for $csproj_path with .NET ${{ matrix.dotnet-version }}: Expected '$expected' not found in output"
+                    exit 1
+                  fi
+                fi
+              done
+            done
+          done
+            
             
       
         

--- a/.github/workflows/example-tests.yml
+++ b/.github/workflows/example-tests.yml
@@ -1,0 +1,128 @@
+name: example-integration-test
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+    tags:
+      - v*
+
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+jobs:
+  build:
+    name: run example-based integration tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dotnet-version: ['8.0', '9.0']
+        include:
+        - dotnet-version: '8.0'
+          display-name: '.NET 8.0'
+          framework: 'net8'
+          prefix: 'net8'
+          install-version: '8.0.x'
+        - dotnet-version: '9.0'
+          display-name: '.NET 9.0'
+          framework: 'net9'
+          prefix: 'net9'
+          install-version: '9.0.x'
+    env:
+      NUPKG_OUTDIR: bin/Release/nugets
+      GOVER: 1.20.0
+      GOOS: linux
+      GOARCH: amd64
+      GOPROXY: https://proxy.golang.org
+      DAPR_CLI_VER: 1.14.0
+      DAPR_RUNTIME_VER: 1.14.0
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/release-1.14/install/install.sh
+      DAPR_CLI_REF: ''
+    steps:
+      - name: Set up Dapr CLI
+        run: wget -q ${{ env.DAPR_INSTALL_URL }} -O - | /bin/bash -s ${{ env.DAPR_CLI_VER }}
+      - name: Checkout Dapr CLI repo to override dapr command.
+        uses: actions/checkout@v2
+        if: env.DAPR_CLI_REF != ''
+        with:
+          repository: dapr/cli
+          ref: ${{ env.DAPR_CLI_REF }}
+          path: cli
+      - name: Checkout Dapr repo to override daprd.
+        uses: actions/checkout@v2
+        if: env.DAPR_REF != ''
+        with:
+          repository: dapr/dapr
+          ref: ${{ env.DAPR_REF }}
+          path: dapr
+      - name: Set up Go from dapr/go.mod
+        if: env.DAPR_REF != ''
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "dapr/go.mod"
+      - name: Set up Go from cli/go.mod
+        if: env.DAPR_REF == '' && env.DAPR_CLI_REF != ''
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "cli/go.mod"
+      - name: Build and override dapr cli with referenced commit.
+        if: env.DAPR_CLI_REF != ''
+        run: |
+          cd cli
+          make
+          sudo cp dist/linux_amd64/release/dapr /usr/local/bin/dapr
+          cd ..
+      - name: Initialize Dapr runtime ${{ env.DAPR_RUNTIME_VER }}
+        run: |
+          dapr uninstall --all
+          dapr init --runtime-version ${{ env.DAPR_RUNTIME_VER }}
+      - name: Build and override daprd with referenced commit.
+        if: env.DAPR_REF != ''
+        run: |
+          cd dapr
+          make
+          mkdir -p $HOME/.dapr/bin/
+          cp dist/linux_amd64/release/daprd $HOME/.dapr/bin/daprd
+          cd ..
+      - name: Override placement service.
+        if: env.DAPR_REF != ''
+        run: |
+          docker stop dapr_placement
+          cd dapr
+          ./dist/linux_amd64/release/placement &
+      - uses: actions/checkout@v1
+      - name: Parse release version
+        run: python ./.github/scripts/get_release_version.py
+      - name: Setup ${{ matrix.display-name }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.install-version }}
+          dotnet-quality: 'ga'  # Prefer a GA release, but use the RC if not available
+      - name: Setup .NET 8 (required)
+        uses: actions/setup-dotnet@v3
+        if: ${{ matrix.install-version != '8.0.x' }}
+        with:
+          dotnet-version: '8.0.x'
+          dotnet-quality: 'ga'
+      - name: Setup .NET 9 (required)
+        uses: actions/setup-dotnet@v3
+        if: ${{ matrix.install-version != '9.0.x' }}
+        with:
+          dotnet-version: '9.0.x'
+          dotnet-quality: 'ga'
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build & test projects
+        # disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
+        run: |
+          for project in $(find . -name '*.csproj'); do
+            echo "Building and testing $project with .NET ${{matrix.dotnet-version}}"
+            dotnet build $project --configuration Release /p:GITHUB_ACTIONS=false
+            dotnet run --project $project -- 0
+            
+      
+        


### PR DESCRIPTION
# Description

We've got an E2E test that runs through a series of operations against the various Dapr functionalities with a Dapr instance. But we also have all these example projects that themselves are intended to be kept up to date with the evolution of the SDK and when themselves are more easily updated with changes. 

This PR represents an idea to perform E2E testing using each of the example projects and their console output. Initially, it runs on ubuntu-linux, but I'd like to extend it to also do testing against Windows as well, much like dapr/quickstarts does.

In practice, a lot of the examples need updating to be both conformant with this testing style and to generally get them up to date with what's available in the SDK, so this test suite will start small and grow as the examples are improved on and expanded.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
