### PR TITLE
Added `TryGetReminder` method to actors

### DIFF
--- a/src/Dapr.Actors/DaprHttpInteractor.cs
+++ b/src/Dapr.Actors/DaprHttpInteractor.cs
@@ -265,7 +265,7 @@ namespace Dapr.Actors
             return this.SendAsync(RequestFunc, relativeUrl, cancellationToken);
         }
 
-        public async Task<Stream> GetReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default)
+        public async Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default)
         {
             var relativeUrl = string.Format(CultureInfo.InvariantCulture, Constants.ActorReminderRelativeUrlFormat, actorType, actorId, reminderName);
 
@@ -278,8 +278,7 @@ namespace Dapr.Actors
                 return request;
             }
 
-            var response = await this.SendAsync(RequestFunc, relativeUrl, cancellationToken);
-            return await response.Content.ReadAsStreamAsync();
+            return await this.SendAsync(RequestFunc, relativeUrl, cancellationToken);
         }
 
         public Task UnregisterReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default)

--- a/src/Dapr.Actors/IDaprInteractor.cs
+++ b/src/Dapr.Actors/IDaprInteractor.cs
@@ -11,6 +11,8 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
+using System.Net.Http;
+
 namespace Dapr.Actors
 {
     using System.IO;
@@ -81,8 +83,8 @@ namespace Dapr.Actors
         /// <param name="actorId">ActorId.</param>
         /// <param name="reminderName">Name of reminder to unregister.</param>
         /// <param name="cancellationToken">Cancels the operation.</param>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        Task<Stream> GetReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default);
+        /// <returns>A <see cref="Task"/> containing the response of the asynchronous HTTP operation.</returns>
+        Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unregisters a reminder.

--- a/src/Dapr.Actors/Runtime/Actor.cs
+++ b/src/Dapr.Actors/Runtime/Actor.cs
@@ -398,6 +398,17 @@ namespace Dapr.Actors.Runtime
         }
 
         /// <summary>
+        /// Attempts to get a reminder previously registered using <see cref="Dapr.Actors.Runtime.Actor.RegisterReminderAsync(ActorReminderOptions)"/>.
+        /// </summary>
+        /// <param name="reminderName">The name of the reminder to attempt to get.</param>
+        /// <returns>A <see cref="ConditionalValue{TValue}"/> that reflects whether the reminder could be returned or not in the <c>HasValue</c> property, and if it does, the value in the <c>HasValue</c> property.</returns>
+        protected async Task<ConditionalValue<IActorReminder>> TryGetReminderAsync(string reminderName)
+        {
+            var reminder = await this.GetReminderAsync(reminderName);
+            return reminder == null ? new ConditionalValue<IActorReminder>() : new ConditionalValue<IActorReminder>(true, reminder);
+        }
+
+        /// <summary>
         /// Unregisters a reminder previously registered using <see cref="Dapr.Actors.Runtime.Actor.RegisterReminderAsync(ActorReminderOptions)" />.
         /// </summary>
         /// <param name="reminder">The actor reminder to unregister.</param>

--- a/test/Dapr.Actors.Test/ActorUnitTestTests.cs
+++ b/test/Dapr.Actors.Test/ActorUnitTestTests.cs
@@ -120,6 +120,22 @@ namespace Dapr.Actors
             Assert.Empty(reminders);
         }
 
+        [Fact]
+        public async Task ReminderReturnsNullIfNotAvailable()
+        {
+            var timerManager = new Mock<ActorTimerManager>(MockBehavior.Strict);
+            timerManager
+                .Setup(tm => tm.GetReminderAsync(It.IsAny<ActorReminderToken>()))
+                .Returns(() => Task.FromResult<IActorReminder>(null));
+            
+            var host = ActorHost.CreateForTest<CoolTestActor>(new ActorTestOptions() { TimerManager = timerManager.Object, });
+            var actor = new CoolTestActor(host);
+            
+            //There is no starting reminder, so this should always return null
+            var retrievedReminder = await actor.GetReminderAsync();
+            Assert.Null(retrievedReminder);
+        }
+
         public interface ICoolTestActor : IActor
         {
         }

--- a/test/Dapr.Actors.Test/ActorUnitTestTests.cs
+++ b/test/Dapr.Actors.Test/ActorUnitTestTests.cs
@@ -69,7 +69,7 @@ namespace Dapr.Actors
         }
 
         [Fact]
-        public async Task CanTestStartingAndStoppinReminder()
+        public async Task CanTestStartingAndStoppingReminder()
         {
             var reminders = new List<ActorReminder>();
             IActorReminder getReminder = null;

--- a/test/Dapr.Actors.Test/DaprHttpInteractorTest.cs
+++ b/test/Dapr.Actors.Test/DaprHttpInteractorTest.cs
@@ -147,6 +147,30 @@ namespace Dapr.Actors.Test
         }
 
         [Fact]
