### PR TITLE
Rewriting actor state caching mechanism

### DIFF
--- a/src/Dapr.Actors/IDaprInteractor.cs
+++ b/src/Dapr.Actors/IDaprInteractor.cs
@@ -11,6 +11,8 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Dapr.Actors
 {
     using System.IO;
@@ -50,9 +52,31 @@ namespace Dapr.Actors
         /// <param name="actorType">Type of actor.</param>
         /// <param name="actorId">ActorId.</param>
         /// <param name="keyName">Name of key to get value for.</param>
+        /// <param name="data">The data to persist to state.</param>
+        /// <param name="cancellationToken">Cancels the operation.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task SaveStateAsync(
+            string actorType,
+            string actorId,
+            string keyName,
+            string data,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a state from Dapr.
+        /// </summary>
+        /// <param name="actorType">Type of actor.</param>
+        /// <param name="actorId">ActorId.</param>
+        /// <param name="keyName">Name of key to get value for.</param>
         /// <param name="cancellationToken">Cancels the operation.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         Task<ActorStateResponse<string>> GetStateAsync(string actorType, string actorId, string keyName, CancellationToken cancellationToken = default);
+
+        Task<ActorStateResponse<List<string>>> GetListStateAsync(
+            string actorType,
+            string actorId,
+            string keyName,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Invokes Actor method.

--- a/src/Dapr.Actors/Runtime/ActorStateCache.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateCache.cs
@@ -1,0 +1,224 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Dapr.Actors.Runtime;
+
+internal sealed class ActorStateCache : IActorStateCache
+{
+    /// <summary>
+    /// Maintains the cache state.
+    /// </summary>
+    private readonly Dictionary<string, StateMetadata> stateMetadata = new();
+    
+    /// <summary>
+    /// Adds the indicated value to the cache.
+    /// </summary>
+    /// <param name="stateName">The name of the state.</param>
+    /// <param name="value">The cached value.</param>
+    /// <param name="ttl">How far out the TTL expiry should be.</param>
+    /// <typeparam name="T">The type of value getting cached.</typeparam>
+    /// <returns><c>stateContainsKey</c> indicates if the cache already contains the key or not and
+    /// <c>addedToState</c> indicates if the value was added or updated in the cache.</returns>
+    public (bool stateContainsKey, bool addedToState) Add<T>(string stateName, T value, TimeSpan? ttl = null)
+    {
+        if (!stateMetadata.TryGetValue(stateName, out var state))
+        {
+            stateMetadata.Add(stateName, StateMetadata.Create(value, StateChangeKind.Add, ttl));
+            return (false, true);
+        }
+
+        if (!IsMarkedAsRemoveOrExpired(state))
+        {
+            return (true, false);
+        }
+
+        stateMetadata[stateName] = StateMetadata.Create(value, StateChangeKind.Update, ttl);
+        return (true, true);
+    }
+
+    /// <summary>
+    /// Adds the indicated value to the cache.
+    /// </summary>
+    /// <param name="stateName">The name of the state.</param>
+    /// <param name="value">The cached value.</param>
+    /// <param name="ttlExpiry">The TTL expiry timestamp.</param>
+    /// <typeparam name="T">The type of value getting cached.</typeparam>
+    /// <returns><c>stateContainsKey</c> indicates if the cache already contains the key or not and
+    /// <c>addedToState</c> indicates if the value was added or updated in the cache.</returns>
+    public (bool stateContainsKey, bool addedToState) Add<T>(string stateName, T value, DateTimeOffset ttlExpiry)
+    {
+        if (!stateMetadata.TryGetValue(stateName, out var state))
+        {
+            stateMetadata.Add(stateName, StateMetadata.Create(value, StateChangeKind.Add, ttlExpiry));
+            return (false, true);
+        }
+
+        if (!IsMarkedAsRemoveOrExpired(state))
+        {
+            return (true, false);
+        }
+
+        stateMetadata[stateName] = StateMetadata.Create(value, StateChangeKind.Update, ttlExpiry);
+        return (true, true);
+
+    }
+
+    /// <summary>
+    /// Sets the cache with the specified value whether it already exists or not.
+    /// </summary>
+    /// <param name="stateName">The name of the state to save the value to.</param>
+    /// <param name="metadata">The state metadata to save to the cache.</param>
+    public void Set(string stateName, StateMetadata metadata)
+    {
+        stateMetadata[stateName] = metadata;
+    }
+
+    /// <summary>
+    /// Removes the indicated state name from the cache.
+    /// </summary>
+    /// <param name="stateName">The name of the state to remove.</param>
+    public void Remove(string stateName) => stateMetadata.Remove(stateName);
+
+    /// <summary>
+    /// Retrieves the current state from the cache if available and not expired. 
+    /// </summary>
+    /// <param name="stateName">The name of the state to retrieve.</param>
+    /// <param name="metadata">If available and not expired, the value of the state persisted in the cache.</param>
+    /// <returns>True if the cache contains the state name; false if not.</returns>
+    public (bool containsKey, bool isMarkedAsRemoveOrExpired) TryGet(string stateName, out StateMetadata? metadata)
+    {
+        var isMarkedAsRemoveOrExpired = false;
+        metadata = null;
+
+        if (!stateMetadata.TryGetValue(stateName, out var state))
+        {
+            return (false, false);
+        }
+
+        if (IsMarkedAsRemoveOrExpired(state))
+        {
+            isMarkedAsRemoveOrExpired = true;
+        }
+            
+        metadata = state;
+        return (true, isMarkedAsRemoveOrExpired);
+
+    }
+
+    /// <summary>
+    /// Clears the all the data from the cache.
+    /// </summary>
+    public void Clear()
+    {
+        stateMetadata.Clear();
+    }
+
+    /// <summary>
+    /// Builds out the change lists of states to update in the provider and states to remove from the cache. This
+    /// is typically only called by invocation of the <c>SaveStateAsync</c> method in <see cref="ActorStateManager"/>.
+    /// </summary>
+    /// <returns>The list of state changes and states to remove from the cache.</returns>
+    public (IReadOnlyList<ActorStateChange> stateChanges, IReadOnlyList<string> statesToRemove) BuildChangeList()
+    {
+        var stateChanges = new List<ActorStateChange>();
+        var statesToRemove = new List<string>();
+
+        if (stateMetadata.Count == 0)
+        {
+            return (stateChanges, statesToRemove);
+        }
+
+        foreach (var stateName in stateMetadata.Keys)
+        {
+            var metadata = stateMetadata[stateName];
+            if (metadata.ChangeKind is not StateChangeKind.None)
+            {
+                stateChanges.Add(new ActorStateChange(stateName, metadata.Type, metadata.Value, metadata.ChangeKind, metadata.TTLExpireTime));
+
+                if (metadata.ChangeKind is StateChangeKind.Remove)
+                {
+                    statesToRemove.Add(stateName);
+                }
+                
+                //Mark the states as unmodified so the tracking for the next invocation is done correctly
+                var updatedState = metadata with { ChangeKind = StateChangeKind.None };
+                stateMetadata[stateName] = updatedState;
+            }
+        }
+
+        return (stateChanges, statesToRemove);
+    }
+
+    /// <summary>
+    /// Helper method that determines if a state metadata is expired.
+    /// </summary>
+    /// <param name="metadata">The metadata to evaluate.</param>
+    /// <returns>True if the state metadata is marked for removal or the TTL has expired, otherwise false.</returns>
+    public bool IsMarkedAsRemoveOrExpired(StateMetadata metadata) =>
+        metadata.ChangeKind == StateChangeKind.Remove || (metadata.TTLExpireTime.HasValue &&
+                                                          metadata.TTLExpireTime.Value <= DateTimeOffset.UtcNow);
+    
+    /// <summary>
+    /// Exposed for testing only.
+    /// </summary>
+    /// <returns></returns>
+    internal Dictionary<string, StateMetadata> GetStateMetadata() => stateMetadata;
+     
+    internal sealed record StateMetadata
+    {
+        /// <summary>
+        /// This should only be used for testing purposes. Use the static `Create` methods for any actual usage.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="type"></param>
+        /// <param name="changeKind"></param>
+        /// <param name="ttlExpireTime"></param>
+        /// <param name="ttl"></param>
+        /// <exception cref="ArgumentException"></exception>
+        internal StateMetadata(object? value, Type type, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime = null, TimeSpan? ttl = null)
+        {
+            this.Value = value;
+            this.Type = type;
+            this.ChangeKind = changeKind;
+
+            if (ttlExpireTime.HasValue && ttl.HasValue) {
+                throw new ArgumentException("Cannot specify both TTLExpireTime and TTL");
+            }
+
+            this.TTLExpireTime = ttl.HasValue ? DateTimeOffset.UtcNow.Add(ttl.Value) : ttlExpireTime;
+        }
+
+        public object? Value { get; init; }
+
+        public StateChangeKind ChangeKind { get; init; }
+
+        public Type Type { get; init; }
+
+        public DateTimeOffset? TTLExpireTime { get; init; }
+
+        public static StateMetadata Create<T>(T? value, StateChangeKind changeKind) =>
+            new(value, typeof(T), changeKind);
+
+        public static StateMetadata Create<T>(T? value, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime) =>
+            new(value, typeof(T), changeKind, ttlExpireTime: ttlExpireTime);
+
+        public static StateMetadata Create<T>(T? value, StateChangeKind changeKind, TimeSpan? ttl) =>
+            new(value, typeof(T), changeKind, ttl: ttl);
+
+        public static StateMetadata CreateForRemove() => new(null, typeof(object), StateChangeKind.Remove);
+    }
+}

--- a/src/Dapr.Actors/Runtime/ActorStateChange.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateChange.cs
@@ -1,5 +1,5 @@
 ﻿// ------------------------------------------------------------------------
-// Copyright 2021 The Dapr Authors
+// Copyright 2025 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,75 +11,22 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
-namespace Dapr.Actors.Runtime
-{
-    using System;
+#nullable enable
+namespace Dapr.Actors.Runtime;
 
-    /// <summary>
-    /// Represents a change to an actor state with a given state name.
-    /// </summary>
-    public sealed class ActorStateChange
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ActorStateChange"/> class.
-        /// </summary>
-        /// <param name="stateName">The name of the actor state.</param>
-        /// <param name="type">The type of value associated with given actor state name.</param>
-        /// <param name="value">The value associated with given actor state name.</param>
-        /// <param name="changeKind">The kind of state change for given actor state name.</param>
-        /// <param name="ttlExpireTime">The time to live for the state.</param>
-        public ActorStateChange(string stateName, Type type, object value, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime)
-        {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+using System;
 
-            this.StateName = stateName;
-            this.Type = type;
-            this.Value = value;
-            this.ChangeKind = changeKind;
-            this.TTLExpireTime = ttlExpireTime;
-        }
-
-        /// <summary>
-        /// Gets the name of the actor state.
-        /// </summary>
-        /// <value>
-        /// The name of the actor state.
-        /// </value>
-        public string StateName { get; }
-
-        /// <summary>
-        /// Gets the type of value associated with given actor state name.
-        /// </summary>
-        /// <value>
-        /// The type of value associated with given actor state name.
-        /// </value>
-        public Type Type { get; }
-
-        /// <summary>
-        /// Gets the value associated with given actor state name.
-        /// </summary>
-        /// <value>
-        /// The value associated with given actor state name.
-        /// </value>
-        public object Value { get; }
-
-        /// <summary>
-        /// Gets the kind of state change for given actor state name.
-        /// </summary>
-        /// <value>
-        /// The kind of state change for given actor state name.
-        /// </value>
-        public StateChangeKind ChangeKind { get; }
-
-        /// <summary>
-        /// Gets the time to live for the state.
-        /// </summary>
-        /// <value>
-        /// The time to live for the state.
-        /// </value>
-        /// <remarks>
-        /// If null, the state will not expire.
-        /// </remarks>
-        public DateTimeOffset? TTLExpireTime { get; }
-    }
-}
+/// <summary>
+/// Represents a change to an actor state with a given state name.
+/// </summary>
+/// <param name="StateName">The name of the actor state.</param>
+/// <param name="Type">The type of value associated with the given actor state name.</param>
+/// <param name="Value">The value associated with the given actor state name.</param>
+/// <param name="ChangeKind">The kind of state change for the given actor state name.</param>
+/// <param name="TTLExpireTime">The time to live for the state. If null, the state wil not expire.</param>
+public sealed record ActorStateChange(
+    string StateName,
+    Type Type,
+    object? Value,
+    StateChangeKind ChangeKind,
+    DateTimeOffset? TTLExpireTime);

--- a/src/Dapr.Actors/Runtime/ActorStateManager.cs
+++ b/src/Dapr.Actors/Runtime/ActorStateManager.cs
@@ -19,567 +19,451 @@ using System.Threading.Tasks;
 using Dapr.Actors.Resources;
 using Dapr.Actors.Communication;
 
-namespace Dapr.Actors.Runtime
+namespace Dapr.Actors.Runtime;
+
+internal sealed class ActorStateManager : IActorStateManager, IActorContextualState
 {
-    internal sealed class ActorStateManager : IActorStateManager, IActorContextualState
+    private readonly Actor actor;
+    private readonly string actorTypeName;
+    private readonly IActorStateCache defaultCache;
+    private static readonly AsyncLocal<(string id, IActorStateCache stateCache)> context = new();
+        
+    internal ActorStateManager(Actor actor)
     {
-        private readonly Actor actor;
-        private readonly string actorTypeName;
-        private readonly Dictionary<string, StateMetadata> defaultTracker;
-        private static AsyncLocal<(string id, Dictionary<string, StateMetadata> tracker)> context = new AsyncLocal<(string, Dictionary<string, StateMetadata>)>();
+        this.actor = actor;
+        this.actorTypeName = actor.Host.ActorTypeInfo.ActorTypeName;
+        this.defaultCache =  new ActorStateCache();
+    }
 
-        internal ActorStateManager(Actor actor)
+    internal ActorStateManager(Actor actor, IActorStateCache stateCache)
+    {
+        this.actor = actor;
+        this.actorTypeName = actor.Host.ActorTypeInfo.ActorTypeName;
+        this.defaultCache = stateCache;
+    }
+
+    public async Task AddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken)
+    {
+        EnsureStateProviderInitialized();
+
+        if (!(await this.TryAddStateAsync(stateName, value, cancellationToken)))
         {
-            this.actor = actor;
-            this.actorTypeName = actor.Host.ActorTypeInfo.ActorTypeName;
-            this.defaultTracker = new Dictionary<string, StateMetadata>();
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, SR.ActorStateAlreadyExists, stateName));
+        }
+    }
+
+    public async Task AddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        EnsureStateProviderInitialized();
+
+        if (!(await this.TryAddStateAsync(stateName, value, ttl, cancellationToken)))
+        {
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, SR.ActorStateAlreadyExists, stateName));
+        }
+    }
+
+    public async Task<bool> TryAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var cache = GetContextualStateTracker();
+        var (stateContainsKey, addedToState) = cache.Add(stateName, value);
+        if (stateContainsKey)
+        {
+            return addedToState;
         }
 
