### PR TITLE
Fixed `ConversationOptions` not accepting unset `ConversationId`

### DIFF
--- a/src/Dapr.AI/Conversation/DaprConversationClient.cs
+++ b/src/Dapr.AI/Conversation/DaprConversationClient.cs
@@ -77,7 +77,11 @@ public sealed class DaprConversationClient : DaprAIClient
 
         if (options is not null)
         {
-            request.ContextID = options.ConversationId;
+            if (options.ConversationId is not null)
+            {
+                request.ContextID = options.ConversationId;
+            }
+
             request.ScrubPII = options.ScrubPII;
 
             foreach (var (key, value) in options.Metadata)


### PR DESCRIPTION
# Description

A developer can pass options into the Conversations API that change the behavior. When options are passed today without a `ConversationId` value, this throws as it expects that to be populated.

This patch fixes this - `ConversationId` is optional and will be treated as such.

Thanks for spotting this issue @marcduiker !

## Issue reference

N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
