### PR TITLE
Updating publish script workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+﻿name: publish
+
+on:
+  workflow_run:
+    workflows: ["build", "integration-test"]
+    types:
+      - completed
+
+jobs:
+  publish:
+    name: Publish Packages
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      startswith(github.ref, 'refs/tags/v') &&
+      !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: packages
+          path: packages
+
+      - name: List packages (for sanity check)
+        run: ls -R
+        working-directory: packages
+
+      - name: Publish binaries to github for tags
+        if: startswith(github.ref, 'refs/tags/v')
+        run: |
+          sudo npm install --silent --no-progress -g github-release-cli@1.3.1
+
+          OWNER_NAME="${GITHUB_REPOSITORY%%/*}"
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          RELEASE_ARTIFACT=(./packages/*)
+
+          export GITHUB_TOKEN=${{ secrets.DAPR_BOT_TOKEN }}
+          echo "Uploading Nuget packages to GitHub Release"
+          github-release upload \
+            --owner $OWNER_NAME \
+            --repo $REPO_NAME \
+            --body "Release dapr dotnet SDK v${REL_VERSION}" \
+            --tag "v${REL_VERSION}" \
+            --name "Dapr dotnet SDK v${REL_VERSION}" \
+            --prerelease true \
+            ${RELEASE_ARTIFACT[*]}
+
+      - name: Publish nuget packages to nuget.org
+        if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
+        run: |
+          dotnet nuget push "./packages/Dapr*.nupkg" --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -17,11 +17,6 @@ on:
     - dev-*
     - feature-*
 
-  workflow_run:
-    workflows: [ "integration-test" ]
-    types:
-      - completed
-
 jobs:
   build:
     name: Build
@@ -121,48 +116,3 @@ jobs:
       with:
         TRX_PATH: ${{ github.workspace }}/TestResults
         REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
-    name: Publish Packages
-    needs: ['build', 'test']
-    runs-on: ubuntu-latest
-    # Only run this job if workflow_run was successful and we're on a tag
-    if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') &&
-            startswith(github.ref, 'refs/tags/v') && 
-            !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
-    steps:
-    - name: Download release artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: packages
-        path: packages
-    - name: List packages (for sanity check)
-      run: ls -R
-      working-directory: packages
-    - name: Publish binaries to github for tags
-      if: startswith(github.ref, 'refs/tags/v')
-      run: |
-        sudo npm install --silent --no-progress -g github-release-cli@1.3.1
-        
-        # Parse repository to get owner and repo names
-        OWNER_NAME="${GITHUB_REPOSITORY%%/*}"
-        REPO_NAME="${GITHUB_REPOSITORY#*/}"
-        
-        # Get the list of files
-        RELEASE_ARTIFACT=(./packages/*)
-        
-        export GITHUB_TOKEN=${{ secrets.DAPR_BOT_TOKEN }}
-        echo "Uploading Nuget packages to GitHub Release"
-        github-release upload \
-          --owner $OWNER_NAME \
-          --repo $REPO_NAME \
-          --body "Release dapr dotnet SDK v${REL_VERSION}" \
-          --tag "v${REL_VERSION}" \
-          --name "Dapr dotnet SDK v${REL_VERSION}" \
-          --prerelease true \
-          ${RELEASE_ARTIFACT[*]}
-    - name: Publish nuget packages to nuget.org
-      if: startswith(github.ref, 'refs/tags/v') && !(endsWith(github.ref, '-rc') || endsWith(github.ref, '-dev') || endsWith(github.ref, '-prerelease'))
-      run: |
-        dotnet nuget push "./packages/Dapr*.nupkg" --skip-duplicate --api-key ${{ secrets.NUGETORG_DAPR_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
# Description

Updating GitHub workflow to split out publishing to a separate workflow that's dependent on the success of both the sdk_build.yml and itests.yml completing. Publish isn't firing because of a misconfiguration in the workflow today.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