-        public async Task AddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken)
+        if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
         {
-            EnsureStateProviderInitialized();
-
-            if (!(await this.TryAddStateAsync(stateName, value, cancellationToken)))
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, SR.ActorStateAlreadyExists, stateName));
-            }
+            return false;
         }
 
-        public async Task AddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken)
-        {
-            EnsureStateProviderInitialized();
+        return addedToState;
+    }
 
-            if (!(await this.TryAddStateAsync(stateName, value, ttl, cancellationToken)))
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, SR.ActorStateAlreadyExists, stateName));
-            }
+    public async Task<bool> TryAddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken = default)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var cache = GetContextualStateTracker();
+        var (stateContainsKey, addedToState) = cache.Add(stateName, value, ttl);
+        if (stateContainsKey)
+        {
+            return addedToState;
+        }
+        
+        if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
+        {
+            return false;
         }
 
-        public async Task<bool> TryAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken = default)
+        return addedToState;
+    }
+
+    public async Task<T> GetStateAsync<T>(string stateName, CancellationToken cancellationToken)
+    {
+        EnsureStateProviderInitialized();
+
+        var condRes = await this.TryGetStateAsync<T>(stateName, cancellationToken);
+
+        if (condRes.HasValue)
         {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
-            {
-                var stateMetadata = stateChangeTracker[stateName];
-
-                // Check if the property was marked as remove or is expired in the cache
-                if (stateMetadata.ChangeKind == StateChangeKind.Remove || (stateMetadata.TTLExpireTime.HasValue && stateMetadata.TTLExpireTime.Value <= DateTimeOffset.UtcNow))
-                {
-                    stateChangeTracker[stateName] = StateMetadata.Create(value, StateChangeKind.Update);
-                    return true;
-                }
-
-                return false;
-            }
-
-            if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
-            {
-                return false;
-            }
-
-            stateChangeTracker[stateName] = StateMetadata.Create(value, StateChangeKind.Add);
-            return true;
+            return condRes.Value;
         }
 
-        public async Task<bool> TryAddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken = default)
+        throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, SR.ErrorNamedActorStateNotFound, stateName));
+    }
+
+    public async Task<ConditionalValue<T>> TryGetStateAsync<T>(string stateName, CancellationToken cancellationToken)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var stateChangeTracker = GetContextualStateTracker();
+        var getCacheValue = stateChangeTracker.TryGet(stateName, out var state);
+        if (getCacheValue.containsKey)
         {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
-            {
-                var stateMetadata = stateChangeTracker[stateName];
-
-                // Check if the property was marked as remove in the cache or has been expired.
-                if (stateMetadata.ChangeKind == StateChangeKind.Remove || (stateMetadata.TTLExpireTime.HasValue && stateMetadata.TTLExpireTime.Value <= DateTimeOffset.UtcNow))
-                {
-                    stateChangeTracker[stateName] = StateMetadata.Create(value, StateChangeKind.Update, ttl: ttl);
-                    return true;
-                }
-
-                return false;
-            }
-
-            if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
-            {
-                return false;
-            }
-
-            stateChangeTracker[stateName] = StateMetadata.Create(value, StateChangeKind.Add, ttl: ttl);
-            return true;
+            return getCacheValue.isMarkedAsRemoveOrExpired
+                ? new ConditionalValue<T>(false, default)
+                : new ConditionalValue<T>(true, (T)state!.Value);
+        }
+        
+        var conditionalResult = await this.TryGetStateFromStateProviderAsync<T>(stateName, cancellationToken);
+        if (conditionalResult.HasValue)
+        {
+            var stateMetadata = ActorStateCache.StateMetadata.Create(conditionalResult.Value.Value,
+                StateChangeKind.None, conditionalResult.Value.TTLExpireTime);
+            stateChangeTracker.Add(stateName, stateMetadata);
+            return new ConditionalValue<T>(true, conditionalResult.Value.Value);
         }
 
-        public async Task<T> GetStateAsync<T>(string stateName, CancellationToken cancellationToken)
+        return new ConditionalValue<T>(false, default);
+    }
+
+    public async Task SetStateAsync<T>(string stateName, T value, CancellationToken cancellationToken)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var stateChangeTracker = GetContextualStateTracker();
+        var (cacheContainsKey, _) = stateChangeTracker.TryGet(stateName, out var state);
+        if (cacheContainsKey && state is not null)
         {
-            EnsureStateProviderInitialized();
-
-            var condRes = await this.TryGetStateAsync<T>(stateName, cancellationToken);
-
-            if (condRes.HasValue)
+            var updatedState = state with { Value = value, TTLExpireTime = null };
+            if (state.ChangeKind is StateChangeKind.None or StateChangeKind.Remove)
             {
-                return condRes.Value;
+                updatedState = updatedState with { ChangeKind = StateChangeKind.Update };
             }
 
+            stateChangeTracker.Set(stateName, updatedState);
+        }
+        else if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(),
+                     stateName, cancellationToken))
+        {
+            stateChangeTracker.Add(stateName, ActorStateCache.StateMetadata.Create(value, StateChangeKind.Update));
+        }
+        else
+        {
+            stateChangeTracker.Set(stateName, ActorStateCache.StateMetadata.Create(value, StateChangeKind.Add));
+        }
+    }
+
+    public async Task SetStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var stateChangeTracker = GetContextualStateTracker();
+        var getCacheValue = stateChangeTracker.TryGet(stateName, out var state);
+        if (getCacheValue.containsKey && state is not null)
+        {
+            var updatedState = state with { Value = state.Value, TTLExpireTime = DateTimeOffset.UtcNow.Add(ttl) };
+            if (updatedState.ChangeKind is StateChangeKind.None or StateChangeKind.Remove)
+            {
+                updatedState = updatedState with { ChangeKind = StateChangeKind.Update };
+            }
+            stateChangeTracker.Set(stateName, updatedState);
+        }
+        else if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(),
+                     stateName, cancellationToken))
+        {
+            stateChangeTracker.Add(stateName, ActorStateCache.StateMetadata.Create(value, StateChangeKind.Update, ttl));
+        }
+        else
+        {
+            stateChangeTracker.Set(stateName, ActorStateCache.StateMetadata.Create(value, StateChangeKind.Add, ttl));
+        }
+    }
+
+    public async Task RemoveStateAsync(string stateName, CancellationToken cancellationToken)
+    {
+        EnsureStateProviderInitialized();
+
+        if (!(await this.TryRemoveStateAsync(stateName, cancellationToken)))
+        {
             throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, SR.ErrorNamedActorStateNotFound, stateName));
         }
+    }
 
