### PR TITLE
Replace HashSet with ConcurrentDictionary in WorkflowLoggingService

### DIFF
--- a/src/Dapr.Workflow/WorkflowLoggingService.cs
+++ b/src/Dapr.Workflow/WorkflowLoggingService.cs
@@ -13,12 +13,11 @@
 
 namespace Dapr.Workflow
 {
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
-    using Microsoft.Extensions.Configuration;
+    using System.Collections.Concurrent;
 
     /// <summary>
     /// Defines runtime options for workflows.
@@ -26,8 +25,8 @@ namespace Dapr.Workflow
     internal sealed class WorkflowLoggingService : IHostedService
     {
         private readonly ILogger<WorkflowLoggingService> logger;
-        private static readonly HashSet<string> registeredWorkflows = new();
-        private static readonly HashSet<string> registeredActivities = new();
+        private static readonly ConcurrentDictionary<string, byte> registeredWorkflows = new();
+        private static readonly ConcurrentDictionary<string, byte> registeredActivities = new();
 
         public WorkflowLoggingService(ILogger<WorkflowLoggingService> logger)
         {
@@ -38,13 +37,13 @@ namespace Dapr.Workflow
             this.logger.Log(LogLevel.Information, "WorkflowLoggingService started");
 
             this.logger.Log(LogLevel.Information, "List of registered workflows");
-            foreach (string item in registeredWorkflows)
+            foreach (string item in registeredWorkflows.Keys)
             {
                 this.logger.Log(LogLevel.Information, item);
             }
 
             this.logger.Log(LogLevel.Information, "List of registered activities:");
-            foreach (string item in registeredActivities)
+            foreach (string item in registeredActivities.Keys)
             {
                 this.logger.Log(LogLevel.Information, item);
             }
@@ -55,18 +54,18 @@ namespace Dapr.Workflow
         public Task StopAsync(CancellationToken cancellationToken)
         {
             this.logger.Log(LogLevel.Information, "WorkflowLoggingService stopped");
-    
+
             return Task.CompletedTask;
         }
 
         public static void LogWorkflowName(string workflowName)
         {
-            registeredWorkflows.Add(workflowName);
+            registeredWorkflows.TryAdd(workflowName, 0);
         }
 
         public static void LogActivityName(string activityName)
         {
-            registeredActivities.Add(activityName);
+            registeredActivities.TryAdd(activityName, 0);
         }
 
     }


### PR DESCRIPTION
This should help with issue #1273 - intermittent exceptions from WorkflowLoggingService.

There is no concurrent HashSet in .NET, so we use ConcurrentDictionary with a byte as the value to simulate a set. For this use-case we do not care if the Key already exists, so we can use TryAdd to add items without considering the return value.

# Description

Replaces `HashSet<string>` as the collection that stores Activity and Workflow names for logging with `ConcurrentDictionary<string, byte>`

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1273

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
