### PR TITLE
Update dotnet-development-dapr-aspire.md

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-development/dotnet-development-dapr-aspire.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-development/dotnet-development-dapr-aspire.md
@@ -68,12 +68,18 @@ dotnet new web MyApp
 ```
 
 Next we'll configure the AppHost project to add the necessary package to support local Dapr development. Navigate
-into the AppHost directory with the following and install the `Aspire.Hosting.Dapr` package from NuGet into the project.
+into the AppHost directory with the following and install the `CommunityToolkit.Aspire.Hosting.Dapr` package from NuGet into the project.
 We'll also add a reference to our `MyApp` project so we can reference it during the registration process.
+
+{{% alert color="primary" %}}
+
+This package was previously called `Aspire.Hosting.Dapr`, which has been [marked as deprecated](https://www.nuget.org/packages/Aspire.Hosting.Dapr).
+
+{{% /alert %}}
 
 ```sh
 cd aspiredemo.AppHost
-dotnet add package Aspire.Hosting.Dapr
+dotnet add package CommunityToolkit.Aspire.Hosting.Dapr
 dotnet add reference ../MyApp/
 ```
 


### PR DESCRIPTION
# Description

Updates the Aspire documentation to reference the new package name from the CommunityToolkit namespace. It also adds a note explaining that the old package has been deprecated. It includes a link to the deprecated NuGet package for clarity.

## Issue reference

This is purely a documentation update.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Extended the documentation