-        public async Task<ConditionalValue<T>> TryGetStateAsync<T>(string stateName, CancellationToken cancellationToken)
+    public async Task<bool> TryRemoveStateAsync(string stateName, CancellationToken cancellationToken)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var stateChangeTracker = GetContextualStateTracker();
+
+        var cacheGetResult = stateChangeTracker.TryGet(stateName, out var state);
+        if (cacheGetResult.containsKey && state is not null)
         {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
+            if (cacheGetResult.isMarkedAsRemoveOrExpired)
             {
-                var stateMetadata = stateChangeTracker[stateName];
-
-                // Check if the property was marked as remove in the cache or is expired
-                if (stateMetadata.ChangeKind == StateChangeKind.Remove || (stateMetadata.TTLExpireTime.HasValue && stateMetadata.TTLExpireTime.Value <= DateTimeOffset.UtcNow))
-                {
-                    return new ConditionalValue<T>(false, default);
-                }
-
-                return new ConditionalValue<T>(true, (T)stateMetadata.Value);
+                stateChangeTracker.Remove(stateName);
+                return false;
             }
 
-            var conditionalResult = await this.TryGetStateFromStateProviderAsync<T>(stateName, cancellationToken);
-            if (conditionalResult.HasValue)
+            switch (state.ChangeKind)
             {
-                stateChangeTracker.Add(stateName, StateMetadata.Create(conditionalResult.Value.Value, StateChangeKind.None, ttlExpireTime: conditionalResult.Value.TTLExpireTime));
-                return new ConditionalValue<T>(true, conditionalResult.Value.Value);
-            }
-
-            return new ConditionalValue<T>(false, default);
-        }
-
-        public async Task SetStateAsync<T>(string stateName, T value, CancellationToken cancellationToken)
-        {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
-            {
-                var stateMetadata = stateChangeTracker[stateName];
-                stateMetadata.Value = value;
-                stateMetadata.TTLExpireTime = null;
-
-                if (stateMetadata.ChangeKind == StateChangeKind.None ||
-                    stateMetadata.ChangeKind == StateChangeKind.Remove)
-                {
-                    stateMetadata.ChangeKind = StateChangeKind.Update;
-                }
-            }
-            else if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
-            {
-                stateChangeTracker.Add(stateName, StateMetadata.Create(value, StateChangeKind.Update));
-            }
-            else
-            {
-                stateChangeTracker[stateName] = StateMetadata.Create(value, StateChangeKind.Add);
-            }
-        }
-
-        public async Task SetStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken)
-        {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
-            {
-                var stateMetadata = stateChangeTracker[stateName];
-                stateMetadata.Value = value;
-                stateMetadata.TTLExpireTime = DateTimeOffset.UtcNow.Add(ttl);
-
-                if (stateMetadata.ChangeKind == StateChangeKind.None ||
-                    stateMetadata.ChangeKind == StateChangeKind.Remove)
-                {
-                    stateMetadata.ChangeKind = StateChangeKind.Update;
-                }
-            }
-            else if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
-            {
-                stateChangeTracker.Add(stateName, StateMetadata.Create(value, StateChangeKind.Update, ttl: ttl));
-            }
-            else
-            {
-                stateChangeTracker[stateName] = StateMetadata.Create(value, StateChangeKind.Add, ttl: ttl);
-            }
-        }
-
-        public async Task RemoveStateAsync(string stateName, CancellationToken cancellationToken)
-        {
-            EnsureStateProviderInitialized();
-
-            if (!(await this.TryRemoveStateAsync(stateName, cancellationToken)))
-            {
-                throw new KeyNotFoundException(string.Format(CultureInfo.CurrentCulture, SR.ErrorNamedActorStateNotFound, stateName));
-            }
-        }
-
-        public async Task<bool> TryRemoveStateAsync(string stateName, CancellationToken cancellationToken)
-        {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
-            {
-                var stateMetadata = stateChangeTracker[stateName];
-
-                if (stateMetadata.TTLExpireTime.HasValue && stateMetadata.TTLExpireTime.Value <= DateTimeOffset.UtcNow)
-                {
-                    stateChangeTracker.Remove(stateName);
+                case StateChangeKind.Remove:
                     return false;
-                }
-
-                switch (stateMetadata.ChangeKind)
-                {
-                    case StateChangeKind.Remove:
-                        return false;
-                    case StateChangeKind.Add:
-                        stateChangeTracker.Remove(stateName);
-                        return true;
-                }
-
-                stateMetadata.ChangeKind = StateChangeKind.Remove;
-                return true;
+                case StateChangeKind.Add:
+                    stateChangeTracker.Remove(stateName);
+                    return true;
             }
 
-            if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
-            {
-                stateChangeTracker.Add(stateName, StateMetadata.CreateForRemove());
-                return true;
-            }
-
-            return false;
+            var updatedState = state with { ChangeKind = StateChangeKind.Remove };
+            stateChangeTracker.Set(stateName, updatedState);
+            return true;
+        }
+        
+        if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
+        {
+            stateChangeTracker.Add(stateName, ActorStateCache.StateMetadata.CreateForRemove());
+            return true;
         }
 
-        public async Task<bool> ContainsStateAsync(string stateName, CancellationToken cancellationToken)
+        return false;
+    }
+
+    public async Task<bool> ContainsStateAsync(string stateName, CancellationToken cancellationToken)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var stateChangeTracker = GetContextualStateTracker();
+        var getCacheValue = stateChangeTracker.TryGet(stateName, out var state);
+        if (getCacheValue.containsKey && state is not null)
         {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
-            {
-                var stateMetadata = stateChangeTracker[stateName];
-
-                // Check if the property was marked as remove in the cache
-                return stateMetadata.ChangeKind != StateChangeKind.Remove;
-            }
-
-            if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
-            {
-                return true;
-            }
-
-            return false;
+            //Check if the property was marked as remove in the cache
+            return state.ChangeKind != StateChangeKind.Remove;
         }
 
-        public async Task<T> GetOrAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken)
+        if (await this.actor.Host.StateProvider.ContainsStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken))
         {
-            EnsureStateProviderInitialized();
-
-            var condRes = await this.TryGetStateAsync<T>(stateName, cancellationToken);
-
-            if (condRes.HasValue)
-            {
-                return condRes.Value;
-            }
-
-            var changeKind = this.IsStateMarkedForRemove(stateName) ? StateChangeKind.Update : StateChangeKind.Add;
-
-            var stateChangeTracker = GetContextualStateTracker();
-            stateChangeTracker[stateName] = StateMetadata.Create(value, changeKind);
-            return value;
+            return true;
         }
 
-        public async Task<T> GetOrAddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken)
+        return false;
+    }
+
+    public async Task<T> GetOrAddStateAsync<T>(string stateName, T value, CancellationToken cancellationToken)
+    {
+        EnsureStateProviderInitialized();
+
+        var condRes = await this.TryGetStateAsync<T>(stateName, cancellationToken);
+
+        if (condRes.HasValue)
         {
-            EnsureStateProviderInitialized();
-
-            var condRes = await this.TryGetStateAsync<T>(stateName, cancellationToken);
-
-            if (condRes.HasValue)
-            {
-                return condRes.Value;
-            }
-
-            var changeKind = this.IsStateMarkedForRemove(stateName) ? StateChangeKind.Update : StateChangeKind.Add;
-
-            var stateChangeTracker = GetContextualStateTracker();
-            stateChangeTracker[stateName] = StateMetadata.Create(value, changeKind, ttl: ttl);
-            return value;
+            return condRes.Value;
         }
 
-        public async Task<T> AddOrUpdateStateAsync<T>(
-            string stateName,
-            T addValue,
-            Func<string, T, T> updateValueFactory,
-            CancellationToken cancellationToken = default)
+        var changeKind = this.IsStateMarkedForRemove(stateName) ? StateChangeKind.Update : StateChangeKind.Add;
+
+        var stateChangeTracker = GetContextualStateTracker();
+        stateChangeTracker.Set(stateName, ActorStateCache.StateMetadata.Create(value, changeKind));
+        return value;
+    }
+
+    public async Task<T> GetOrAddStateAsync<T>(string stateName, T value, TimeSpan ttl, CancellationToken cancellationToken)
+    {
+        EnsureStateProviderInitialized();
+
+        var condRes = await this.TryGetStateAsync<T>(stateName, cancellationToken);
+
+        if (condRes.HasValue)
         {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
-            {
-                var stateMetadata = stateChangeTracker[stateName];
-
-                // Check if the property was marked as remove in the cache
-                if (stateMetadata.ChangeKind == StateChangeKind.Remove)
-                {
-                    stateChangeTracker[stateName] = StateMetadata.Create(addValue, StateChangeKind.Update);
-                    return addValue;
-                }
-
-                var newValue = updateValueFactory.Invoke(stateName, (T)stateMetadata.Value);
-                stateMetadata.Value = newValue;
-
-                if (stateMetadata.ChangeKind == StateChangeKind.None)
-                {
-                    stateMetadata.ChangeKind = StateChangeKind.Update;
-                }
-
-                return newValue;
-            }
-
-            var conditionalResult = await this.TryGetStateFromStateProviderAsync<T>(stateName, cancellationToken);
-            if (conditionalResult.HasValue)
-            {
-                var newValue = updateValueFactory.Invoke(stateName, conditionalResult.Value.Value);
-                stateChangeTracker.Add(stateName, StateMetadata.Create(newValue, StateChangeKind.Update));
-
-                return newValue;
-            }
-
-            stateChangeTracker[stateName] = StateMetadata.Create(addValue, StateChangeKind.Add);
-            return addValue;
+            return condRes.Value;
         }
 
-        public async Task<T> AddOrUpdateStateAsync<T>(
-            string stateName,
-            T addValue,
-            Func<string, T, T> updateValueFactory,
-            TimeSpan ttl,
-            CancellationToken cancellationToken = default)
+        var changeKind = this.IsStateMarkedForRemove(stateName) ? StateChangeKind.Update : StateChangeKind.Add;
+
+        var stateChangeTracker = GetContextualStateTracker();
+        stateChangeTracker.Set(stateName, ActorStateCache.StateMetadata.Create(value, changeKind, ttl));
+        return value;
+    }
+
+    public async Task<T> AddOrUpdateStateAsync<T>(
+        string stateName,
+        T addValue,
+        Func<string, T, T> updateValueFactory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var stateChangeTracker = GetContextualStateTracker();
+        var getCacheValue = stateChangeTracker.TryGet(stateName, out var state);
+        if (getCacheValue.containsKey && state is not null)
         {
-            ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
-
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName))
+            //Check if the property was marked as remove in the cache
+            if (state.ChangeKind == StateChangeKind.Remove)
             {
-                var stateMetadata = stateChangeTracker[stateName];
-
-                // Check if the property was marked as remove in the cache
-                if (stateMetadata.ChangeKind == StateChangeKind.Remove)
-                {
-                    stateChangeTracker[stateName] = StateMetadata.Create(addValue, StateChangeKind.Update, ttl: ttl);
-                    return addValue;
-                }
-
-                var newValue = updateValueFactory.Invoke(stateName, (T)stateMetadata.Value);
-                stateMetadata.Value = newValue;
-
-                if (stateMetadata.ChangeKind == StateChangeKind.None)
-                {
-                    stateMetadata.ChangeKind = StateChangeKind.Update;
-                }
-
-                return newValue;
+                stateChangeTracker.Set(stateName, ActorStateCache.StateMetadata.Create(addValue, StateChangeKind.Update));
+                return addValue;
             }
 
