### PR TITLE
Fix for Jobs mapping handler

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-jobs/dotnet-jobs-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-jobs/dotnet-jobs-howto.md
@@ -245,6 +245,27 @@ app.MapDaprScheduledJob("myJob", (string jobName, ReadOnlyMemory<byte> jobPayloa
 app.Run();
 ```
 
+## Support cancellation tokens when processing mapped invocations
+You may want to ensure that timeouts are handled on job invocations so that they don't indefinitely hang and use system resources. When setting up the job mapping, there's an optional `TimeSpan` parameter that can be 
+provided as the last argument to specify a timeout for the request. Every time the job mapping invocation is triggered, a new `CancellationTokenSource` will be created using this timeout parameter and a `CancellationToken`
+will be created from it to put an upper bound on the processing of the request. If a timeout isn't provided, this defaults to `CancellationToken.None` and a timeout will not be automatically applied to the mapping.
+
+```cs
+//We have this from the example above
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDaprJobsClient();
+
+var app = builder.Build();
+
+//Add our endpoint registration
+app.MapDaprScheduledJob("myJob", (string jobName, ReadOnlyMemory<byte> jobPayload) => {
+    //Do something...
+}, TimeSpan.FromSeconds(15)); //Assigns a maximum timeout of 15 seconds for handling the invocation request
+
+app.Run();
+```
+
 ## Register the job
 
 Finally, we have to register the job we want scheduled. Note that from here, all SDK methods have cancellation token support and use a default token if not otherwise set.


### PR DESCRIPTION
# Description
The original implementation of the jobs mapping handler allowed the user to provide a `CancellationToken` to the mapping. This unfortunately meant that long-running jobs mappers would fail when this timeout was hit because it was globally applied instead of applied to each request invocation, as intended.

I've modified the approach to instead allow the user to pass an optional `TimeSpan` indicating a timeout value to use. As part of the mapping, a new `CancellationToken` is created using this timeout value, if provided (defaults to `CancellationToken.None` if not) so it's now performed on a per-request basis.

I've also updated the example and unit tests to go along with this.

Thanks to @siri-varma for their research in identifying this issue.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1472

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
