### PR TITLE
Add example for invoking Non-Dapr HTTP endpoints using DaprClient

### DIFF
--- a/examples/Client/ServiceInvocation/InvokeServiceHttpNonDaprEndpointExample.cs
+++ b/examples/Client/ServiceInvocation/InvokeServiceHttpNonDaprEndpointExample.cs
@@ -1,0 +1,64 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2021 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Client;
+
+namespace Samples.Client
+{
+    public class InvokeServiceHttpNonDaprEndpointExample : Example
+    {
+        public override string DisplayName => "Invoke a non Dapr endpoint using DaprClient";
+    
+        public override async Task RunAsync(CancellationToken cancellationToken)
+        {
+            using var client = new DaprClientBuilder().Build();
+        
+            // Invoke a POST method named "deposit" that takes input of type "Transaction" as defined in the RoutingSample.
+            Console.WriteLine("Invoking deposit using non Dapr endpoint.");
+            var data = new { id = "17", amount = 99m };
+            var account = await client.InvokeMethodAsync<object, Account>("http://localhost:5000", "deposit", data, cancellationToken);
+            Console.WriteLine("Returned: id:{0} | Balance:{1}", account.Id, account.Balance);
+        
+            // Invokes a POST method named "Withdraw" that takes input of type "Transaction" as defined in the RoutingSample.
+            Console.WriteLine("Invoking withdraw using non Dapr endpoint.");
+            data = new { id = "17", amount = 10m, };
+            await client.InvokeMethodAsync<object>("http://localhost:5000", "withdraw", data, cancellationToken);
+            Console.WriteLine("Completed");
+        
+            // Invokes a GET method named "hello" that takes input of type "MyData" and returns a string.
+            Console.WriteLine("Invoking balance using non Dapr endpoint.");
+            account = await client.InvokeMethodAsync<Account>(HttpMethod.Get, "http://localhost:5000", "17", cancellationToken);
+            Console.WriteLine($"Received balance {account.Balance}");
+        }
+
+        internal class Transaction
+        {
+            public string? Id { get; set; }
+        
+            public decimal Amount { get; set; }
+        }
+    
+        internal class Account 
+        {
+            public string? Id { get; set; }
+        
+            public decimal Balance { get; set; }
+        }
+    }
+}
+
+

--- a/examples/Client/ServiceInvocation/Program.cs
+++ b/examples/Client/ServiceInvocation/Program.cs
@@ -24,6 +24,7 @@ namespace Samples.Client
             new InvokeServiceGrpcExample(),
             new InvokeServiceHttpExample(),
             new InvokeServiceHttpClientExample(),
+            new InvokeServiceHttpNonDaprEndpointExample()
         };
 
         static async Task<int> Main(string[] args)

--- a/examples/Client/ServiceInvocation/README.md
+++ b/examples/Client/ServiceInvocation/README.md
@@ -45,3 +45,9 @@ See [InvokeServiceHttpExample.cs](./InvokeServiceHttpExample.cs) for an example 
 Make sure to first run the [GrpcService](../../AspNetCore/GrpcServiceSample) to have a service to invoke.
 
 See [InvokeServiceGrpcExample.cs](./InvokeServiceGrpcExample.cs) for an example using the `DaprClient` to invoke a service using gRPC through Dapr.
+
+## Dapr Non-Dapr endpoint
+
+Make sure to first run the [Routing Service](../../AspNetCore/RoutingSample) to have a service to invoke.
+
+See [InvokeServiceHttpNonDaprEndpointExample](./InvokeServiceHttpNonDaprEndpointExample.cs) for an example using the `DaprClient` to invoke a non-Dapr endpoint through Dapr.


### PR DESCRIPTION
# Description
Enhances the examples and add a DaprClient Non-Dapr client invocation example.

_Please explain the changes you've made_

## Issue reference
#1501

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