-            var conditionalResult = await this.TryGetStateFromStateProviderAsync<T>(stateName, cancellationToken);
-            if (conditionalResult.HasValue)
+            var newValue = updateValueFactory.Invoke(stateName, (T)state.Value);
+            var updatedState = state with { Value = newValue };
+
+            if (state.ChangeKind == StateChangeKind.None)
             {
-                var newValue = updateValueFactory.Invoke(stateName, conditionalResult.Value.Value);
-                stateChangeTracker.Add(stateName, StateMetadata.Create(newValue, StateChangeKind.Update, ttl: ttl));
-
-                return newValue;
+                updatedState = updatedState with { ChangeKind = StateChangeKind.Update };
             }
-
-            stateChangeTracker[stateName] = StateMetadata.Create(addValue, StateChangeKind.Add, ttl: ttl);
-            return addValue;
+            
+            stateChangeTracker.Set(stateName, updatedState);
+            return newValue;
         }
 
-        public Task ClearCacheAsync(CancellationToken cancellationToken)
+        var conditionalResult = await this.TryGetStateFromStateProviderAsync<T>(stateName, cancellationToken);
+        if (conditionalResult.HasValue)
         {
-            EnsureStateProviderInitialized();
+            var newValue = updateValueFactory.Invoke(stateName, conditionalResult.Value.Value);
+            stateChangeTracker.Add(stateName, ActorStateCache.StateMetadata.Create(newValue, StateChangeKind.Update));
 
-            var stateChangeTracker = GetContextualStateTracker();
-
-            stateChangeTracker.Clear();
-            return Task.CompletedTask;
+            return newValue;
         }
 
-        public async Task SaveStateAsync(CancellationToken cancellationToken = default)
+        stateChangeTracker.Set(stateName, ActorStateCache.StateMetadata.Create(addValue, StateChangeKind.Add));
+        return addValue;
+    }
+
+    public async Task<T> AddOrUpdateStateAsync<T>(
+        string stateName,
+        T addValue,
+        Func<string, T, T> updateValueFactory,
+        TimeSpan ttl,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentVerifier.ThrowIfNull(stateName, nameof(stateName));
+
+        EnsureStateProviderInitialized();
+
+        var stateChangeTracker = GetContextualStateTracker();
+        var getCacheValue = stateChangeTracker.TryGet(stateName, out var state);
+        if (getCacheValue.containsKey && state is not null)
         {
-            EnsureStateProviderInitialized();
-
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.Count > 0)
+            if (state.ChangeKind == StateChangeKind.Remove)
             {
-                var stateChangeList = new List<ActorStateChange>();
-                var statesToRemove = new List<string>();
-
-                foreach (var stateName in stateChangeTracker.Keys)
-                {
-                    var stateMetadata = stateChangeTracker[stateName];
-
-                    if (stateMetadata.ChangeKind != StateChangeKind.None)
-                    {
-                        stateChangeList.Add(
-                            new ActorStateChange(stateName, stateMetadata.Type, stateMetadata.Value, stateMetadata.ChangeKind, stateMetadata.TTLExpireTime));
-
-                        if (stateMetadata.ChangeKind == StateChangeKind.Remove)
-                        {
-                            statesToRemove.Add(stateName);
-                        }
-
-                        // Mark the states as unmodified so that tracking for next invocation is done correctly.
-                        stateMetadata.ChangeKind = StateChangeKind.None;
-                    }
-                }
-
-                if (stateChangeList.Count > 0)
-                {
-                    await this.actor.Host.StateProvider.SaveStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateChangeList.AsReadOnly(), cancellationToken);
-                }
-
-                // Remove the states from tracker whcih were marked for removal.
-                foreach (var stateToRemove in statesToRemove)
-                {
-                    stateChangeTracker.Remove(stateToRemove);
-                }
+                stateChangeTracker.Set(stateName, ActorStateCache.StateMetadata.Create(addValue, StateChangeKind.Update, ttl));
+                return addValue;
             }
+
+            var newValue = updateValueFactory.Invoke(stateName, (T)state.Value);
+            var updatedState = state with { Value = newValue };
+
+            if (state.ChangeKind == StateChangeKind.None)
+            {
+                updatedState = updatedState with { ChangeKind = StateChangeKind.Update };
+            }
+            
+            stateChangeTracker.Set(stateName, updatedState);
+
+            return newValue;
         }
 
-        public Task SetStateContext(string stateContext)
+        var conditionalResult = await this.TryGetStateFromStateProviderAsync<T>(stateName, cancellationToken);
+        if (conditionalResult.HasValue)
         {
-            if (stateContext != null)
-            {
-                context.Value = (stateContext, new Dictionary<string, StateMetadata>());
-            }
-            else
-            {
-                context.Value = (null, null);
-            }
+            var newValue = updateValueFactory.Invoke(stateName, conditionalResult.Value.Value);
+            stateChangeTracker.Add(stateName, ActorStateCache.StateMetadata.Create(newValue, StateChangeKind.Update, ttl));
 
-            return Task.CompletedTask;
+            return newValue;
         }
 
-        private bool IsStateMarkedForRemove(string stateName)
+        stateChangeTracker.Set(stateName, ActorStateCache.StateMetadata.Create(addValue, StateChangeKind.Add, ttl));
+        return addValue;
+    }
+
+    public Task ClearCacheAsync(CancellationToken cancellationToken)
+    {
+        EnsureStateProviderInitialized();
+
+        var cache = GetContextualStateTracker();
+        cache.Clear();
+        
+        return Task.CompletedTask;
+    }
+
+    public async Task SaveStateAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureStateProviderInitialized();
+
+        var stateChangeTracker = GetContextualStateTracker();
+        var (stateChanges, statesToRemove) = stateChangeTracker.BuildChangeList();
+
+        if (stateChanges.Count > 0)
         {
-            var stateChangeTracker = GetContextualStateTracker();
-
-            if (stateChangeTracker.ContainsKey(stateName) &&
-                stateChangeTracker[stateName].ChangeKind == StateChangeKind.Remove)
-            {
-                return true;
-            }
-
-            return false;
+            await this.actor.Host.StateProvider.SaveStateAsync(this.actorTypeName, this.actor.Id.ToString(), stateChanges, cancellationToken);
         }
-
-        private Task<ConditionalValue<ActorStateResponse<T>>> TryGetStateFromStateProviderAsync<T>(string stateName, CancellationToken cancellationToken)
+        
+        //Remove the states from the tracker which were marked for removal
+        if (statesToRemove.Count > 0)
         {
-            EnsureStateProviderInitialized();
-            return this.actor.Host.StateProvider.TryLoadStateAsync<T>(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken);
-        }
-
-        private void EnsureStateProviderInitialized()
-        {
-            if (this.actor.Host.StateProvider == null)
+            foreach (var stateToRemove in statesToRemove)
             {
-                throw new InvalidOperationException(
-                    "The actor was initialized without a state provider, and so cannot interact with state. " +
-                    "If this is inside a unit test, replace Actor.StateProvider with a mock.");
-            }
-        }
-
-        private Dictionary<string, StateMetadata> GetContextualStateTracker()
-        {
-            if (context.Value.id != null)
-            {
-                return context.Value.tracker;
-            }
-            else
-            {
-                return defaultTracker;
-            }
-        }
-
-        private sealed class StateMetadata
-        {
-            private StateMetadata(object value, Type type, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime = null, TimeSpan? ttl = null)
-            {
-                this.Value = value;
-                this.Type = type;
-                this.ChangeKind = changeKind;
-
-                if (ttlExpireTime.HasValue && ttl.HasValue) {
-                    throw new ArgumentException("Cannot specify both TTLExpireTime and TTL");
-                }
-                if (ttl.HasValue) {
-                    this.TTLExpireTime = DateTimeOffset.UtcNow.Add(ttl.Value);
-                } else {
-                    this.TTLExpireTime = ttlExpireTime;
-                }
-            }
-
-            public object Value { get; set; }
-
-            public StateChangeKind ChangeKind { get; set; }
-
-            public Type Type { get; }
-
-            public DateTimeOffset? TTLExpireTime { get; set; }
-
-            public static StateMetadata Create<T>(T value, StateChangeKind changeKind)
-            {
-                return new StateMetadata(value, typeof(T), changeKind);
-            }
-
-            public static StateMetadata Create<T>(T value, StateChangeKind changeKind, DateTimeOffset? ttlExpireTime)
-            {
-                return new StateMetadata(value, typeof(T), changeKind, ttlExpireTime: ttlExpireTime);
-            }
-
-            public static StateMetadata Create<T>(T value, StateChangeKind changeKind, TimeSpan? ttl)
-            {
-                return new StateMetadata(value, typeof(T), changeKind, ttl: ttl);
-            }
-
-            public static StateMetadata CreateForRemove()
-            {
-                return new StateMetadata(null, typeof(object), StateChangeKind.Remove);
+                stateChangeTracker.Remove(stateToRemove);
             }
         }
     }
+
+    public Task SetStateContext(string stateContext)
+    {
+        context.Value = stateContext != null ? (stateContext, new ActorStateCache()) : (null, null);
+        return Task.CompletedTask;
+    }
+
+    private bool IsStateMarkedForRemove(string stateName)
+    {
+        var stateChangeTracker = GetContextualStateTracker();
+
+        var getCacheResult = stateChangeTracker.TryGet(stateName, out var state);
+        return getCacheResult.containsKey && state is not null && state.ChangeKind == StateChangeKind.Remove;
+    }
+
+    private Task<ConditionalValue<ActorStateResponse<T>>> TryGetStateFromStateProviderAsync<T>(string stateName, CancellationToken cancellationToken)
+    {
+        EnsureStateProviderInitialized();
+        return this.actor.Host.StateProvider.TryLoadStateAsync<T>(this.actorTypeName, this.actor.Id.ToString(), stateName, cancellationToken);
+    }
+
+    private void EnsureStateProviderInitialized()
+    {
+        if (this.actor.Host.StateProvider == null)
+        {
+            throw new InvalidOperationException(
+                "The actor was initialized without a state provider, and so cannot interact with state. " +
+                "If this is inside a unit test, replace Actor.StateProvider with a mock.");
+        }
+    }
+
+    private IActorStateCache GetContextualStateTracker() => context.Value.id != null ? context.Value.stateCache : defaultCache;
 }

