### PR TITLE
Actor reminders should return null if not registered

### DIFF
--- a/src/Dapr.Actors/DaprHttpInteractor.cs
+++ b/src/Dapr.Actors/DaprHttpInteractor.cs
@@ -265,7 +265,7 @@ namespace Dapr.Actors
             return this.SendAsync(RequestFunc, relativeUrl, cancellationToken);
         }
 
-        public async Task<Stream> GetReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default)
+        public async Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default)
         {
             var relativeUrl = string.Format(CultureInfo.InvariantCulture, Constants.ActorReminderRelativeUrlFormat, actorType, actorId, reminderName);
 
@@ -278,8 +278,7 @@ namespace Dapr.Actors
                 return request;
             }
 
-            var response = await this.SendAsync(RequestFunc, relativeUrl, cancellationToken);
-            return await response.Content.ReadAsStreamAsync();
+            return await this.SendAsync(RequestFunc, relativeUrl, cancellationToken);
         }
 
         public Task UnregisterReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default)

--- a/src/Dapr.Actors/IDaprInteractor.cs
+++ b/src/Dapr.Actors/IDaprInteractor.cs
@@ -11,6 +11,8 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
+using System.Net.Http;
+
 namespace Dapr.Actors
 {
     using System.IO;
@@ -81,8 +83,8 @@ namespace Dapr.Actors
         /// <param name="actorId">ActorId.</param>
         /// <param name="reminderName">Name of reminder to unregister.</param>
         /// <param name="cancellationToken">Cancels the operation.</param>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        Task<Stream> GetReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default);
+        /// <returns>A <see cref="Task"/> containing the response of the asynchronous HTTP operation.</returns>
+        Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unregisters a reminder.

--- a/test/Dapr.Actors.Test/ActorUnitTestTests.cs
+++ b/test/Dapr.Actors.Test/ActorUnitTestTests.cs
@@ -120,6 +120,22 @@ namespace Dapr.Actors
             Assert.Empty(reminders);
         }
 
+        [Fact]
+        public async Task ReminderReturnsNullIfNotAvailable()
+        {
+            var timerManager = new Mock<ActorTimerManager>(MockBehavior.Strict);
+            timerManager
+                .Setup(tm => tm.GetReminderAsync(It.IsAny<ActorReminderToken>()))
+                .Returns(() => Task.FromResult<IActorReminder>(null));
+            
+            var host = ActorHost.CreateForTest<CoolTestActor>(new ActorTestOptions() { TimerManager = timerManager.Object, });
+            var actor = new CoolTestActor(host);
+            
+            //There is no starting reminder, so this should always return null
+            var retrievedReminder = await actor.GetReminderAsync();
+            Assert.Null(retrievedReminder);
+        }
+
         public interface ICoolTestActor : IActor
         {
         }

--- a/test/Dapr.Actors.Test/ActorUnitTestTests.cs
+++ b/test/Dapr.Actors.Test/ActorUnitTestTests.cs
@@ -69,7 +69,7 @@ namespace Dapr.Actors
         }
 
         [Fact]
-        public async Task CanTestStartingAndStoppinReminder()
+        public async Task CanTestStartingAndStoppingReminder()
         {
             var reminders = new List<ActorReminder>();
             IActorReminder getReminder = null;

--- a/test/Dapr.Actors.Test/DaprHttpInteractorTest.cs
+++ b/test/Dapr.Actors.Test/DaprHttpInteractorTest.cs
@@ -147,6 +147,30 @@ namespace Dapr.Actors.Test
         }
 
         [Fact]
