### PR TITLE
Standardized dotnet version via Directory.Build.Props file

### DIFF
--- a/examples/AI/ConversationalAI/ConversationalAI.csproj
+++ b/examples/AI/ConversationalAI/ConversationalAI.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Actor/ActorClient/ActorClient.csproj
+++ b/examples/Actor/ActorClient/ActorClient.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Actor/DemoActor/DemoActor.csproj
+++ b/examples/Actor/DemoActor/DemoActor.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6</TargetFramework>
-    </PropertyGroup>
-
-    <PropertyGroup>
         <IsPublishable>true</IsPublishable>
         <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
         <ContainerRepository>demo-actor</ContainerRepository>

--- a/examples/Actor/IDemoActor/IDemoActor.csproj
+++ b/examples/Actor/IDemoActor/IDemoActor.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.Actors\Dapr.Actors.csproj" />
   </ItemGroup>

--- a/examples/AspNetCore/ControllerSample/ControllerSample.csproj
+++ b/examples/AspNetCore/ControllerSample/ControllerSample.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
   </ItemGroup>

--- a/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
+++ b/examples/AspNetCore/GrpcServiceSample/GrpcServiceSample.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
   </PropertyGroup>
 

--- a/examples/AspNetCore/RoutingSample/RoutingSample.csproj
+++ b/examples/AspNetCore/RoutingSample/RoutingSample.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />
   </ItemGroup>

--- a/examples/AspNetCore/SecretStoreConfigurationProviderSample/SecretStoreConfigurationProviderSample.csproj
+++ b/examples/AspNetCore/SecretStoreConfigurationProviderSample/SecretStoreConfigurationProviderSample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Client/ConfigurationApi/ConfigurationApi.csproj
+++ b/examples/Client/ConfigurationApi/ConfigurationApi.csproj
@@ -1,10 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dapr.Client\Dapr.Client.csproj" />
     <ProjectReference Include="..\..\..\src\Dapr.AspNetCore\Dapr.AspNetCore.csproj" />

--- a/examples/Client/Cryptography/Cryptography.csproj
+++ b/examples/Client/Cryptography/Cryptography.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>

--- a/examples/Client/DistributedLock/DistributedLock.csproj
+++ b/examples/Client/DistributedLock/DistributedLock.csproj
@@ -6,9 +6,4 @@
     <ProjectReference Include="..\..\..\src\Dapr.Common\Dapr.Common.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
-  </PropertyGroup>
-
-
 </Project>

--- a/examples/Client/PublishSubscribe/BulkPublishEventExample/BulkPublishEventExample.csproj
+++ b/examples/Client/PublishSubscribe/BulkPublishEventExample/BulkPublishEventExample.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
         <RootNamespace>Samples.Client</RootNamespace>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Client/PublishSubscribe/PublishEventExample/PublishEventExample.csproj
+++ b/examples/Client/PublishSubscribe/PublishEventExample/PublishEventExample.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Client/PublishSubscribe/StreamingSubscriptionExample/StreamingSubscriptionExample.csproj
+++ b/examples/Client/PublishSubscribe/StreamingSubscriptionExample/StreamingSubscriptionExample.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Client/ServiceInvocation/ServiceInvocation.csproj
+++ b/examples/Client/ServiceInvocation/ServiceInvocation.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Client/StateManagement/StateManagement.csproj
+++ b/examples/Client/StateManagement/StateManagement.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Samples.Client</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,10 +1,11 @@
 <Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_managed_netcore.props" />
+    <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_managed_netcore.props" />
 
-  <PropertyGroup>
-    <!-- Set Output Path for samples-->
-    <OutputPath>$(RepoRoot)bin\$(Configuration)\examples\$(MSBuildProjectName)\</OutputPath>
+    <PropertyGroup>
+        <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
+        <!-- Set Output Path for samples-->
+        <OutputPath>$(RepoRoot)bin\$(Configuration)\examples\$(MSBuildProjectName)\</OutputPath>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 </Project>

--- a/examples/GeneratedActor/ActorClient/ActorClient.csproj
+++ b/examples/GeneratedActor/ActorClient/ActorClient.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
         <LangVersion>10.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/examples/GeneratedActor/ActorCommon/ActorCommon.csproj
+++ b/examples/GeneratedActor/ActorCommon/ActorCommon.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/examples/GeneratedActor/ActorService/ActorService.csproj
+++ b/examples/GeneratedActor/ActorService/ActorService.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/examples/Jobs/JobsSample/JobsSample.csproj
+++ b/examples/Jobs/JobsSample/JobsSample.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowAsyncOperations/WorkflowAsyncOperations.csproj
+++ b/examples/Workflow/WorkflowAsyncOperations/WorkflowAsyncOperations.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowConsoleApp/WorkflowConsoleApp.csproj
+++ b/examples/Workflow/WorkflowConsoleApp/WorkflowConsoleApp.csproj
@@ -6,7 +6,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>612,618</NoWarn>
   </PropertyGroup>

--- a/examples/Workflow/WorkflowExternalInteraction/WorkflowExternalInteraction.csproj
+++ b/examples/Workflow/WorkflowExternalInteraction/WorkflowExternalInteraction.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowFanOutFanIn/WorkflowFanOutFanIn.csproj
+++ b/examples/Workflow/WorkflowFanOutFanIn/WorkflowFanOutFanIn.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowMonitor/WorkflowMonitor.csproj
+++ b/examples/Workflow/WorkflowMonitor/WorkflowMonitor.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowSubworkflow/WorkflowSubworkflow.csproj
+++ b/examples/Workflow/WorkflowSubworkflow/WorkflowSubworkflow.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowTaskChaining/WorkflowTaskChaining.csproj
+++ b/examples/Workflow/WorkflowTaskChaining/WorkflowTaskChaining.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/examples/Workflow/WorkflowUnitTest/WorkflowUnitTest.csproj
+++ b/examples/Workflow/WorkflowUnitTest/WorkflowUnitTest.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Dapr.AI/Dapr.AI.csproj
+++ b/src/Dapr.AI/Dapr.AI.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6;net8</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Dapr.AI</PackageId>

--- a/src/Dapr.Common/Dapr.Common.csproj
+++ b/src/Dapr.Common/Dapr.Common.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Dapr.Protos/Dapr.Protos.csproj
+++ b/src/Dapr.Protos/Dapr.Protos.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Description>This package contains the reference protos used by develop services using Dapr.</Description>

--- a/src/Dapr.Workflow/Dapr.Workflow.csproj
+++ b/src/Dapr.Workflow/Dapr.Workflow.csproj
@@ -3,7 +3,6 @@
   <!-- NuGet configuration -->
   <PropertyGroup>
     <!-- NOTE: Workflows targeted .NET 7 (whereas other packages did not, so we must continue until .NET 7 EOL). -->
-    <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageId>Dapr.Workflow</PackageId>
     <Title>Dapr Workflow Authoring SDK</Title>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\properties\dapr_nuget.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net8;net9</TargetFrameworks>
+    <TargetFrameworks>net6;net7;net8;net9</TargetFrameworks>
     <OutputPath>$(RepoRoot)bin\$(Configuration)\prod\$(MSBuildProjectName)\</OutputPath>
 
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>


### PR DESCRIPTION
# Description

The version used for compilation some times was provided through the Directory.Build.props file others directly in the .csproj file. In order to simplify its management now all projects use the one in the Directory.Build.props files.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