--- a/src/Dapr.Actors/Runtime/IActorStateCache.cs
+++ b/src/Dapr.Actors/Runtime/IActorStateCache.cs
@@ -1,0 +1,85 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Dapr.Actors.Runtime;
+
+internal interface IActorStateCache
+{
+    /// <summary>
+    /// Adds the indicated value to the cache.
+    /// </summary>
+    /// <param name="stateName">The name of the state.</param>
+    /// <param name="value">The cached value.</param>
+    /// <param name="ttl">How far out the TTL expiry should be.</param>
+    /// <typeparam name="T">The type of value getting cached.</typeparam>
+    /// <returns><c>stateContainsKey</c> indicates if the cache already contains the key or not and
+    /// <c>addedToState</c> indicates if the value was added or updated in the cache.</returns>
+    (bool stateContainsKey, bool addedToState) Add<T>(string stateName, T value, TimeSpan? ttl = null);
+
+    /// <summary>
+    /// Adds the indicated value to the cache.
+    /// </summary>
+    /// <param name="stateName">The name of the state.</param>
+    /// <param name="value">The cached value.</param>
+    /// <param name="ttlExpiry">The TTL expiry timestamp.</param>
+    /// <typeparam name="T">The type of value getting cached.</typeparam>
+    /// <returns><c>stateContainsKey</c> indicates if the cache already contains the key or not and
+    /// <c>addedToState</c> indicates if the value was added or updated in the cache.</returns>
+    (bool stateContainsKey, bool addedToState) Add<T>(string stateName, T value, DateTimeOffset ttlExpiry);
+
+    /// <summary>
+    /// Sets the cache with the specified value whether it already exists or not.
+    /// </summary>
+    /// <param name="stateName">The name of the state to save the value to.</param>
+    /// <param name="metadata">The state metadata to save to the cache.</param>
+    void Set(string stateName, ActorStateCache.StateMetadata metadata);
+
+    /// <summary>
+    /// Removes the indicated state name from the cache.
+    /// </summary>
+    /// <param name="stateName">The name of the state to remove.</param>
+    void Remove(string stateName);
+
+    /// <summary>
+    /// Retrieves the current state from the cache if available and not expired. 
+    /// </summary>
+    /// <param name="stateName">The name of the state to retrieve.</param>
+    /// <param name="metadata">If available and not expired, the value of the state persisted in the cache.</param>
+    /// <returns>True if the cache contains the state name; false if not.</returns>
+    (bool containsKey, bool isMarkedAsRemoveOrExpired) TryGet(
+        string stateName,
+        out ActorStateCache.StateMetadata? metadata);
+
+    /// <summary>
+    /// Clears the all the data from the cache.
+    /// </summary>
+    void Clear();
+
+    /// <summary>
+    /// Builds out the change lists of states to update in the provider and states to remove from the cache. This
+    /// is typically only called by invocation of the <c>SaveStateAsync</c> method in <see cref="ActorStateManager"/>.
+    /// </summary>
+    /// <returns></returns>
+    (IReadOnlyList<ActorStateChange> stateChanges, IReadOnlyList<string> statesToRemove) BuildChangeList();
+
+    /// <summary>
+    /// Helper method that determines if a state metadata is expired.
+    /// </summary>
+    /// <param name="metadata">The metadata to evaluate.</param>
+    /// <returns>True if the state metadata is marked for removal or the TTL has expired, otherwise false.</returns>
+    bool IsMarkedAsRemoveOrExpired(ActorStateCache.StateMetadata metadata);
+}

--- a/test/Dapr.Actors.Test/ActorStateManagerTest.cs
+++ b/test/Dapr.Actors.Test/ActorStateManagerTest.cs
@@ -11,182 +11,193 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
-namespace Dapr.Actors.Test
+namespace Dapr.Actors.Test;
+
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Xunit;
+using Dapr.Actors.Communication;
+using Dapr.Actors.Runtime;
+using Moq;
+
+/// <summary>
+/// Contains tests for ActorStateManager.
+/// </summary>
+public sealed class ActorStateManagerTest
 {
-    using System;
-    using System.Text.Json;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using System.Collections.Generic;
-    using Xunit;
-    using Dapr.Actors.Communication;
-    using Dapr.Actors.Runtime;
-    using Moq;
-
-    /// <summary>
-    /// Contains tests for ActorStateManager.
-    /// </summary>
-    public class ActorStateManagerTest
+    [Fact]
+    public async Task SetGet()
     {
-        [Fact]
-        public async Task SetGet()
-        {
-            var interactor = new Mock<TestDaprInteractor>();
-            var host = ActorHost.CreateForTest<TestActor>();
-            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
-            var mngr = new ActorStateManager(new TestActor(host));
-            var token = new CancellationToken();
+        var interactor = new Mock<TestDaprInteractor>();
+        var host = ActorHost.CreateForTest<TestActor>();
+        host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+        var mngr = new ActorStateManager(new TestActor(host));
+        var token = new CancellationToken();
 
-            interactor
-              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+        interactor
+            .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
 
-            await mngr.AddStateAsync("key1", "value1", token);
-            await mngr.AddStateAsync("key2", "value2", token);
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+        await mngr.AddStateAsync("key1", "value1", token);
+        await mngr.AddStateAsync("key2", "value2", token);
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
 
-            await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key1", "value3", token));
-            await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key2", "value4", token));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key1", "value3", token));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key2", "value4", token));
 
-            await mngr.SetStateAsync("key1", "value5", token);
-            await mngr.SetStateAsync("key2", "value6", token);
-            Assert.Equal("value5", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value6", await mngr.GetStateAsync<string>("key2", token));
-        }
-
-        [Fact]
-        public async Task StateWithTTL()
-        {
-            var interactor = new Mock<TestDaprInteractor>();
-            var host = ActorHost.CreateForTest<TestActor>();
-            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
-            var mngr = new ActorStateManager(new TestActor(host));
-            var token = new CancellationToken();
-
-            interactor
-              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
-
-            await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
-            await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-
-            await Task.Delay(TimeSpan.FromSeconds(1.5));
-
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
-
-            // Should be able to add state again after expiry and should not expire.
-            await mngr.AddStateAsync("key1", "value1", token);
-            await mngr.AddStateAsync("key2", "value2", token);
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-            await Task.Delay(TimeSpan.FromSeconds(1.5));
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-        }
-
-        [Fact]
-        public async Task StateRemoveAddTTL()
-        {
-            var interactor = new Mock<TestDaprInteractor>();
-            var host = ActorHost.CreateForTest<TestActor>();
-            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
-            var mngr = new ActorStateManager(new TestActor(host));
-            var token = new CancellationToken();
-
-            interactor
-              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
-
-            await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
-            await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-
-            await mngr.SetStateAsync("key1", "value1", token);
-            await mngr.SetStateAsync("key2", "value2", token);
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-
-            // TTL is removed so state should not expire.
-            await Task.Delay(TimeSpan.FromSeconds(1.5));
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-
-            // Adding TTL back should expire state.
-            await mngr.SetStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
-            await mngr.SetStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-            await Task.Delay(TimeSpan.FromSeconds(1.5));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
-        }
-
-        [Fact]
-        public async Task StateDaprdExpireTime()
-        {
-            var interactor = new Mock<TestDaprInteractor>();
-            var host = ActorHost.CreateForTest<TestActor>();
-            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
-            var mngr = new ActorStateManager(new TestActor(host));
-            var token = new CancellationToken();
-
-            // Existing key which has an expiry time.
-            interactor
-              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-              .Returns(Task.FromResult(new ActorStateResponse<string>("\"value1\"", DateTime.UtcNow.AddSeconds(1))));
-
-            await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key1", "value3", token));
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-
-            // No longer return the value from the state provider.
-            interactor
-              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
-
-            // Key should be expired after 1 seconds.
-            await Task.Delay(TimeSpan.FromSeconds(1.5));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.RemoveStateAsync("key1", token));
-            await mngr.AddStateAsync("key1", "value2", TimeSpan.FromSeconds(1), token);
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key1", token));
-        }
-
-        [Fact]
-        public async Task RemoveState()
-        {
-            var interactor = new Mock<TestDaprInteractor>();
-            var host = ActorHost.CreateForTest<TestActor>();
-            host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
-            var mngr = new ActorStateManager(new TestActor(host));
-            var token = new CancellationToken();
-
-            interactor
-              .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-              .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
-
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.RemoveStateAsync("key1", token));
-
-            await mngr.AddStateAsync("key1", "value1", token);
-            await mngr.AddStateAsync("key2", "value2", token);
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-
-            await mngr.RemoveStateAsync("key1", token);
-            await mngr.RemoveStateAsync("key2", token);
-
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
-
-            // Should be able to add state again after removal.
-            await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
-            await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
-            Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
-            Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
-        }
+        await mngr.SetStateAsync("key1", "value5", token);
+        await mngr.SetStateAsync("key2", "value6", token);
+        Assert.Equal("value5", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value6", await mngr.GetStateAsync<string>("key2", token));
     }
+
+    [Fact]
+    public async Task StateWithTTL()
+    {
+        var interactor = new Mock<TestDaprInteractor>();
+        var host = ActorHost.CreateForTest<TestActor>();
+        host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+        var mngr = new ActorStateManager(new TestActor(host));
+        var token = new CancellationToken();
+
+        interactor
+            .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+        await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
+        await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+        await Task.Delay(TimeSpan.FromSeconds(1.5));
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
+
+        // Should be able to add state again after expiry and should not expire.
+        await mngr.AddStateAsync("key1", "value1", token);
+        await mngr.AddStateAsync("key2", "value2", token);
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+        await Task.Delay(TimeSpan.FromSeconds(1.5));
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+    }
+
+    [Fact]
+    public async Task StateRemoveAddTTL()
+    {
+        var interactor = new Mock<TestDaprInteractor>();
+        var host = ActorHost.CreateForTest<TestActor>();
+        host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+        var mngr = new ActorStateManager(new TestActor(host));
+        var token = new CancellationToken();
+
+        interactor
+            .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+        await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
+        await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+        await mngr.SetStateAsync("key1", "value1", token);
+        await mngr.SetStateAsync("key2", "value2", token);
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+        // TTL is removed so state should not expire.
+        await Task.Delay(TimeSpan.FromSeconds(1.5));
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+        // Adding TTL back should expire state.
+        await mngr.SetStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
+        await mngr.SetStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+        await Task.Delay(TimeSpan.FromSeconds(1.5));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
+    }
+
+    [Fact]
+    public async Task StateDaprdExpireTime()
+    {
+        var interactor = new Mock<TestDaprInteractor>();
+        var host = ActorHost.CreateForTest<TestActor>();
+        host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+        var mngr = new ActorStateManager(new TestActor(host));
+        var token = new CancellationToken();
+
+        // Existing key which has an expiry time.
+        interactor
+            .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new ActorStateResponse<string>("\"value1\"", DateTime.UtcNow.AddSeconds(1))));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => mngr.AddStateAsync("key1", "value3", token));
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+
+        // No longer return the value from the state provider.
+        interactor
+            .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+        // Key should be expired after 1 seconds.
+        await Task.Delay(TimeSpan.FromSeconds(1.5));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.RemoveStateAsync("key1", token));
+        await mngr.AddStateAsync("key1", "value2", TimeSpan.FromSeconds(1), token);
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key1", token));
+    }
+
+    [Fact]
+    public async Task RemoveState()
+    {
+        var interactor = new Mock<TestDaprInteractor>();
+        var host = ActorHost.CreateForTest<TestActor>();
+        host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+        var mngr = new ActorStateManager(new TestActor(host));
+        var token = new CancellationToken();
+
+        interactor
+            .Setup(d => d.GetStateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new ActorStateResponse<string>("", null)));
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.RemoveStateAsync("key1", token));
+
+        await mngr.AddStateAsync("key1", "value1", token);
+        await mngr.AddStateAsync("key2", "value2", token);
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+
+        await mngr.RemoveStateAsync("key1", token);
+        await mngr.RemoveStateAsync("key2", token);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key1", token));
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => mngr.GetStateAsync<string>("key2", token));
+
+        // Should be able to add state again after removal.
+        await mngr.AddStateAsync("key1", "value1", TimeSpan.FromSeconds(1), token);
+        await mngr.AddStateAsync("key2", "value2", TimeSpan.FromSeconds(1), token);
+        Assert.Equal("value1", await mngr.GetStateAsync<string>("key1", token));
+        Assert.Equal("value2", await mngr.GetStateAsync<string>("key2", token));
+    }
+
+    // [Fact]
+    // public async Task AddStateAsync_NoTTL()
+    // {
+    //     var interactor = new Mock<TestDaprInteractor>();
+    //     var host = ActorHost.CreateForTest<TestActor>();
+    //     host.StateProvider = new DaprStateProvider(interactor.Object, new JsonSerializerOptions());
+    //     var mngr = new ActorStateManager(new TestActor(host));
+    //     var cts = new CancellationTokenSource();
+    //  
+    //     
+    // }
 }