+        public async Task GetReminder_ValidateRequest()
+        {
+            await using var client = TestClient.CreateForDaprHttpInterator();
+            
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string reminderName = "ReminderName";
+
+            var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
+            {
+                await httpInteractor.GetReminderAsync(actorType, actorId, reminderName);
+            });
+
+            request.Dismiss();
+
+            var actualPath = request.Request.RequestUri.LocalPath.TrimStart('/');
+            var expectedPath = string.Format(CultureInfo.InvariantCulture, Constants.ActorReminderRelativeUrlFormat,
+                actorType, actorId, reminderName);
+
+            actualPath.ShouldBe(expectedPath);
+            request.Request.Method.ShouldBe(HttpMethod.Get);
+        }
+
+        [Fact]
         public async Task RegisterTimer_ValidateRequest()
         {
             await using var client = TestClient.CreateForDaprHttpInterator();

--- a/test/Dapr.Actors.Test/DaprHttpInteractorTest.cs
+++ b/test/Dapr.Actors.Test/DaprHttpInteractorTest.cs
@@ -34,9 +34,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var keyName = "StateKey_Test";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string keyName = "StateKey_Test";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -57,9 +57,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var data = "StateData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string data = "StateData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -80,10 +80,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var methodName = "MethodName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string methodName = "MethodName";
+            const string payload = "JsonData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -104,10 +104,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var reminderName = "ReminderName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string reminderName = "ReminderName";
+            const string payload = "JsonData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -128,9 +128,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var reminderName = "ReminderName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string reminderName = "ReminderName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -175,10 +175,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
+            const string payload = "JsonData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -222,9 +222,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator(apiToken: "test_token");
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -243,9 +243,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -263,9 +263,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -296,9 +296,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -318,9 +318,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -340,10 +340,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var methodName = "MethodName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string methodName = "MethodName";
+            const string payload = "JsonData";
 
             ActorReentrancyContextAccessor.ReentrancyContext = "1";
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
@@ -361,10 +361,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var methodName = "MethodName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string methodName = "MethodName";
+            const string payload = "JsonData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -380,9 +380,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var keyName = "StateKey_Test";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string keyName = "StateKey_Test";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -409,9 +409,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var keyName = "StateKey_Test";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string keyName = "StateKey_Test";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {

--- a/test/Dapr.Actors.Test/TestDaprInteractor.cs
+++ b/test/Dapr.Actors.Test/TestDaprInteractor.cs
@@ -108,10 +108,10 @@ public class TestDaprInteractor : IDaprInteractor
     /// <param name="reminderName">Name of reminder to unregister.</param>
     /// <param name="cancellationToken">Cancels the operation.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-    public Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName,
+    public virtual async Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName,
         CancellationToken cancellationToken = default)
     {
-        throw new System.NotImplementedException();
+        return await _testDaprInteractor.GetReminderAsync(actorType, actorId, reminderName);
     }
 
     /// <summary>

--- a/test/Dapr.Actors.Test/TestDaprInteractor.cs
+++ b/test/Dapr.Actors.Test/TestDaprInteractor.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Actors.Communication;
@@ -107,7 +108,7 @@ public class TestDaprInteractor : IDaprInteractor
     /// <param name="reminderName">Name of reminder to unregister.</param>
     /// <param name="cancellationToken">Cancels the operation.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-    public Task<Stream> GetReminderAsync(string actorType, string actorId, string reminderName,
+    public Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName,
         CancellationToken cancellationToken = default)
     {
         throw new System.NotImplementedException();


### PR DESCRIPTION
# Description
Actor reminders should return null if they aren't registered and should return a `ReminderInfo` if they are registered. According to the API documentation, this is distinguished by the status code returned:

| Status Code | Action |
| --- | --- |
| 200 | Read the actor info from the response body |
| 500 | Not available |

The original implementation of this never read the status code and instead started with a `ReminderInfo` populated with default values for each property and attempted to deserialize each property and update the value if available in the returned body. As a result, this means that the response would never be null and if not registered, the only way to determine this was to do a default check against each of the properties.

This PR changes this - if the status code is 500, this will return a null value. If the status code is 200, it will perform the `ReminderInfo` deserialization as it did before.

There were no unit tests validating this behavior, so I've also gone through and added several.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1466 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [N/A] Extended the documentation
