### PR TITLE
Add A2A implementation for TaskStore

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NoWarn>CS8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
@@ -15,6 +16,7 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.71.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.71.0" />
+    <PackageVersion Include="A2A" Version="0.1.0-preview.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.35" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.35" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
@@ -27,10 +29,10 @@
     <PackageVersion Include="Microsoft.DurableTask.Worker.Grpc" Version="1.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
@@ -44,7 +46,7 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/Dapr.AI/A2A/DaprTaskStore.cs
+++ b/src/Dapr.AI/A2A/DaprTaskStore.cs
@@ -1,0 +1,162 @@
+using A2A;
+using Dapr.Client;
+
+/// <summary>
+/// Represents a Dapr-backed state store implementation for the A2A Dotnet ITaskStore interface, allowing agents to keep persistent state.
+/// </summary>
+public class DaprTaskStore : ITaskStore
+{
+    private readonly DaprClient _daprClient;
+    private readonly string _stateStoreName;
+
+    // Dapr state operation settings: strong consistency, with default concurrency (override per operation as needed)
+    private static readonly StateOptions StrongConsistency = new StateOptions
+    {
+        Consistency = ConsistencyMode.Strong  // Ensure reads/writes use strong consistency
+    };
+
+    /// <summary>
+    /// Constructor for the Task Store.
+    /// </summary>
+    /// <param name="daprClient">A Dapr Client insance</param>
+    /// <param name="stateStoreName">The name of the state store component to use</param>
+    public DaprTaskStore(DaprClient daprClient, string stateStoreName = "statestore")
+    {
+        _daprClient = daprClient ?? throw new ArgumentNullException(nameof(daprClient));
+        _stateStoreName = stateStoreName;
+    }
+
+    /// <summary>
+    /// Retrieves a task by its ID.
+    /// </summary>
+    /// <param name="taskId">The ID of the task to retrieve.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>The task if found, null otherwise.</returns>
+    public async Task<AgentTask?> GetTaskAsync(string taskId, CancellationToken cancellationToken = default)
+    {
+        if (taskId == null) throw new ArgumentNullException(nameof(taskId));
+
+        // Retrieve the AgentTask from Dapr state store with strong consistency to get the latest data
+        AgentTask? task = await _daprClient.GetStateAsync<AgentTask>(
+                              _stateStoreName,
+                              key: taskId,
+                              consistencyMode: ConsistencyMode.Strong,
+                              metadata: null,
+                              cancellationToken: cancellationToken);
+        return task;
+    }
+
+    /// <summary>
+    /// Stores or updates a task.
+    /// </summary>
+    /// <param name="task">The task to store.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task representing the operation.</returns>
+    public async Task SetTaskAsync(AgentTask task, CancellationToken cancellationToken = default)
+    {
+        if (task == null) throw new ArgumentNullException(nameof(task));
+        // The task.Id will be used as the key. We save the entire AgentTask object.
+        // Use strong consistency on write; concurrency defaults to last-write-wins for new entries.
+        await _daprClient.SaveStateAsync(
+            _stateStoreName,
+            key: task.Id,
+            value: task,
+            stateOptions: StrongConsistency,   // strong consistency ensures durability before ack
+            metadata: null,
+            cancellationToken: cancellationToken
+        );
+        // Note: If the task already existed, this will overwrite it (last-write-wins behavior since no ETag used).
+    }
+
+    /// <summary>
+    /// Updates the status of a task.
+    /// </summary>
+    /// <param name="taskId">The ID of the task.</param>
+    /// <param name="status">The new status.</param>
+    /// <param name="message">Optional message associated with the status.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>The updated task status.</returns>
+    public async Task<AgentTaskStatus> UpdateStatusAsync(string taskId, TaskState status, Message? message = null, CancellationToken cancellationToken = default)
+    {
+        if (taskId == null) throw new ArgumentNullException(nameof(taskId));
+        // Fetch state with its ETag for concurrency control.
+        // We use strong consistency to get the latest state and ETag.
+        var (existingTask, etag) = await _daprClient.GetStateAndETagAsync<AgentTask>(
+                                        _stateStoreName,
+                                        key: taskId,
+                                        consistencyMode: ConsistencyMode.Strong,
+                                        metadata: null,
+                                        cancellationToken: cancellationToken);
+        if (existingTask == null)
+        {
+            throw new KeyNotFoundException($"Task with ID '{taskId}' not found.");
+        }
+
+        // Update the status field of the retrieved task object.
+        var st = existingTask.Status;
+        st.State = status;
+        if (message != null)
+        {
+            st.Message = message;
+        }
+
+        existingTask.Status = st;
+
+        // Attempt to save the updated task back with the ETag for optimistic concurrency.
+        var stateOptions = new StateOptions
+        {
+            Consistency = ConsistencyMode.Strong,
+            Concurrency = ConcurrencyMode.FirstWrite  // enable first-write-wins
+        };
+        bool saved = await _daprClient.TrySaveStateAsync(
+                         _stateStoreName,
+                         key: taskId,
+                         value: existingTask,
+                         etag: etag,                // use ETag to ensure no concurrent modification
+                         stateOptions: stateOptions,
+                         metadata: null,
+                         cancellationToken: cancellationToken
+                     );
+        if (!saved)
+        {
+            // The save failed due to an ETag mismatch (concurrent update happened).
+            throw new InvalidOperationException($"Concurrent update detected for task '{taskId}'. Update was not saved.");
+        }
+
+        return existingTask.Status;
+    }
+
+    /// <summary>
+    /// Retrieves push notification configuration for a task.
+    /// </summary>
+    /// <param name="taskId">The ID of the task.</param>
+    /// <param name="notificationConfigId">The ID of the push notification configuration.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>The push notification configuration if found, null otherwise.</returns>
+    public Task<TaskPushNotificationConfig?> GetPushNotificationAsync(string taskId, string notificationConfigId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Stores push notification configuration for a task.
+    /// </summary>
+    /// <param name="pushNotificationConfig">The push notification configuration.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task representing the operation.</returns>
+    public Task SetPushNotificationConfigAsync(TaskPushNotificationConfig pushNotificationConfig, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Retrieves push notification configuration for a task.
+    /// </summary>
+    /// <param name="taskId">The ID of the task.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>The push notification configuration if found, null otherwise.</returns>
+    public Task<IEnumerable<TaskPushNotificationConfig>> GetPushNotificationsAsync(string taskId, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Dapr.AI/Dapr.AI.csproj
+++ b/src/Dapr.AI/Dapr.AI.csproj
@@ -19,8 +19,13 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="A2A" />
+    </ItemGroup>
+    
+    <ItemGroup>
         <ProjectReference Include="..\Dapr.Common\Dapr.Common.csproj" />
         <ProjectReference Include="..\Dapr.Protos\Dapr.Protos.csproj" />
+        <ProjectReference Include="..\Dapr.Client\Dapr.Client.csproj" />
     </ItemGroup>
     
 </Project>


### PR DESCRIPTION
Adds a Dapr state API implementation for Dotnet A2A, allowing agents to persist tasks using Dapr.
