### PR TITLE
Fixed unit tests validating actor reminder deserialization

### DIFF
--- a/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
@@ -1,4 +1,17 @@
-﻿// ------------------------------------------------------------
+﻿// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // ------------------------------------------------------------

--- a/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
@@ -36,7 +36,7 @@ public sealed class DefaultActorTimerManagerTests
             
         interactor
             .Setup(d => d.RegisterReminderAsync(actorType, actorId, "remindername", It.Is<string>(data => !string.IsNullOrEmpty(data)), It.IsAny<CancellationToken>()))
-            .Callback<string, string, string, string, CancellationToken>((actorType, actorID, reminderName, data, token) => {
+            .Callback<string, string, string, string, CancellationToken>((innerType, innerId, reminderName, data, token) => {
                 actualData = data;
             })
             .Returns(Task.CompletedTask);
@@ -62,8 +62,8 @@ public sealed class DefaultActorTimerManagerTests
     [Fact]
     public async Task RegisterReminderAsync_WithRepetition_CallsInteractor_WithCorrectData()
     {
-        var actorId = "123";
-        var actorType = "abc";
+        const string actorId = "123";
+        const string actorType = "abc";
         var interactor = new Mock<TestDaprInteractor>();
         var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
         var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", new byte[] { }, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1), 10);
@@ -71,7 +71,7 @@ public sealed class DefaultActorTimerManagerTests
 
         interactor
             .Setup(d => d.RegisterReminderAsync(actorType, actorId, "remindername", It.Is<string>(data => !string.IsNullOrEmpty(data)), It.IsAny<CancellationToken>()))
-            .Callback<string, string, string, string, CancellationToken>((actorType, actorID, reminderName, data, token) => {
+            .Callback<string, string, string, string, CancellationToken>((innerType, innerActorId, reminderName, data, token) => {
                 actualData = data;
             })
             .Returns(Task.CompletedTask);

--- a/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
@@ -16,139 +16,138 @@ using Moq;
 using Xunit;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
-namespace Dapr.Actors.Runtime
+namespace Dapr.Actors.Runtime;
+
+public sealed class DefaultActorTimerManagerTests
 {
-    public sealed class DefaultActorTimerManagerTests
+    /// <summary>
+    /// When register reminder is called, interactor is called with correct data.
+    /// </summary>
+    /// <returns></returns>
+    [Fact]
+    public async Task RegisterReminderAsync_CallsInteractor_WithCorrectData()
     {
-        /// <summary>
-        /// When register reminder is called, interactor is called with correct data.
-        /// </summary>
-        /// <returns></returns>
-        [Fact]
-        public async Task RegisterReminderAsync_CallsInteractor_WithCorrectData()
+        var actorId = "123";
+        var actorType = "abc";
+        var interactor = new Mock<TestDaprInteractor>();
+        var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
+        var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", new byte[] { }, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+        var actualData = string.Empty;
+            
+        interactor
+            .Setup(d => d.RegisterReminderAsync(actorType, actorId, "remindername", It.Is<string>(data => !string.IsNullOrEmpty(data)), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, string, CancellationToken>((actorType, actorID, reminderName, data, token) => {
+                actualData = data;
+            })
+            .Returns(Task.CompletedTask);
+
+        await defaultActorTimerManager.RegisterReminderAsync(actorReminder);
+
+        JsonElement json = JsonSerializer.Deserialize<dynamic>(actualData);
+
+        var isPeriodSet = json.TryGetProperty("period", out var period);
+        var isdDueTimeSet = json.TryGetProperty("dueTime", out var dueTime);
+            
+        Assert.True(isPeriodSet);
+        Assert.True(isdDueTimeSet);
+            
+        Assert.Equal("0h1m0s0ms", period.GetString());
+        Assert.Equal("0h1m0s0ms", dueTime.GetString());
+    }
+
+    /// <summary>
+    /// When register reminder is called with repetition, interactor is called with correct data.
+    /// </summary>
+    /// <returns></returns>
+    [Fact]
+    public async Task RegisterReminderAsync_WithRepetition_CallsInteractor_WithCorrectData()
+    {
+        var actorId = "123";
+        var actorType = "abc";
+        var interactor = new Mock<TestDaprInteractor>();
+        var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
+        var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", new byte[] { }, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1), 10);
+        var actualData = string.Empty;
+
+        interactor
+            .Setup(d => d.RegisterReminderAsync(actorType, actorId, "remindername", It.Is<string>(data => !string.IsNullOrEmpty(data)), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, string, CancellationToken>((actorType, actorID, reminderName, data, token) => {
+                actualData = data;
+            })
+            .Returns(Task.CompletedTask);
+
+        await defaultActorTimerManager.RegisterReminderAsync(actorReminder);
+
+        JsonElement json = JsonSerializer.Deserialize<dynamic>(actualData);
+
+        var isPeriodSet = json.TryGetProperty("period", out var period);
+        var isdDueTimeSet = json.TryGetProperty("dueTime", out var dueTime);
+            
+        Assert.True(isPeriodSet);
+        Assert.True(isdDueTimeSet);
+            
+        Assert.Equal("R10/PT1M", period.GetString());
+        Assert.Equal("0h1m0s0ms", dueTime.GetString());
+    }
+
+    /// <summary>
+    /// Get the GetReminder method is called without a registered reminder, it should return null.
+    /// </summary>
+    [Fact]
+    public async Task GetReminderAsync_ReturnsNullWhenUnavailable()
+    {
+        const string actorId = "123";
+        const string actorType = "abc";
+        const string reminderName = "reminderName";
+        var interactor = new Mock<TestDaprInteractor>();
+        interactor
+            .Setup(d => d.GetReminderAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+        var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
+
+        var reminderResult = await defaultActorTimerManager.GetReminderAsync(new ActorReminderToken(actorType, new ActorId(actorId), reminderName));
+        Assert.Null(reminderResult);
+    }
+
+    [Fact]
+    public async Task GetReminderAsync_ReturnsResultWhenAvailable()
+    {
+        const string actorId = "123";
+        const string actorType = "abc";
+        const string reminderName = "reminderName";
+        var interactor = new Mock<TestDaprInteractor>();
+            
+        //Create the reminder we'll return
+        var state = Array.Empty<byte>();
+        var dueTime = TimeSpan.FromMinutes(1);
+        var period = TimeSpan.FromMinutes(1);
+        var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", state, dueTime, period, 10);
+            
+        //Serialize and create the response value
+        var actorReminderInfo = new ReminderInfo(actorReminder.State, actorReminder.DueTime, actorReminder.Period,
+            actorReminder.Repetitions, actorReminder.Ttl);
+        var serializedActorReminderInfo = await actorReminderInfo.SerializeAsync();
+        var reminderResponse = new HttpResponseMessage(HttpStatusCode.OK)
         {
-            var actorId = "123";
-            var actorType = "abc";
-            var interactor = new Mock<TestDaprInteractor>();
-            var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
-            var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", new byte[] { }, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
-            var actualData = string.Empty;
+            Content = new StringContent(serializedActorReminderInfo)
+        };
             
-            interactor
-                .Setup(d => d.RegisterReminderAsync(actorType, actorId, "remindername", It.Is<string>(data => !string.IsNullOrEmpty(data)), It.IsAny<CancellationToken>()))
-                .Callback<string, string, string, string, CancellationToken>((actorType, actorID, reminderName, data, token) => {
-                    actualData = data;
-                })
-                .Returns(Task.CompletedTask);
-
-            await defaultActorTimerManager.RegisterReminderAsync(actorReminder);
-
-            JsonElement json = JsonSerializer.Deserialize<dynamic>(actualData);
-
-            var isPeriodSet = json.TryGetProperty("period", out var period);
-            var isdDueTimeSet = json.TryGetProperty("dueTime", out var dueTime);
+        //Register the response
+        var actualData = string.Empty;
+        interactor
+            .Setup(d => d.GetReminderAsync(actorType, actorId, reminderName, It.IsAny<CancellationToken>()))
+            .Callback<string, string, string, CancellationToken>((type, id, name, token) => {
+            })
+            .Returns(Task.FromResult(reminderResponse));
+        var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
             
-            Assert.True(isPeriodSet);
-            Assert.True(isdDueTimeSet);
+        var reminderResult = await defaultActorTimerManager.GetReminderAsync(new ActorReminderToken(actorType, new ActorId(actorId), reminderName));
+        Assert.NotNull(reminderResult);
             
-            Assert.Equal("0h1m0s0ms", period.GetString());
-            Assert.Equal("0h1m0s0ms", dueTime.GetString());
-        }
-
-        /// <summary>
-        /// When register reminder is called with repetition, interactor is called with correct data.
-        /// </summary>
-        /// <returns></returns>
-        [Fact]
-        public async Task RegisterReminderAsync_WithRepetition_CallsInteractor_WithCorrectData()
-        {
-            var actorId = "123";
-            var actorType = "abc";
-            var interactor = new Mock<TestDaprInteractor>();
-            var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
-            var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", new byte[] { }, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1), 10);
-            var actualData = string.Empty;
-
-            interactor
-                .Setup(d => d.RegisterReminderAsync(actorType, actorId, "remindername", It.Is<string>(data => !string.IsNullOrEmpty(data)), It.IsAny<CancellationToken>()))
-                .Callback<string, string, string, string, CancellationToken>((actorType, actorID, reminderName, data, token) => {
-                    actualData = data;
-                })
-                .Returns(Task.CompletedTask);
-
-            await defaultActorTimerManager.RegisterReminderAsync(actorReminder);
-
-            JsonElement json = JsonSerializer.Deserialize<dynamic>(actualData);
-
-            var isPeriodSet = json.TryGetProperty("period", out var period);
-            var isdDueTimeSet = json.TryGetProperty("dueTime", out var dueTime);
-            
-            Assert.True(isPeriodSet);
-            Assert.True(isdDueTimeSet);
-            
-            Assert.Equal("R10/PT1M", period.GetString());
-            Assert.Equal("0h1m0s0ms", dueTime.GetString());
-        }
-
-        /// <summary>
-        /// Get the GetReminder method is called without a registered reminder, it should return null.
-        /// </summary>
-        [Fact]
-        public async Task GetReminderAsync_ReturnsNullWhenUnavailable()
-        {
-            const string actorId = "123";
-            const string actorType = "abc";
-            const string reminderName = "reminderName";
-            var interactor = new Mock<TestDaprInteractor>();
-            interactor
-                .Setup(d => d.GetReminderAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.InternalServerError));
-            var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
-
-            var reminderResult = await defaultActorTimerManager.GetReminderAsync(new ActorReminderToken(actorType, new ActorId(actorId), reminderName));
-            Assert.Null(reminderResult);
-        }
-
-        [Fact]
-        public async Task GetReminderAsync_ReturnsResultWhenAvailable()
-        {
-            const string actorId = "123";
-            const string actorType = "abc";
-            const string reminderName = "reminderName";
-            var interactor = new Mock<TestDaprInteractor>();
-            
-            //Create the reminder we'll return
-            var state = Array.Empty<byte>();
-            var dueTime = TimeSpan.FromMinutes(1);
-            var period = TimeSpan.FromMinutes(1);
-            var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", state, dueTime, period, 10);
-            
-            //Serialize and create the response value
-            var actorReminderInfo = new ReminderInfo(actorReminder.State, actorReminder.DueTime, actorReminder.Period,
-                actorReminder.Repetitions, actorReminder.Ttl);
-            var serializedActorReminderInfo = await actorReminderInfo.SerializeAsync();
-            var reminderResponse = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(serializedActorReminderInfo)
-            };
-            
-            //Register the response
-            var actualData = string.Empty;
-            interactor
-                .Setup(d => d.GetReminderAsync(actorType, actorId, reminderName, It.IsAny<CancellationToken>()))
-                .Callback<string, string, string, CancellationToken>((type, id, name, token) => {
-                })
-                .Returns(Task.FromResult(reminderResponse));
-            var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
-            
-            var reminderResult = await defaultActorTimerManager.GetReminderAsync(new ActorReminderToken(actorType, new ActorId(actorId), reminderName));
-            Assert.NotNull(reminderResult);
-            
-            Assert.Equal(dueTime, reminderResult.DueTime);
-            Assert.Equal(state, reminderResult.State);
-            Assert.Equal(period, reminderResult.Period);
-            Assert.Equal(reminderName, reminderResult.Name);
-        }
+        Assert.Equal(dueTime, reminderResult.DueTime);
+        Assert.Equal(state, reminderResult.State);
+        Assert.Equal(period, reminderResult.Period);
+        Assert.Equal(reminderName, reminderResult.Name);
     }
 }

--- a/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
@@ -41,7 +41,7 @@ public sealed class DefaultActorTimerManagerTests
         var actorType = "abc";
         var interactor = new Mock<TestDaprInteractor>();
         var defaultActorTimerManager = new DefaultActorTimerManager(interactor.Object);
-        var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", new byte[] { }, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+        var actorReminder = new ActorReminder(actorType, new ActorId(actorId), "remindername", Array.Empty<byte>(), TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
         var actualData = string.Empty;
             
         interactor
@@ -144,7 +144,6 @@ public sealed class DefaultActorTimerManagerTests
         };
             
         //Register the response
-        var actualData = string.Empty;
         interactor
             .Setup(d => d.GetReminderAsync(actorType, actorId, reminderName, It.IsAny<CancellationToken>()))
             .Callback<string, string, string, CancellationToken>((type, id, name, token) => {

--- a/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
@@ -145,7 +145,7 @@ namespace Dapr.Actors.Runtime
             var reminderResult = await defaultActorTimerManager.GetReminderAsync(new ActorReminderToken(actorType, new ActorId(actorId), reminderName));
             Assert.NotNull(reminderResult);
             
-            Assert.Equal(period, reminderResult.Period);
+            Assert.Equal(dueTime, reminderResult.DueTime);
             Assert.Equal(state, reminderResult.State);
             Assert.Equal(period, reminderResult.Period);
             Assert.Equal(reminderName, reminderResult.Name);

--- a/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/DefaultActorTimerManagerTests.cs
@@ -4,14 +4,11 @@
 // ------------------------------------------------------------
 
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Dapr.Actors.Serialization;
 using Moq;
 using Xunit;
 using JsonSerializer = System.Text.Json.JsonSerializer;


### PR DESCRIPTION
# Description

While investigating #1464 , I discovered that there already existed several unit tests with one on point. While I'm unable to recreate the issue detailed, I did notice that there were a few improvements to make to the unit tests in this class, including:
- The `GetReminderAsync_ReturnsResultWhenAvailable` test double checked the `Period` property instead of checking both `Period` and `DueTime`.
- Several actor callbacks re-used the same variable names as outside the delegate.
- Used `const string` where possible instead of `var`.
- Removed unused usings
- Removed unused variables in tests
- Added Dapr copyright header

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1464 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [N/A] Extended the documentation
