### PR TITLE
Updated Dapr runtime/CLI version used in integration tests

### DIFF
--- a/.github/workflows/itests.yml
+++ b/.github/workflows/itests.yml
@@ -48,8 +48,8 @@ jobs:
       GOOS: linux
       GOARCH: amd64
       GOPROXY: https://proxy.golang.org
-      DAPR_CLI_VER: 1.14.0
-      DAPR_RUNTIME_VER: 1.14.0
+      DAPR_CLI_VER: 1.15.0
+      DAPR_RUNTIME_VER: 1.15.3
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/release-1.14/install/install.sh
       DAPR_CLI_REF: ''
     steps:

--- a/test/Dapr.E2E.Test/DaprTestApp.cs
+++ b/test/Dapr.E2E.Test/DaprTestApp.cs
@@ -58,8 +58,7 @@ namespace Dapr.E2E.Test
                 "--components-path", componentsPath,
                 "--config", configPath,
                 "--log-level", "debug",
-                "--max-body-size", "32",
-
+                "--max-body-size", "32"
             };
 
             if (configuration.UseAppPort)

--- a/test/Dapr.E2E.Test/DaprTestApp.cs
+++ b/test/Dapr.E2E.Test/DaprTestApp.cs
@@ -58,7 +58,7 @@ namespace Dapr.E2E.Test
                 "--components-path", componentsPath,
                 "--config", configPath,
                 "--log-level", "debug",
-                "--dapr-http-max-request-size", "32",
+                "--max-body-size", "32",
 
             };
 


### PR DESCRIPTION
# Description

This PR updates the runtime/CLI version used in integration tests to 1.15.3 and 1.15.0, respectively. Because 1.15.0 of the CLI came with some argument changes identified in [this issue](https://github.com/dapr/cli/issues/1504), this also proactively assigns the updated names to the changed arguments.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
