### PR TITLE
Additional commits to drop .NET 6 and 7

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-contributing/dotnet-contributing.md
+++ b/daprdocs/content/en/dotnet-sdk-contributing/dotnet-contributing.md
@@ -101,17 +101,8 @@ squashing the PR locally and resubmitting to ensure that the sign-off statement 
 
 # Languages, Tools and Processes
 All source code in the Dapr .NET SDK is written in C# and targets the latest language version available to the earliest
-supported .NET SDK. As of v1.15, this means that because .NET 6 is still supported, the latest language version available
-is [C# version 10](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-10).
-
-As of v1.15, the following versions of .NET are supported:
-
-| Version | Notes                                                           |
-| --- |-----------------------------------------------------------------|
-| .NET 6 | Will be discontinued in v1.16                                   |
-| .NET 7 | Only supported in Dapr.Workflows, will be discontinued in v1.16 |
-| .NET 8 | Will continue to be supported in v1.16                          |
-| .NET 9 | Will continue to be supported in v1.16                          |
+supported .NET SDK. As of v1.16, this means that both .NET 8 and .NET 9 are supported. The latest language version available
+is [C# version 12](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-12)
 
 Contributors are welcome to use whatever IDE they're most comfortable developing in, but please do not submit 
 IDE-specific preference files along with your contributions as these will be rejected.

--- a/daprdocs/content/en/dotnet-sdk-docs/_index.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/_index.md
@@ -18,15 +18,7 @@ Dapr offers a variety of packages to help with the development of .NET applicati
 
 - [Dapr CLI]({{< ref install-dapr-cli.md >}}) installed
 - Initialized [Dapr environment]({{< ref install-dapr-selfhost.md >}})
-- [.NET 6](https://dotnet.microsoft.com/download), [.NET 8](https://dotnet.microsoft.com/download) or [.NET 9](https://dotnet.microsoft.com/download) installed
-
-{{% alert title="Note" color="primary" %}}
-
-Note that while .NET 6 is generally supported as the minimum .NET requirement across the Dapr .NET SDK packages
-and .NET 7 is the minimally supported version of .NET by Dapr.Workflows in Dapr v1.15, only .NET 8 and .NET 9 will
-continue to be supported by Dapr in v1.16 and later.
-
-{{% /alert %}}
+- [.NET 8](https://dotnet.microsoft.com/download) or [.NET 9](https://dotnet.microsoft.com/download) installed
 
 ## Installation
 

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-actors/dotnet-actors-howto.md
@@ -45,15 +45,7 @@ This project contains the implementation of the actor client which calls MyActor
 
 - [Dapr CLI]({{< ref install-dapr-cli.md >}}) installed.
 - Initialized [Dapr environment]({{< ref install-dapr-selfhost.md >}}).
-- [.NET 6](https://dotnet.microsoft.com/download), [.NET 8](https://dotnet.microsoft.com/download) or [.NET 9](https://dotnet.microsoft.com/download) installed
-
-{{% alert title="Note" color="primary" %}}
-
-Note that while .NET 6 is generally supported as the minimum .NET requirement across the Dapr .NET SDK packages
-and .NET 7 is the minimally supported version of .NET by Dapr.Workflows in Dapr v1.15, only .NET 8 and .NET 9 will
-continue to be supported by Dapr in v1.16 and later.
-
-{{% /alert %}}
+- [.NET 8](https://dotnet.microsoft.com/download) or [.NET 9](https://dotnet.microsoft.com/download) installed
 
 ## Step 0: Prepare
 

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-ai/dotnet-ai-conversation-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-ai/dotnet-ai-conversation-howto.md
@@ -7,16 +7,9 @@ description: Learn how to create and use the Dapr Conversational AI client using
 ---
 
 ## Prerequisites
-- [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0), [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0), or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed
+- [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0), or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost)
-
-{{% alert title="Note" color="primary" %}}
-
-.NET 6 is supported as the minimum required for the Dapr .NET SDK packages in this release. Only .NET 8 and .NET 9
-will be supported in Dapr v1.16 and later releases.
-
-{{% /alert %}}
 
 ## Installation
 

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-development/dotnet-development-dapr-aspire.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-development/dotnet-development-dapr-aspire.md
@@ -24,13 +24,11 @@ Amazon AWS, deployment is currently outside the scope of this guide. More inform
 documentation [here](https://learn.microsoft.com/en-us/dotnet/aspire/deployment/overview).
 
 ## Prerequisites
-- While the Dapr .NET SDK is compatible with [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0), 
-[.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0), 
-.NET Aspire is only compatible with [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) or 
-[.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0).
+- Both the Dapr .NET SDK and .NET Aspire are compatible with [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) 
+or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0)
 - An OCI compliant container runtime such as [Docker Desktop](https://www.docker.com/products/docker-desktop) or 
 [Podman](https://podman.io/)
-- Install and initialize Dapr v1.13 or later
+- Install and initialize Dapr v1.16 or later
 
 ## Using .NET Aspire via CLI
 

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-jobs/dotnet-jobs-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-jobs/dotnet-jobs-howto.md
@@ -18,14 +18,8 @@ In the .NET example project:
 ## Prerequisites
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost)
-- [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0), [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed
+- [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed
 - [Dapr.Jobs](https://www.nuget.org/packages/Dapr.Jobs) NuGet package installed to your project
-
-{{% alert title="Note" color="primary" %}}
-
-Note that while .NET 6 is the minimum support version of .NET in Dapr v1.15, only .NET 8 and .NET 9 will continue to be supported by Dapr in v1.16 and later.
-
-{{% /alert %}}
 
 ## Set up the environment
 Clone the [.NET SDK repo](https://github.com/dapr/dotnet-sdk).

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-messaging/dotnet-messaging-pubsub-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-messaging/dotnet-messaging-pubsub-howto.md
@@ -17,14 +17,8 @@ runtime and which do not require an endpoint to be pre-configured. In this guide
 ## Prerequisites
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost)
-- [.NET 6](https://dotnet.microsoft.com/download/dotnet/6.0), [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed
+- [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed
 - [Dapr.Messaging](https://www.nuget.org/packages/Dapr.Messaging) NuGet package installed to your project
-
-{{% alert title="Note" color="primary" %}}
-
-Note that while .NET 6 is the minimum support version of .NET in Dapr v1.15, only .NET 8 and .NET 9 will continue to be supported by Dapr in v1.16 and later.
-
-{{% /alert %}}
 
 ## Set up the environment
 Clone the [.NET SDK repo](https://github.com/dapr/dotnet-sdk).

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-workflow/dotnet-workflow-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-workflow/dotnet-workflow-howto.md
@@ -20,14 +20,7 @@ In the .NET example project:
 
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
-- [.NET 7](https://dotnet.microsoft.com/download/dotnet/7.0), [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed
-
-{{% alert title="Note" color="primary" %}}
-
-Dapr.Workflows supports .NET 7 or newer in v1.15. However, following the release of Dapr v1.16, only
-.NET 8 and .NET 9 will be supported.
-
-{{% /alert %}}
+- [.NET 8](https://dotnet.microsoft.com/download/dotnet/8.0) or [.NET 9](https://dotnet.microsoft.com/download/dotnet/9.0) installed
 
 ## Set up the environment
 

--- a/examples/Actor/README.md
+++ b/examples/Actor/README.md
@@ -4,7 +4,7 @@ The Actor example shows how to create a virtual actor (`DemoActor`) and invoke i
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://github.com/dapr/dotnet-sdk/)

--- a/examples/AspNetCore/ControllerSample/README.md
+++ b/examples/AspNetCore/ControllerSample/README.md
@@ -12,7 +12,7 @@ The application also registers for pub/sub with the `deposit`, `multideposit` an
 
 ## Prerequisitess
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/AspNetCore/GrpcServiceSample/README.md
+++ b/examples/AspNetCore/GrpcServiceSample/README.md
@@ -11,7 +11,7 @@ The application also registers for pub/sub with the `deposit` and `withdraw` top
 
 ## Prerequisitess
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/AspNetCore/RoutingSample/README.md
+++ b/examples/AspNetCore/RoutingSample/README.md
@@ -12,7 +12,7 @@ The application also registers for pub/sub with the `deposit`, `multideposit`, a
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/AspNetCore/SecretStoreConfigurationProviderSample/README.md
+++ b/examples/AspNetCore/SecretStoreConfigurationProviderSample/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/ConfigurationApi/README.md
+++ b/examples/Client/ConfigurationApi/README.md
@@ -9,7 +9,7 @@ It demonstrates the following APIs:
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/DistributedLock/README.md
+++ b/examples/Client/DistributedLock/README.md
@@ -2,13 +2,13 @@
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)
 
 ## Distributed Lock API
-Dapr 1.8 introduces the Distributed Lock API. This API can be used to prevent multiple processes from accessing the same resource. In Dapr, locks are scoped to a specific App ID.
+Dapr 1.8 introduced the Distributed Lock API. This API can be used to prevent multiple processes from accessing the same resource. In Dapr, locks are scoped to a specific App ID.
 
 For this example, we will be running multiple instances of the same application to demonstrate an event driven consumer pattern. This example also includes a simple generator that creates some data that can be processed.
 

--- a/examples/Client/PublishSubscribe/BulkPublishEventExample/README.md
+++ b/examples/Client/PublishSubscribe/BulkPublishEventExample/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/PublishSubscribe/PublishEventExample/README.md
+++ b/examples/Client/PublishSubscribe/PublishEventExample/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/ServiceInvocation/README.md
+++ b/examples/Client/ServiceInvocation/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Client/StateManagement/README.md
+++ b/examples/Client/StateManagement/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/GeneratedActor/README.md
+++ b/examples/GeneratedActor/README.md
@@ -4,7 +4,7 @@ An example of generating a strongly-typed actor client.
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://docs.dapr.io/developing-applications/sdks/dotnet/)

--- a/examples/Workflow/README.md
+++ b/examples/Workflow/README.md
@@ -4,7 +4,7 @@ This Dapr workflow example shows how to create a Dapr workflow (`Workflow`) and 
 
 ## Prerequisites
 
-- [.NET 6+](https://dotnet.microsoft.com/download) installed
+- [.NET 8+](https://dotnet.microsoft.com/download) installed
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/)
 - [Initialized Dapr environment](https://docs.dapr.io/getting-started/install-dapr-selfhost/)
 - [Dapr .NET SDK](https://github.com/dapr/dotnet-sdk/)

--- a/properties/dapr_managed_netcore.props
+++ b/properties/dapr_managed_netcore.props
@@ -3,7 +3,7 @@
   <Import Project="dapr_common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>


### PR DESCRIPTION
# Description

Updated all the documentation to reflect support for .NET 8 and 9 throughout, updated examples and READMEs accordingly.

Also increased the minimum C# langversion from 10.0 to 12.0 as C# 12 was released with .NET 8.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1429 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
