### PR TITLE
Drop .NET 6 and .NET 7 support

### DIFF
--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -20,18 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet-version: ['6.0', '7.0', '8.0', '9.0']
+        dotnet-version: ['8.0', '9.0']
         include:
-        - dotnet-version: '6.0'
-          display-name: '.NET 6.0'
-          framework: 'net6'
-          prefix: 'net6'
-          install-version: '6.0.x'
-        - dotnet-version: '7.0'
-          display-name: '.NET 7.0'
-          framework: 'net7'
-          prefix: 'net7'
-          install-version: '7.0.x'
         - dotnet-version: '8.0'
           display-name: '.NET 8.0'
           framework: 'net8'
@@ -48,9 +38,9 @@ jobs:
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
-      DAPR_CLI_VER: 1.14.0
-      DAPR_RUNTIME_VER: 1.14.0
-      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/release-1.14/install/install.sh
+      DAPR_CLI_VER: 1.15.0
+      DAPR_RUNTIME_VER: 1.15.3
+      DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/release-1.15/install/install.sh
       DAPR_CLI_REF: ''
     steps:
       - name: Set up Dapr CLI

--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -114,9 +114,11 @@ jobs:
         with:
           dotnet-version: '9.0.x'
           dotnet-quality: 'ga'
+      - name: Restore dependencies
+        run: dotnet restore
       - name: Build
         # disable deterministic builds, just for test run. Deterministic builds break coverage for some reason
-        run: dotnet build --configuration release /p:GITHUB_ACTIONS=false
+        run: dotnet build --configuration release --no-restore /p:GITHUB_ACTIONS=false
       - name: Run General Tests
         id: tests
         continue-on-error: true # proceed if tests fail, the report step will report the failure with more details.

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -44,18 +44,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet-version: ['6.0', '7.0', '8.0', '9.0']
+        dotnet-version: ['8.0', '9.0']
         include:
-        - dotnet-version: '6.0'
-          display-name: '.NET 6.0'
-          framework: 'net6'
-          prefix: 'net6'
-          install-version: '6.0.x'
-        - dotnet-version: '7.0'
-          display-name: '.NET 7.0'
-          framework: 'net7'
-          prefix: 'net7'
-          install-version: '7.0.x'
         - dotnet-version: '8.0'
           display-name: '.NET 8.0'
           framework: 'net8'

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -28,8 +28,10 @@ jobs:
         with:
           dotnet-version: 9.0.x
           dotnet-quality: 'ga'
+      - name: Restore dependencies
+        run: dotnet restore
       - name: Build
-        run: dotnet build --configuration release
+        run: dotnet build --configuration release --no-restore
       - name: Generate Packages
         run: dotnet pack --configuration release
       - name: Upload packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,13 +54,13 @@ This section describes the guidelines for contributing code / docs to Dapr.
 All contributions come through pull requests. To submit a proposed change, we recommend following this workflow:
 
 1. Make sure there's an issue (bug or proposal) raised, which sets the expectations for the contribution you are about to make.
-1. Fork the relevant repo and create a new branch
-1. Create your change
+2. Fork the relevant repo and create a new branch
+3. Create your change
     - Code changes require tests
-1. Update relevant documentation for the change
-1. Commit and open a PR
-1. Wait for the CI process to finish and make sure all checks are green
-1. A maintainer of the project will be assigned, and you can expect a review within a few days
+4. Update relevant documentation for the change
+5. Commit and open a PR
+6. Wait for the CI process to finish and make sure all checks are green
+7. A maintainer of the project will be assigned, and you can expect a review within a few days
 
 #### Use work-in-progress PRs for early feedback
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,21 @@ This repo builds the following packages:
 - Dapr.AspNetCore
 - Dapr.Actors
 - Dapr.Actors.AspNetCore
+- Dapr.Actors.Generators
+- Dapr.AI
+- Dapr.Jobs
+- Dapr.Messaging
 - Dapr.Extensions.Configuration
 - Dapr.Workflow
 
+It also builds the following packages which are not intended for public use and contain common types used in the packages above:
+- Dapr.Common
+- Dapr.Protos
+
+
 ### Prerequisites
 
