### PR TITLE
Actor deserialization - @monthly always returns 30 days now

### DIFF
--- a/src/Dapr.Actors/Extensions/DurationExtensions.cs
+++ b/src/Dapr.Actors/Extensions/DurationExtensions.cs
@@ -68,13 +68,12 @@ internal static class DurationExtensions
 
         if (period.StartsWith(MonthlyPrefixPeriod))
         {
-            var dateTime = DateTime.UtcNow;
-            return dateTime.AddMonths(1) - dateTime;
+            return TimeSpan.FromDays(30);
         }
 
         if (period.StartsWith(MidnightPrefixPeriod))
         {
-            return new TimeSpan();
+            return TimeSpan.Zero;
         }
 
         if (period.StartsWith(WeeklyPrefixPeriod))

--- a/src/Dapr.Actors/Runtime/ConverterUtils.cs
+++ b/src/Dapr.Actors/Runtime/ConverterUtils.cs
@@ -49,7 +49,7 @@ internal static class ConverterUtils
         int msIndex = spanOfValue.IndexOf("ms");
 
         // handle days from hours.
-        var hoursSpan = spanOfValue.Slice(0, hIndex);
+        var hoursSpan = spanOfValue[..hIndex];
         var hours = int.Parse(hoursSpan);
         var days = hours / 24;
         hours %= 24;

--- a/test/Dapr.Actors.Test/Runtime/ActorManagerTests.cs
+++ b/test/Dapr.Actors.Test/Runtime/ActorManagerTests.cs
@@ -219,19 +219,19 @@ namespace Dapr.Actors.Runtime
             Assert.Equal(TimeSpan.FromHours(3).Add(TimeSpan.FromMinutes(2)).Add(TimeSpan.FromSeconds(15)), result.Period);
         }
         
-        // [Fact]
-        // public async Task DeserializeTimer_Period_DaprFormat_Monthly()
-        // {
-        //     const string timerJson = "{\"callback\": \"TimerCallback\", \"period\": \"@monthly\"}";
-        //     await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(timerJson));
-        //     var result = await ActorManager.DeserializeAsync(stream);
-        //     
-        //     Assert.Equal("TimerCallback", result.Callback);
-        //     Assert.Equal(Array.Empty<byte>(), result.Data);
-        //     Assert.Null(result.Ttl);
-        //     Assert.Equal(TimeSpan.Zero, result.DueTime);
-        //     Assert.Equal(TimeSpan.FromDays(30), result.Period);
-        // }
+        [Fact]
+        public async Task DeserializeTimer_Period_DaprFormat_Monthly()
+        {
+            const string timerJson = "{\"callback\": \"TimerCallback\", \"period\": \"@monthly\"}";
+            await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(timerJson));
+            var result = await ActorManager.DeserializeAsync(stream);
+            
+            Assert.Equal("TimerCallback", result.Callback);
+            Assert.Equal(Array.Empty<byte>(), result.Data);
+            Assert.Null(result.Ttl);
+            Assert.Equal(TimeSpan.Zero, result.DueTime);
+            Assert.Equal(TimeSpan.FromDays(30), result.Period);
+        }
         
         [Fact]
         public async Task DeserializeTimer_Period_DaprFormat_Weekly()


### PR DESCRIPTION
# Description

Re-enabled the test with a fix to use a fixed 30 days for @monthly in actor deserialization for now.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1529 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