--- a/test/Dapr.Actors.Test/Runtime/ActorManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorManagerTests.cs
@@ -18,242 +18,241 @@ using Dapr.Actors.Client;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Dapr.Actors.Runtime
+namespace Dapr.Actors.Runtime;
+
+public sealed class ActorManagerTests
 {
-    public sealed class ActorManagerTests
+    private ActorManager CreateActorManager(Type type, ActorActivator activator = null)
     {
-        private ActorManager CreateActorManager(Type type, ActorActivator activator = null)
-        {
-            var registration = new ActorRegistration(ActorTypeInformation.Get(type, actorTypeName: null));
-            var interactor = new DaprHttpInteractor(clientHandler: null, "http://localhost:3500", apiToken: null, requestTimeout: null);
-            return new ActorManager(registration, activator ?? new DefaultActorActivator(), JsonSerializerDefaults.Web, false, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory, interactor);
-        }
+        var registration = new ActorRegistration(ActorTypeInformation.Get(type, actorTypeName: null));
+        var interactor = new DaprHttpInteractor(clientHandler: null, "http://localhost:3500", apiToken: null, requestTimeout: null);
+        return new ActorManager(registration, activator ?? new DefaultActorActivator(), JsonSerializerDefaults.Web, false, NullLoggerFactory.Instance, ActorProxy.DefaultProxyFactory, interactor);
+    }
 
-        [Fact]
-        public async Task ActivateActorAsync_CreatesActorAndCallsActivateLifecycleMethod()
-        {
-            var manager = CreateActorManager(typeof(TestActor));
+    [Fact]
+    public async Task ActivateActorAsync_CreatesActorAndCallsActivateLifecycleMethod()
+    {
+        var manager = CreateActorManager(typeof(TestActor));
 
-            var id = ActorId.CreateRandom();
+        var id = ActorId.CreateRandom();
+        await manager.ActivateActorAsync(id);
+
+        Assert.True(manager.TryGetActorAsync(id, out var actor));
+        Assert.True(Assert.IsType<TestActor>(actor).IsActivated);
+    }
+
+    [Fact]
+    public async Task ActivateActorAsync_CanActivateMultipleActors()
+    {
+        var manager = CreateActorManager(typeof(TestActor));
+
+        await manager.ActivateActorAsync(new ActorId("1"));
+        Assert.True(manager.TryGetActorAsync(new ActorId("1"), out var actor1));
+
+        await manager.ActivateActorAsync(new ActorId("2"));
+        Assert.True(manager.TryGetActorAsync(new ActorId("2"), out var actor2));
+
+        Assert.NotSame(actor1, actor2);
+    }
+
+    [Fact]
+    public async Task ActivateActorAsync_UsesActivator()
+    {
+        var activator = new TestActivator();
+
+        var manager = CreateActorManager(typeof(TestActor), activator);
+
+        var id = ActorId.CreateRandom();
+        await manager.ActivateActorAsync(id);
+
+        Assert.Equal(1, activator.CreateCallCount);
+    }
+
+    [Fact]
+    public async Task ActivateActorAsync_DoubleActivation_DeactivatesNewActor()
+    {
+        // We have to use the activator to observe the behavior here. We don't
+        // have a way to interact with the "new" actor that gets destroyed immediately.
+        var activator = new TestActivator();
+
+        var manager = CreateActorManager(typeof(TestActor), activator);
+
+        var id = ActorId.CreateRandom();
+        await manager.ActivateActorAsync(id);
+
+        Assert.True(manager.TryGetActorAsync(id, out var original));
+
+        // It's a double-activation! We don't expect the runtime to do this, but the code
+        // handles it.
+        await manager.ActivateActorAsync(id);
+
+        // Still holding the original actor
+        Assert.True(manager.TryGetActorAsync(id, out var another));
+        Assert.Same(original, another);
+        Assert.False(Assert.IsType<TestActor>(another).IsDeactivated);
+        Assert.False(Assert.IsType<TestActor>(another).IsDisposed);
+
+        // We should have seen 2 create operations and 1 delete
+        Assert.Equal(2, activator.CreateCallCount);
+        Assert.Equal(1, activator.DeleteCallCount);
+    }
+
+    [Fact]
+    public async Task ActivateActorAsync_ExceptionDuringActivation_ActorNotStoredAndDeleted()
+    {
+        var activator = new TestActivator();
+
+        var manager = CreateActorManager(typeof(ThrowsDuringOnActivateAsync), activator);
+
+        var id = ActorId.CreateRandom();
+
+        await Assert.ThrowsAsync<InvalidTimeZoneException>(async () =>
+        {
             await manager.ActivateActorAsync(id);
+        });
 
-            Assert.True(manager.TryGetActorAsync(id, out var actor));
-            Assert.True(Assert.IsType<TestActor>(actor).IsActivated);
-        }
+        Assert.False(manager.TryGetActorAsync(id, out _));
+        Assert.Equal(1, activator.DeleteCallCount);
+    }
 
-        [Fact]
-        public async Task ActivateActorAsync_CanActivateMultipleActors()
-        {
-            var manager = CreateActorManager(typeof(TestActor));
+    [Fact]
+    public async Task DectivateActorAsync_DeletesActorAndCallsDeactivateLifecycleMethod()
+    {
+        var manager = CreateActorManager(typeof(TestActor));
 
-            await manager.ActivateActorAsync(new ActorId("1"));
-            Assert.True(manager.TryGetActorAsync(new ActorId("1"), out var actor1));
-
-            await manager.ActivateActorAsync(new ActorId("2"));
-            Assert.True(manager.TryGetActorAsync(new ActorId("2"), out var actor2));
-
-            Assert.NotSame(actor1, actor2);
-        }
-
-        [Fact]
-        public async Task ActivateActorAsync_UsesActivator()
-        {
-            var activator = new TestActivator();
-
-            var manager = CreateActorManager(typeof(TestActor), activator);
-
-            var id = ActorId.CreateRandom();
-            await manager.ActivateActorAsync(id);
-
-            Assert.Equal(1, activator.CreateCallCount);
-        }
-
-        [Fact]
-        public async Task ActivateActorAsync_DoubleActivation_DeactivatesNewActor()
-        {
-            // We have to use the activator to observe the behavior here. We don't
-            // have a way to interact with the "new" actor that gets destroyed immediately.
-            var activator = new TestActivator();
-
-            var manager = CreateActorManager(typeof(TestActor), activator);
-
-            var id = ActorId.CreateRandom();
-            await manager.ActivateActorAsync(id);
-
-            Assert.True(manager.TryGetActorAsync(id, out var original));
-
-            // It's a double-activation! We don't expect the runtime to do this, but the code
-            // handles it.
-            await manager.ActivateActorAsync(id);
-
-            // Still holding the original actor
-            Assert.True(manager.TryGetActorAsync(id, out var another));
-            Assert.Same(original, another);
-            Assert.False(Assert.IsType<TestActor>(another).IsDeactivated);
-            Assert.False(Assert.IsType<TestActor>(another).IsDisposed);
-
-            // We should have seen 2 create operations and 1 delete
-            Assert.Equal(2, activator.CreateCallCount);
-            Assert.Equal(1, activator.DeleteCallCount);
-        }
-
-        [Fact]
-        public async Task ActivateActorAsync_ExceptionDuringActivation_ActorNotStoredAndDeleted()
-        {
-            var activator = new TestActivator();
-
-            var manager = CreateActorManager(typeof(ThrowsDuringOnActivateAsync), activator);
-
-            var id = ActorId.CreateRandom();
-
-            await Assert.ThrowsAsync<InvalidTimeZoneException>(async () =>
-            {
-                await manager.ActivateActorAsync(id);
-            });
-
-            Assert.False(manager.TryGetActorAsync(id, out _));
-            Assert.Equal(1, activator.DeleteCallCount);
-        }
-
-        [Fact]
-        public async Task DectivateActorAsync_DeletesActorAndCallsDeactivateLifecycleMethod()
-        {
-            var manager = CreateActorManager(typeof(TestActor));
-
-            var id = ActorId.CreateRandom();
-            await manager.ActivateActorAsync(id);
+        var id = ActorId.CreateRandom();
+        await manager.ActivateActorAsync(id);
             
-            Assert.True(manager.TryGetActorAsync(id, out var actor));
+        Assert.True(manager.TryGetActorAsync(id, out var actor));
+        await manager.DeactivateActorAsync(id);
+
+        Assert.True(Assert.IsType<TestActor>(actor).IsDeactivated);
+        Assert.True(Assert.IsType<TestActor>(actor).IsDisposed);
+    }
+
+    [Fact]
+    public async Task DeactivateActorAsync_ItsOkToDeactivateNonExistentActor()
+    {
+        var manager = CreateActorManager(typeof(TestActor));
+
+        var id = ActorId.CreateRandom();
+        Assert.False(manager.TryGetActorAsync(id, out _));
+        await manager.DeactivateActorAsync(id);
+    }
+
+    [Fact]
+    public async Task DeactivateActorAsync_UsesActivator()
+    {
+        var activator = new TestActivator();
+
+        var manager = CreateActorManager(typeof(TestActor), activator);
+
+        var id = ActorId.CreateRandom();
+        await manager.ActivateActorAsync(id);
+        await manager.DeactivateActorAsync(id);
+
+        Assert.Equal(1, activator.CreateCallCount);
+        Assert.Equal(1, activator.DeleteCallCount);
+    }
+
+    [Fact]
+    public async Task DeactivateActorAsync_ExceptionDuringDeactivation_ActorIsRemovedAndDeleted()
+    {
+        var activator = new TestActivator();
+
+        var manager = CreateActorManager(typeof(ThrowsDuringOnDeactivateAsync), activator);
+
+        var id = ActorId.CreateRandom();
+        await manager.ActivateActorAsync(id);
+        Assert.True(manager.TryGetActorAsync(id, out _));
+
+        await Assert.ThrowsAsync<InvalidTimeZoneException>(async () =>
+        {
             await manager.DeactivateActorAsync(id);
+        });
 
-            Assert.True(Assert.IsType<TestActor>(actor).IsDeactivated);
-            Assert.True(Assert.IsType<TestActor>(actor).IsDisposed);
+        Assert.False(manager.TryGetActorAsync(id, out _));
+        Assert.Equal(1, activator.DeleteCallCount);
+    }
+
+    private interface ITestActor : IActor { }
+
+    private class TestActor : Actor, ITestActor, IDisposable
+    {
+        private static int counter;
+
+        public TestActor(ActorHost host) : base(host)
+        {
+            Sequence = Interlocked.Increment(ref counter);
         }
 
-        [Fact]
-        public async Task DeactivateActorAsync_ItsOkToDeactivateNonExistentActor()
-        {
-            var manager = CreateActorManager(typeof(TestActor));
+        // Makes instances easier to tell apart for debugging.
+        public int Sequence { get; }
 
-            var id = ActorId.CreateRandom();
-            Assert.False(manager.TryGetActorAsync(id, out _));
-            await manager.DeactivateActorAsync(id);
+        public bool IsActivated { get; set; }
+
+        public bool IsDeactivated { get; set; }
+
+        public bool IsDisposed { get; set; }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
         }
 
-        [Fact]
-        public async Task DeactivateActorAsync_UsesActivator()
+        protected override Task OnActivateAsync()
         {
-            var activator = new TestActivator();
-
-            var manager = CreateActorManager(typeof(TestActor), activator);
-
-            var id = ActorId.CreateRandom();
-            await manager.ActivateActorAsync(id);
-            await manager.DeactivateActorAsync(id);
-
-            Assert.Equal(1, activator.CreateCallCount);
-            Assert.Equal(1, activator.DeleteCallCount);
+            IsActivated = true;
+            return Task.CompletedTask;
         }
 
-        [Fact]
-        public async Task DeactivateActorAsync_ExceptionDuringDeactivation_ActorIsRemovedAndDeleted()
+        protected override Task OnDeactivateAsync()
         {
-            var activator = new TestActivator();
+            IsDeactivated = true;
+            return Task.CompletedTask;
+        }
+    }
 
-            var manager = CreateActorManager(typeof(ThrowsDuringOnDeactivateAsync), activator);
-
-            var id = ActorId.CreateRandom();
-            await manager.ActivateActorAsync(id);
-            Assert.True(manager.TryGetActorAsync(id, out _));
-
-            await Assert.ThrowsAsync<InvalidTimeZoneException>(async () =>
-            {
-                await manager.DeactivateActorAsync(id);
-            });
-
-            Assert.False(manager.TryGetActorAsync(id, out _));
-            Assert.Equal(1, activator.DeleteCallCount);
+    private class ThrowsDuringOnActivateAsync : Actor, ITestActor
+    {
+        public ThrowsDuringOnActivateAsync(ActorHost host) : base(host)
+        {
         }
 
-        private interface ITestActor : IActor { }
-
-        private class TestActor : Actor, ITestActor, IDisposable
+        protected override Task OnActivateAsync()
         {
-            private static int counter;
+            throw new InvalidTimeZoneException();
+        }
+    }
 
-            public TestActor(ActorHost host) : base(host)
-            {
-                Sequence = Interlocked.Increment(ref counter);
-            }
-
-            // Makes instances easier to tell apart for debugging.
-            public int Sequence { get; }
-
-            public bool IsActivated { get; set; }
-
-            public bool IsDeactivated { get; set; }
-
-            public bool IsDisposed { get; set; }
-
-            public void Dispose()
-            {
-                IsDisposed = true;
-            }
-
-            protected override Task OnActivateAsync()
-            {
-                IsActivated = true;
-                return Task.CompletedTask;
-            }
-
-            protected override Task OnDeactivateAsync()
-            {
-                IsDeactivated = true;
-                return Task.CompletedTask;
-            }
+    private class ThrowsDuringOnDeactivateAsync : Actor, ITestActor
+    {
+        public ThrowsDuringOnDeactivateAsync(ActorHost host) : base(host)
+        {
         }
 
-        private class ThrowsDuringOnActivateAsync : Actor, ITestActor
+        protected override Task OnDeactivateAsync()
         {
-            public ThrowsDuringOnActivateAsync(ActorHost host) : base(host)
-            {
-            }
+            throw new InvalidTimeZoneException();
+        }
+    }
 
-            protected override Task OnActivateAsync()
-            {
-                throw new InvalidTimeZoneException();
-            }
+    private class TestActivator : DefaultActorActivator
+    {
+        public int CreateCallCount { get; set; }
+
+        public int DeleteCallCount { get; set; }
+
+        public override Task<ActorActivatorState> CreateAsync(ActorHost host)
+        {
+            CreateCallCount++;;
+            return base.CreateAsync(host);
         }
 
-        private class ThrowsDuringOnDeactivateAsync : Actor, ITestActor
+        public override Task DeleteAsync(ActorActivatorState state)
         {
-            public ThrowsDuringOnDeactivateAsync(ActorHost host) : base(host)
-            {
-            }
-
-            protected override Task OnDeactivateAsync()
-            {
-                throw new InvalidTimeZoneException();
-            }
-        }
-
-        private class TestActivator : DefaultActorActivator
-        {
-            public int CreateCallCount { get; set; }
-
-            public int DeleteCallCount { get; set; }
-
-            public override Task<ActorActivatorState> CreateAsync(ActorHost host)
-            {
-                CreateCallCount++;;
-                return base.CreateAsync(host);
-            }
-
-            public override Task DeleteAsync(ActorActivatorState state)
-            {
-                DeleteCallCount++;
-                return base.DeleteAsync(state);
-            }
+            DeleteCallCount++;
+            return base.DeleteAsync(state);
         }
     }
 }

--- a/test/Dapr.Actors.Test/Runtime/ActorStateTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorStateTests.cs
@@ -1,0 +1,358 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Dapr.Actors.Runtime;
+
+public sealed class ActorStateTests
+{
+    [Fact]
+    public void ActorStateCache_Add_DoesNotContainAddsToState()
+    {
+        var cache = new ActorStateCache();
+        const int value = 123;
+        var result = cache.Add("state", value);
+        
+        Assert.False(result.stateContainsKey);
+        Assert.True(result.addedToState);
+    }
+
+    [Fact]
+    public void ActorStateCache_Add_AlreadyExists()
+    {
+        var cache = new ActorStateCache();
+        const int value = 123;
+        const string stateName = "state";
+        var state = ActorStateCache.StateMetadata.Create(value, StateChangeKind.Add);
+        cache.Set(stateName, state);
+
+        var result = cache.Add(stateName, value);
+        
+        Assert.True(result.stateContainsKey);
+        Assert.False(result.addedToState);
+    }
+
+    [Fact]
+    public void ActorStateCache_Add_MarkedAsRemoved()
+    {
+        var cache = new ActorStateCache();
+        const int value = 123;
+        const string stateName = "state";
+        var state = ActorStateCache.StateMetadata.Create(value, StateChangeKind.Remove);
+        cache.Set(stateName, state);
+
+        var result = cache.Add(stateName, value, TimeSpan.FromMinutes(5));
+        
+        Assert.True(result.stateContainsKey);
+        Assert.True(result.addedToState);
+    }
+    
+    [Fact]
+    public void ActorStateCache_AddExpiry_DoesNotContainAddsToState()
+    {
+        var cache = new ActorStateCache();
+        const int value = 123;
+        var result = cache.Add("state", value, DateTimeOffset.UtcNow.AddMinutes(5));
+        
+        Assert.False(result.stateContainsKey);
+        Assert.True(result.addedToState);
+    }
+
+    [Fact]
+    public void ActorStateCache_AddExpiry_AlreadyExists()
+    {
+        var cache = new ActorStateCache();
+        const int value = 123;
+        const string stateName = "state";
+        var state = ActorStateCache.StateMetadata.Create(value, StateChangeKind.Add);
+        cache.Set(stateName, state);
+
+        var result = cache.Add(stateName, value, DateTimeOffset.UtcNow.AddMinutes(5));
+        
+        Assert.True(result.stateContainsKey);
+        Assert.False(result.addedToState);
+    }
+
+    [Fact]
+    public void ActorStateCache_AddExpiry_MarkedAsRemoved()
+    {
+        var cache = new ActorStateCache();
+        const int value = 123;
+        const string stateName = "state";
+        var state = ActorStateCache.StateMetadata.Create(value, StateChangeKind.Remove);
+        cache.Set(stateName, state);
+
+        var result = cache.Add(stateName, value, DateTimeOffset.UtcNow.AddMinutes(5));
+        
+        Assert.True(result.stateContainsKey);
+        Assert.True(result.addedToState);
+    }
+
+    [Fact]
+    public void ActorStateCache_Set()
+    {
+        var cache = new ActorStateCache();
+        const string stateName = "state";
+        const int value = 456;
+        const StateChangeKind kind = StateChangeKind.None;
+        var state = ActorStateCache.StateMetadata.Create(value, kind);
+        
+        cache.Set(stateName, state);
+
+        var stateMetadata = cache.GetStateMetadata();
+        Assert.Single(stateMetadata.Keys);
+        Assert.True(stateMetadata.ContainsKey(stateName));
+        var data = stateMetadata[stateName];
+        Assert.NotNull(data.Value);
+        Assert.Equal(value, data.Value);
+        Assert.Equal(kind, data.ChangeKind);
+        Assert.Null(data.TTLExpireTime);
+        Assert.Equal(value.GetType(), data.Type);
+    }
+
+    [Fact]
+    public void ActorStateCache_Remove()
+    {
+        var cache = new ActorStateCache();
+        const string stateName = "state";
+        const int value = 456;
+        const StateChangeKind kind = StateChangeKind.None;
+        var state = ActorStateCache.StateMetadata.Create(value, kind);
+        
+        cache.Set(stateName, state);
+
+        var stateMetadata = cache.GetStateMetadata();
+        Assert.Single(stateMetadata.Keys);
+        Assert.True(stateMetadata.ContainsKey(stateName));
+
+        cache.Remove(stateName);
+        stateMetadata = cache.GetStateMetadata();
+        Assert.Empty(stateMetadata.Keys);
+    }
+
+    [Fact]
+    public void ActorStateCache_TryGet_ExistsWithoutExpiration()
+    {
+        var cache = new ActorStateCache();
+        const int value = 123;
+        const StateChangeKind kind = StateChangeKind.Add;
+        const string stateName = "state";
+        var state = ActorStateCache.StateMetadata.Create(value, kind);
+        
+        cache.Set(stateName, state);
+
+        var result = cache.TryGet(stateName, out var retrievedState);
+        Assert.True(result.containsKey);
+        Assert.False(result.isMarkedAsRemoveOrExpired);
+        Assert.NotNull(retrievedState);
+        Assert.NotNull(retrievedState.Value);
+        Assert.Equal(value, (int)retrievedState.Value);
+        Assert.Equal(kind, retrievedState.ChangeKind);
+        Assert.Null(retrievedState.TTLExpireTime);
+        Assert.Equal(value.GetType(), retrievedState.Type);
+    }
+
+    [Fact]
+    public void ActorStateCache_TryGet_DoesNotExist()
+    {
+        var cache = new ActorStateCache();
+        var result = cache.TryGet("mystate", out var retrievedState);
+        
+        Assert.False(result.containsKey);
+        Assert.False(result.isMarkedAsRemoveOrExpired);
+        Assert.Null(retrievedState);
+    }
+
+    [Fact]
+    public void ActorStateCache_TryGet_IsExpired()
+    {
+        var cache = new ActorStateCache();
+        const string value = "acb";
+        const StateChangeKind kind = StateChangeKind.Update;
+        const string stateName = "state";
+        var state = ActorStateCache.StateMetadata.Create(value, kind, DateTimeOffset.UtcNow.AddMinutes(-10));
+        
+        cache.Set(stateName, state);
+
+        var result = cache.TryGet(stateName, out var retrievedState);
+        Assert.True(result.containsKey);
+        Assert.True(result.isMarkedAsRemoveOrExpired);
+        Assert.NotNull(retrievedState);
+        Assert.NotNull(retrievedState.Value);
+        Assert.Equal(value, (string)retrievedState.Value);
+        Assert.Equal(kind, retrievedState.ChangeKind);
+        Assert.NotNull(retrievedState.TTLExpireTime);
+        Assert.Equal(value.GetType(), retrievedState.Type);
+    }
+
+    [Fact]
+    public void ActorStateCache_Clear()
+    {
+        var cache = new ActorStateCache();
+        cache.Add("state1", 123);
+        cache.Add("state2", "456");
+        cache.Add("state3", 7890);
+
+        var data = cache.GetStateMetadata();
+        Assert.Equal(3, data.Keys.Count);
+        Assert.Contains("state1", data.Keys);
+        Assert.Contains("state2", data.Keys);
+        Assert.Contains("state3", data.Keys);
+
+        cache.Clear();
+        data = cache.GetStateMetadata();
+        Assert.Empty(data.Keys);
+    }
+
+    [Fact]
+    public void ActorStateCache_BuildChangeList_NoChanges()
+    {
+        var cache = new ActorStateCache();
+        var result = cache.BuildChangeList();
+        
+        Assert.Empty(result.stateChanges);
+        Assert.Empty(result.statesToRemove);
+    }
+
+    [Fact]
+    public void ActorStateCache_BuildChangeList_ChangesWithRemovals()
+    {
+        var cache = new ActorStateCache();
+        cache.Add("state1", 456);
+        var state2Offset = DateTimeOffset.UtcNow.AddMinutes(15);
+        cache.Set("state2", ActorStateCache.StateMetadata.Create("78", StateChangeKind.Remove, state2Offset));
+        cache.Add("state3", "test");
+        
+        var (stateChanges, removalChanges) = cache.BuildChangeList();
+        
+        //Validate stateChanges
+        Assert.Equal(3, stateChanges.Count);
+        Assert.Contains(new ActorStateChange("state1", typeof(int), 456, StateChangeKind.Add, null), stateChanges);
+        Assert.Contains(new ActorStateChange("state2", typeof(string), "78", StateChangeKind.Remove, state2Offset), stateChanges);
+        Assert.Contains(new ActorStateChange("state3", typeof(string), "test", StateChangeKind.Add, null),
+            stateChanges);
+
+        //Validate removalChanges
+        Assert.Single(removalChanges);
+        Assert.Contains("state2", removalChanges);
+        
+        //Validate every state value was marked as None
+        var states = cache.GetStateMetadata();
+        Assert.Equal(3, states.Count);
+        foreach (var state in states)
+        {
+            Assert.Equal(StateChangeKind.None, state.Value.ChangeKind);
+        }
+    }
+    
+    [Fact]
+    public void ActorStateCache_ShouldNotBeMarkedAsRemovedOrExpired()
+    {
+        var cache = new ActorStateCache();
+        var state = ActorStateCache.StateMetadata.Create(123, StateChangeKind.Update, DateTimeOffset.UtcNow.AddMinutes(10));
+        var result = cache.IsMarkedAsRemoveOrExpired(state);
+
+        Assert.False(result);
+    }
+    
+    [Fact]
+    public void ActorStateCache_ShouldBeMarkedAsRemoved()
+    {
+        var cache = new ActorStateCache();
+        var state = ActorStateCache.StateMetadata.Create(123, StateChangeKind.Remove);
+        var result = cache.IsMarkedAsRemoveOrExpired(state);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ActorStateCache_ShouldBeMarkedAsExpired()
+    {
+        var cache = new ActorStateCache();
+        var state = ActorStateCache.StateMetadata.Create(123, StateChangeKind.Update, DateTimeOffset.UtcNow.AddMinutes(-10));
+        var result = cache.IsMarkedAsRemoveOrExpired(state);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void StateMetadata_ShouldThrowIfBothTtlExpireTimeAndTtlAreSet()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            new ActorStateCache.StateMetadata("123", typeof(int), StateChangeKind.None,
+                DateTimeOffset.UtcNow,
+                TimeSpan.FromMinutes(5));
+        });
+    }
+
+    [Fact]
+    public void StateMetadata_CreatePlain()
+    {
+        const int stateValue = 123;
+        var type = stateValue.GetType();
+        const StateChangeKind kind = StateChangeKind.None;
+        var data = ActorStateCache.StateMetadata.Create(stateValue, kind);
+
+        Assert.NotNull(data.Value);
+        Assert.Equal(stateValue, (int)data.Value);
+        Assert.Equal(type, data.Type);
+        Assert.Equal(kind, data.ChangeKind);
+        Assert.Null(data.TTLExpireTime);
+    }
+
+    [Fact]
+    public void StateMetadata_CreateWithTtl()
+    {
+        const int stateValue = 123;
+        var type = stateValue.GetType();
+        const StateChangeKind kind = StateChangeKind.Add;
+        var ttl = TimeSpan.FromMinutes(10);
+        var data = ActorStateCache.StateMetadata.Create(stateValue, kind, ttl);
+
+        Assert.NotNull(data.Value);
+        Assert.Equal(stateValue, (int)data.Value);
+        Assert.Equal(type, data.Type);
+        Assert.Equal(kind, data.ChangeKind);
+        Assert.NotNull(data.TTLExpireTime);
+    }
+
+    [Fact]
+    public void StateMetadata_CreateWithTtlExpiryTime()
+    {
+        const int stateValue = 123;
+        var type = stateValue.GetType();
+        const StateChangeKind kind = StateChangeKind.Add;
+        var ttlExpiry = DateTimeOffset.UtcNow.AddMinutes(5);
+        var data = ActorStateCache.StateMetadata.Create(stateValue, kind, ttlExpiry);
+
+        Assert.NotNull(data.Value);
+        Assert.Equal(stateValue, (int)data.Value);
+        Assert.Equal(type, data.Type);
+        Assert.Equal(kind, data.ChangeKind);
+        Assert.Equal(ttlExpiry, data.TTLExpireTime);
+    }
+
+    [Fact]
+    public void StateMetadata_CreateForRemoval()
+    {
+        var data = ActorStateCache.StateMetadata.CreateForRemove();
+        
+        Assert.Null(data.Value);
+        Assert.Null(data.TTLExpireTime);
+        Assert.Equal(StateChangeKind.Remove, data.ChangeKind);
+    }
+}