-Each project is a normal C# project. At minimum, you need [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) to build, test, and generate NuGet packages.
+Each project is a normal C# project. At minimum, you need [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) to build, test, and generate NuGet packages.
 
 Also make sure to reference the [.NET SDK contribution guide](https://docs.dapr.io/contributing/sdk-contrib/dotnet-contributing/)
 
@@ -59,7 +68,7 @@ On macOS or Linux we recommend [Visual Studio Code](https://code.visualstudio.co
 
 **Windows:**
 
-On Windows, we recommend installing [the latest Visual Studio 2019](https://www.visualstudio.com/vs/) which will set you up with all the .NET build tools and allow you to open the solution files. Community Edition is free and can be used to build everything here.
+On Windows, we recommend installing [the latest Visual Studio 2022](https://www.visualstudio.com/vs/) which will set you up with all the .NET build tools and allow you to open the solution files. Community Edition is free and can be used to build everything here.
 
 Make sure you [update Visual Studio to the most recent release](https://docs.microsoft.com/visualstudio/install/update-visual-studio).
 

--- a/examples/AI/ConversationalAI/ConversationalAI.csproj
+++ b/examples/AI/ConversationalAI/ConversationalAI.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Actor/ActorClient/ActorClient.csproj
+++ b/examples/Actor/ActorClient/ActorClient.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Actor/DemoActor/DemoActor.csproj
+++ b/examples/Actor/DemoActor/DemoActor.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6</TargetFramework>
-    </PropertyGroup>
-
-    <PropertyGroup>
         <IsPublishable>true</IsPublishable>
         <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
         <ContainerRepository>demo-actor</ContainerRepository>

--- a/examples/Actor/IDemoActor/IDemoActor.csproj
+++ b/examples/Actor/IDemoActor/IDemoActor.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.Actors\Dapr.Actors.csproj" />
   </ItemGroup>

--- a/examples/AspNetCore/ControllerSample/ControllerSample.csproj
+++ b/examples/AspNetCore/ControllerSample/ControllerSample.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
   </ItemGroup>

--- a/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
+++ b/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
   </PropertyGroup>
 

--- a/examples/AspNetCore/RoutingSample/RoutingSample.csproj
+++ b/examples/AspNetCore/RoutingSample/RoutingSample.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
   </ItemGroup>

--- a/examples/AspNetCore/SecretStoreConfigurationProviderSample/SecretStoreConfigurationProviderSample.csproj
+++ b/examples/AspNetCore/SecretStoreConfigurationProviderSample/SecretStoreConfigurationProviderSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Client/ConfigurationApi/ConfigurationApi.csproj
+++ b/examples/Client/ConfigurationApi/ConfigurationApi.csproj
@@ -1,10 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.Client\Dapr.Client.csproj" />
     <ProjectReference Include="..\..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />

--- a/examples/Client/Cryptography/Cryptography.csproj
+++ b/examples/Client/Cryptography/Cryptography.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/examples/Client/DistributedLock/DistributedLock.csproj
+++ b/examples/Client/DistributedLock/DistributedLock.csproj
@@ -1,14 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
     <ProjectReference Include="..\..\..\src\Dapr.Client\Dapr.Client.csproj" />
     <ProjectReference Include="..\..\..\src\Dapr.Common\Dapr.Common.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
-
 </Project>

--- a/examples/Client/PublishSubscribe/BulkPublishEventExample/BulkPublishEventExample.csproj
+++ b/examples/Client/PublishSubscribe/BulkPublishEventExample/BulkPublishEventExample.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
         <RootNamespace>Samples.Client</RootNamespace>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Client/PublishSubscribe/PublishEventExample/PublishEventExample.csproj
+++ b/examples/Client/PublishSubscribe/PublishEventExample/PublishEventExample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Client/PublishSubscribe/StreamingSubscriptionExample/StreamingSubscriptionExample.csproj
+++ b/examples/Client/PublishSubscribe/StreamingSubscriptionExample/StreamingSubscriptionExample.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Client/ServiceInvocation/ServiceInvocation.csproj
+++ b/examples/Client/ServiceInvocation/ServiceInvocation.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Client/StateManagement/StateManagement.csproj
+++ b/examples/Client/StateManagement/StateManagement.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_managed_netcore.props" />
 
   <PropertyGroup>
+    <TargetFrameworks>net8;net9</TargetFrameworks>
     <!-- Set Output Path for samples-->
     <OutputPath>$(RepoRoot)bin\$(Configuration)\examples\$(MSBuildProjectName)\</OutputPath>
 

--- a/examples/GeneratedActor/ActorClient/ActorClient.csproj
+++ b/examples/GeneratedActor/ActorClient/ActorClient.csproj
@@ -2,8 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/examples/GeneratedActor/ActorCommon/ActorCommon.csproj
+++ b/examples/GeneratedActor/ActorCommon/ActorCommon.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/GeneratedActor/ActorService/ActorService.csproj
+++ b/examples/GeneratedActor/ActorService/ActorService.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/examples/Jobs/JobsSample/JobsSample.csproj
+++ b/examples/Jobs/JobsSample/JobsSample.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowAsyncOperations/WorkflowAsyncOperations.csproj
+++ b/examples/Workflow/WorkflowAsyncOperations/WorkflowAsyncOperations.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowConsoleApp/WorkflowConsoleApp.csproj
+++ b/examples/Workflow/WorkflowConsoleApp/WorkflowConsoleApp.csproj
@@ -6,7 +6,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>612,618</NoWarn>
   </PropertyGroup>

--- a/examples/Workflow/WorkflowExternalInteraction/WorkflowExternalInteraction.csproj
+++ b/examples/Workflow/WorkflowExternalInteraction/WorkflowExternalInteraction.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowFanOutFanIn/WorkflowFanOutFanIn.csproj
+++ b/examples/Workflow/WorkflowFanOutFanIn/WorkflowFanOutFanIn.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowMonitor/WorkflowMonitor.csproj
+++ b/examples/Workflow/WorkflowMonitor/WorkflowMonitor.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowSubworkflow/WorkflowSubworkflow.csproj
+++ b/examples/Workflow/WorkflowSubworkflow/WorkflowSubworkflow.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowTaskChaining/WorkflowTaskChaining.csproj
+++ b/examples/Workflow/WorkflowTaskChaining/WorkflowTaskChaining.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowUnitTest/WorkflowUnitTest.csproj
+++ b/examples/Workflow/WorkflowUnitTest/WorkflowUnitTest.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "This policy allows the 8.0.100 SDK or patches in that family.",
+  "_comment": "This policy allows the 9.0.100 SDK or patches in that family.",
   "sdk": {
     "version": "9.0.100",
     "rollForward": "latestFeature"

--- a/src/Dapr.AI/Dapr.AI.csproj
+++ b/src/Dapr.AI/Dapr.AI.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6;net8</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Dapr.AI</PackageId>

--- a/src/Dapr.Actors.Generators/Dapr.Actors.Generators.csproj
+++ b/src/Dapr.Actors.Generators/Dapr.Actors.Generators.csproj
@@ -22,6 +22,7 @@
     <PropertyGroup>
         <!-- Generators must target netstandard2.0. -->
         <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks></TargetFrameworks>
 
         <!-- Do not include the generator as a lib dependency -->
         <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Dapr.Actors.Generators/Dapr.Actors.Generators.csproj
+++ b/src/Dapr.Actors.Generators/Dapr.Actors.Generators.csproj
@@ -22,7 +22,6 @@
     <PropertyGroup>
         <!-- Generators must target netstandard2.0. -->
         <TargetFramework>netstandard2.0</TargetFramework>
-        <TargetFrameworks></TargetFrameworks>
 
         <!-- Do not include the generator as a lib dependency -->
         <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Dapr.Common/Dapr.Common.csproj
+++ b/src/Dapr.Common/Dapr.Common.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Dapr.Protos/Dapr.Protos.csproj
+++ b/src/Dapr.Protos/Dapr.Protos.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Description>This package contains the reference protos used by develop services using Dapr.</Description>

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <!-- NuGet configuration -->
   <PropertyGroup>
-    <!-- NOTE: Workflows targeted .NET 7 (whereas other packages did not, so we must continue until .NET 7 EOL). -->
-    <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageId>Dapr.Workflow</PackageId>
     <Title>Dapr Workflow Authoring SDK</Title>
     <Description>Dapr Workflow SDK for building workflows as code with Dapr</Description>
-    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net8;net9</TargetFrameworks>
+    <TargetFrameworks>net8;net9</TargetFrameworks>
     <OutputPath>$(RepoRoot)bin\$(Configuration)\prod\$(MSBuildProjectName)\</OutputPath>
 
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_managed_netcore.props" />
 
   <PropertyGroup>  
-    <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
+    <TargetFrameworks>net8;net9</TargetFrameworks>
       
     <!-- Set Output Path for tests-->
     <OutputPath>$(RepoRoot)bin\$(Configuration)\test\$(MSBuildProjectName)\</OutputPath>


### PR DESCRIPTION
# Description

This PR drops support for .NET 6 and .NET 7 (exclusively targeted in Dapr.Workflow) from the Dapr .NET SDK.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1429 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
