### PR TITLE
Accept DateTimeOffset for workflow start time

### DIFF
--- a/src/Dapr.Workflow/DaprWorkflowClient.cs
+++ b/src/Dapr.Workflow/DaprWorkflowClient.cs
@@ -41,6 +41,10 @@ public class DaprWorkflowClient(DurableTaskClient innerClient) : IAsyncDisposabl
     /// <param name="startTime">
     /// The time when the workflow instance should start executing. If not specified or if a date-time in the past
     /// is specified, the workflow instance will be scheduled immediately.
+    /// If specified with a <see cref="DateTime.Kind"/> of <see cref="DateTimeKind.Unspecified"/>,
+    /// this is interpreted as a local time.
+    /// Setting this value will cause Dapr to not wait for the Workflow to
+    /// "start", improving throughput of creating many workflows.
     /// </param>
     /// <param name="input">
     /// The optional input to pass to the scheduled workflow instance. This must be a serializable value.
@@ -50,6 +54,31 @@ public class DaprWorkflowClient(DurableTaskClient innerClient) : IAsyncDisposabl
         string? instanceId = null,
         object? input = null,
         DateTime? startTime = null)
+    {
+        return ScheduleNewWorkflowAsync(name, instanceId, input, (DateTimeOffset?)startTime);
+    }
+
+    /// <summary>
+    /// Schedules a new workflow instance for execution.
+    /// </summary>
+    /// <param name="name">The name of the workflow to schedule.</param>
+    /// <param name="instanceId">
+    /// The unique ID of the workflow instance to schedule. If not specified, a new GUID value is used.
+    /// </param>
+    /// <param name="startTime">
+    /// The time when the workflow instance should start executing. If not specified or if a date-time in the past
+    /// is specified, the workflow instance will be scheduled immediately.
+    /// Setting this value will cause Dapr to not wait for the Workflow to
+    /// "start", improving throughput of creating many workflows.
+    /// </param>
+    /// <param name="input">
+    /// The optional input to pass to the scheduled workflow instance. This must be a serializable value.
+    /// </param>
+    public Task<string> ScheduleNewWorkflowAsync(
+        string name,
+        string? instanceId = null,
+        object? input = null,
+        DateTimeOffset? startTime = null)
     {
         StartOrchestrationOptions options = new(instanceId, startTime);
         return this.innerClient.ScheduleNewOrchestrationInstanceAsync(name, input, options);

--- a/src/Dapr.Workflow/DaprWorkflowClient.cs
+++ b/src/Dapr.Workflow/DaprWorkflowClient.cs
@@ -76,9 +76,9 @@ public class DaprWorkflowClient(DurableTaskClient innerClient) : IAsyncDisposabl
     /// </param>
     public Task<string> ScheduleNewWorkflowAsync(
         string name,
-        string? instanceId = null,
-        object? input = null,
-        DateTimeOffset? startTime = null)
+        string? instanceId,
+        object? input,
+        DateTimeOffset? startTime)
     {
         StartOrchestrationOptions options = new(instanceId, startTime);
         return this.innerClient.ScheduleNewOrchestrationInstanceAsync(name, input, options);

--- a/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
+++ b/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
@@ -1,0 +1,117 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Microsoft.DurableTask;
+using Moq;
+
+namespace Dapr.Workflow.Test;
+
+public class DaprWorkflowClientTests
+{
+    [Fact]
+    public async Task ScheduleNewWorkflowAsync_DateTimeKindUnspecified_AssumesLocalTime()
+    {
+        var innerClient = new Mock<GrpcDurableTaskClientWrapper>();
+
+        var name = "test-workflow";
+        var instanceId = "test-instance-id";
+        var input = "test-input";
+        var startTime = new DateTime(2025, 07, 10);
+
+        Assert.Equal(DateTimeKind.Unspecified, startTime.Kind);
+
+        innerClient.Setup(c => c.ScheduleNewOrchestrationInstanceAsync(
+            It.IsAny<TaskName>(),
+            It.IsAny<object?>(),
+            It.IsAny<StartOrchestrationOptions?>(),
+            It.IsAny<CancellationToken>()))
+            .Callback((TaskName n, object? i, StartOrchestrationOptions? o, CancellationToken ct) =>
+            {
+                Assert.Equal(name, n);
+                Assert.Equal(input, i);
+                Assert.NotNull(o);
+                Assert.NotNull(o.StartAt);
+                // options configured with local time
+                Assert.Equal(new DateTimeOffset(startTime, TimeZoneInfo.Local.GetUtcOffset(DateTime.Now)), o.StartAt.Value);
+            })
+            .ReturnsAsync("instance-id");
+
+        var client = new DaprWorkflowClient(innerClient.Object);
+
+        await client.ScheduleNewWorkflowAsync(name, instanceId, input, startTime);
+    }
+
+    [Fact]
+    public async Task ScheduleNewWorkflowAsync_DateTimeKindUtc_PreservedAsUtc()
+    {
+        var innerClient = new Mock<GrpcDurableTaskClientWrapper>();
+
+        var name = "test-workflow";
+        var instanceId = "test-instance-id";
+        var input = "test-input";
+        var startTime = new DateTime(2025, 07, 10, 1, 30, 30, DateTimeKind.Utc);
+
+        Assert.Equal(DateTimeKind.Utc, startTime.Kind);
+
+        innerClient.Setup(c => c.ScheduleNewOrchestrationInstanceAsync(
+            It.IsAny<TaskName>(),
+            It.IsAny<object?>(),
+            It.IsAny<StartOrchestrationOptions?>(),
+            It.IsAny<CancellationToken>()))
+            .Callback((TaskName n, object? i, StartOrchestrationOptions? o, CancellationToken ct) =>
+            {
+                Assert.Equal(name, n);
+                Assert.Equal(input, i);
+                Assert.NotNull(o);
+                Assert.NotNull(o.StartAt);
+                // options configured with UTC time
+                Assert.Equal(new DateTimeOffset(startTime, TimeSpan.Zero), o.StartAt.Value);
+            })
+            .ReturnsAsync("instance-id");
+
+        var client = new DaprWorkflowClient(innerClient.Object);
+
+        await client.ScheduleNewWorkflowAsync(name, instanceId, input, startTime);
+    }
+
+    [Fact]
+    public async Task ScheduleNewWorkflowAsync_DateTimeOffset_SetsStartAt()
+    {
+        var innerClient = new Mock<GrpcDurableTaskClientWrapper>();
+
+        var name = "test-workflow";
+        var instanceId = "test-instance-id";
+        var input = "test-input";
+        var startTime = new DateTimeOffset(2025, 07, 10, 1, 30, 30, TimeSpan.FromHours(3));
+
+        innerClient.Setup(c => c.ScheduleNewOrchestrationInstanceAsync(
+            It.IsAny<TaskName>(),
+            It.IsAny<object?>(),
+            It.IsAny<StartOrchestrationOptions?>(),
+            It.IsAny<CancellationToken>()))
+            .Callback((TaskName n, object? i, StartOrchestrationOptions? o, CancellationToken ct) =>
+            {
+                Assert.Equal(name, n);
+                Assert.Equal(input, i);
+                Assert.NotNull(o);
+                Assert.NotNull(o.StartAt);
+                // options configured with specified offset
+                Assert.Equal(startTime, o.StartAt.Value);
+            })
+            .ReturnsAsync("instance-id");
+
+        var client = new DaprWorkflowClient(innerClient.Object);
+
+        await client.ScheduleNewWorkflowAsync(name, instanceId, input, startTime);
+    }
+}

--- a/test/Dapr.Workflow.Test/GrpcDurableTaskClientWrapper.cs
+++ b/test/Dapr.Workflow.Test/GrpcDurableTaskClientWrapper.cs
@@ -1,0 +1,76 @@
+﻿// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using Microsoft.DurableTask;
+using Microsoft.DurableTask.Client;
+using Microsoft.DurableTask.Client.Grpc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Dapr.Workflow.Test;
+
+/// <summary>
+/// Wraps the gRPC Durable Task Client to provide an implementation for mocking.
+/// </summary>
+public class GrpcDurableTaskClientWrapper : DurableTaskClient
+{
+    private GrpcDurableTaskClient grpcClient = new("test", new GrpcDurableTaskClientOptions(), NullLogger.Instance);
+
+    public GrpcDurableTaskClientWrapper() : base("fake")
+    {
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        return grpcClient.DisposeAsync();
+    }
+
+    public override AsyncPageable<OrchestrationMetadata> GetAllInstancesAsync(OrchestrationQuery? filter = null)
+    {
+        return grpcClient.GetAllInstancesAsync(filter);
+    }
+
+    public override Task<OrchestrationMetadata?> GetInstancesAsync(string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
+    {
+        return grpcClient.GetInstancesAsync(instanceId, getInputsAndOutputs, cancellation);
+    }
+
+    public override Task RaiseEventAsync(string instanceId, string eventName, object? eventPayload = null, CancellationToken cancellation = default)
+    {
+        return grpcClient.RaiseEventAsync(instanceId, eventName, eventPayload, cancellation);
+    }
+
+    public override Task ResumeInstanceAsync(string instanceId, string? reason = null, CancellationToken cancellation = default)
+    {
+        return grpcClient.ResumeInstanceAsync(instanceId, reason, cancellation);
+    }
+
+    public override Task<string> ScheduleNewOrchestrationInstanceAsync(TaskName orchestratorName, object? input = null, StartOrchestrationOptions? options = null, CancellationToken cancellation = default)
+    {
+        return grpcClient.ScheduleNewOrchestrationInstanceAsync(orchestratorName, input, options, cancellation);
+    }
+
+    public override Task SuspendInstanceAsync(string instanceId, string? reason = null, CancellationToken cancellation = default)
+    {
+        return grpcClient.SuspendInstanceAsync(instanceId, reason, cancellation);
+    }
+
+    public override Task<OrchestrationMetadata> WaitForInstanceCompletionAsync(string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
+    {
+        return grpcClient.WaitForInstanceCompletionAsync(instanceId, getInputsAndOutputs, cancellation);
+    }
+
+    public override Task<OrchestrationMetadata> WaitForInstanceStartAsync(string instanceId, bool getInputsAndOutputs = false, CancellationToken cancellation = default)
+    {
+        return grpcClient.WaitForInstanceStartAsync(instanceId, getInputsAndOutputs, cancellation);
+    }
+}


### PR DESCRIPTION
Adds overload to `DaprWorkflowClient.ScheduleNewWorkflowAsync` accepting a `DateTimeOffset?` value for `startTime`.

**Note**: I have included the documentation change from #1581 and also included it on the new overload.

### Issue reference

#1576

### Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [X] Extended the documentation