+        public async Task GetReminder_ValidateRequest()
+        {
+            await using var client = TestClient.CreateForDaprHttpInterator();
+            
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string reminderName = "ReminderName";
+
+            var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
+            {
+                await httpInteractor.GetReminderAsync(actorType, actorId, reminderName);
+            });
+
+            request.Dismiss();
+
+            var actualPath = request.Request.RequestUri.LocalPath.TrimStart('/');
+            var expectedPath = string.Format(CultureInfo.InvariantCulture, Constants.ActorReminderRelativeUrlFormat,
+                actorType, actorId, reminderName);
+
+            actualPath.ShouldBe(expectedPath);
+            request.Request.Method.ShouldBe(HttpMethod.Get);
+        }
+
+        [Fact]
         public async Task RegisterTimer_ValidateRequest()
         {
             await using var client = TestClient.CreateForDaprHttpInterator();

--- a/test/Dapr.Actors.Test/DaprHttpInteractorTest.cs
+++ b/test/Dapr.Actors.Test/DaprHttpInteractorTest.cs
@@ -34,9 +34,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var keyName = "StateKey_Test";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string keyName = "StateKey_Test";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -57,9 +57,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var data = "StateData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string data = "StateData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -80,10 +80,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var methodName = "MethodName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string methodName = "MethodName";
+            const string payload = "JsonData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -104,10 +104,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var reminderName = "ReminderName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string reminderName = "ReminderName";
+            const string payload = "JsonData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -128,9 +128,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var reminderName = "ReminderName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string reminderName = "ReminderName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -175,10 +175,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
+            const string payload = "JsonData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -222,9 +222,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator(apiToken: "test_token");
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -243,9 +243,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -263,9 +263,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -296,9 +296,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -318,9 +318,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var timerName = "TimerName";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string timerName = "TimerName";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -340,10 +340,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var methodName = "MethodName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string methodName = "MethodName";
+            const string payload = "JsonData";
 
             ActorReentrancyContextAccessor.ReentrancyContext = "1";
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
@@ -361,10 +361,10 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var methodName = "MethodName";
-            var payload = "JsonData";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string methodName = "MethodName";
+            const string payload = "JsonData";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -380,9 +380,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var keyName = "StateKey_Test";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string keyName = "StateKey_Test";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {
@@ -409,9 +409,9 @@ namespace Dapr.Actors.Test
         {
             await using var client = TestClient.CreateForDaprHttpInterator();
 
-            var actorType = "ActorType_Test";
-            var actorId = "ActorId_Test";
-            var keyName = "StateKey_Test";
+            const string actorType = "ActorType_Test";
+            const string actorId = "ActorId_Test";
+            const string keyName = "StateKey_Test";
 
             var request = await client.CaptureHttpRequestAsync(async httpInteractor =>
             {

--- a/test/Dapr.Actors.Test/TestDaprInteractor.cs
+++ b/test/Dapr.Actors.Test/TestDaprInteractor.cs
@@ -108,10 +108,10 @@ public class TestDaprInteractor : IDaprInteractor
     /// <param name="reminderName">Name of reminder to unregister.</param>
     /// <param name="cancellationToken">Cancels the operation.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-    public Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName,
+    public virtual async Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName,
         CancellationToken cancellationToken = default)
     {
-        throw new System.NotImplementedException();
+        return await _testDaprInteractor.GetReminderAsync(actorType, actorId, reminderName);
     }
 
     /// <summary>

--- a/test/Dapr.Actors.Test/TestDaprInteractor.cs
+++ b/test/Dapr.Actors.Test/TestDaprInteractor.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Actors.Communication;
@@ -107,7 +108,7 @@ public class TestDaprInteractor : IDaprInteractor
     /// <param name="reminderName">Name of reminder to unregister.</param>
     /// <param name="cancellationToken">Cancels the operation.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-    public Task<Stream> GetReminderAsync(string actorType, string actorId, string reminderName,
+    public Task<HttpResponseMessage> GetReminderAsync(string actorType, string actorId, string reminderName,
         CancellationToken cancellationToken = default)
     {
         throw new System.NotImplementedException();


### PR DESCRIPTION
# Description
Added method to try getting a named reminder from the actor. Especially as the `Dapr.Actors` package doesn't support nullability annotations, it can be confusing to understand what a null value means (especially if it never returns null, which #1468 seeks to fix).

As `out` parameters aren't supported in async operations [per this document](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/async#return-types), this instead implements an async method that returns a `ConditionalValue<TValue>`.

If the return type is not available, `HasValue` will be false and the `Value` property will be null. If the return type _is_ available, `HasValue` will be true and the `Value` property will be populated with the `IActorReminder` value.


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1465 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