--- a/test/Dapr.Actors.Test/TestDaprInteractor.cs
+++ b/test/Dapr.Actors.Test/TestDaprInteractor.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Actors.Communication;
@@ -58,7 +59,7 @@ public class TestDaprInteractor : IDaprInteractor
     {
         throw new System.NotImplementedException();
     }
-
+    
     /// <summary>
     /// Saves state batch to Dapr.
     /// </summary>
@@ -79,11 +80,39 @@ public class TestDaprInteractor : IDaprInteractor
     /// <param name="actorType">Type of actor.</param>
     /// <param name="actorId">ActorId.</param>
     /// <param name="keyName">Name of key to get value for.</param>
+    /// <param name="data">The data to persist to state.</param>
+    /// <param name="cancellationToken">Cancels the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public virtual async Task SaveStateAsync(
+        string actorType,
+        string actorId,
+        string keyName,
+        string data,
+        CancellationToken cancellationToken = default)
+    {
+        await _testDaprInteractor.SaveStateAsync(actorType, actorId, keyName, data, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets a state from Dapr.
+    /// </summary>
+    /// <param name="actorType">Type of actor.</param>
+    /// <param name="actorId">ActorId.</param>
+    /// <param name="keyName">Name of key to get value for.</param>
     /// <param name="cancellationToken">Cancels the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public virtual async Task<ActorStateResponse<string>> GetStateAsync(string actorType, string actorId, string keyName, CancellationToken cancellationToken = default)
     {
-        return await _testDaprInteractor.GetStateAsync(actorType, actorId, keyName);
+        return await _testDaprInteractor.GetStateAsync(actorType, actorId, keyName, cancellationToken);
+    }
+
+    public virtual async Task<ActorStateResponse<List<string>>> GetListStateAsync(
+        string actorType,
+        string actorId,
+        string keyName,
+        CancellationToken cancellationToken = default)
+    {
+        return await _testDaprInteractor.GetListStateAsync(actorType, actorId, keyName, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
# Description
The mechanism used to perform actor state caching was just about impossible to actually test and there is more than one issue indicating that something is wrong with how it's working. There are no current unit tests validating the entire caching mechanism and only one unit test for each of the get and set implementations (mostly validating TTL) on the actor state with its provider.

As there's a lot going on with the caching system through the actor state manager, it's been refactored out to a separate type that's far more easily maintainable and testable. I've written a collection of unit tests against the cache and am still working to build out still more unit tests to validate the `ActorStateManager` and then some E2E tests to validate and prove out both #1467 and #1471 as resolved (or otherwise identify where the issue lies).

As an added bonus, I've re-implemented each of the associated and new files to use nullable annotations on a per-file basis to get that effort underway.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1467 and #1471

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [N/A] Extended the documentation
