### PR TITLE
Fixed incorrect link format

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-messaging/_index.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-messaging/_index.md
@@ -8,7 +8,7 @@ description: Get up and running with the Dapr Messaging .NET SDK
 
 With the Dapr Messaging package, you can interact with the Dapr messaging APIs from a .NET application. In the
 v1.15 release, this package only contains the functionality corresponding to the 
-[streaming PubSub capability]({{% ref dotnet-messaging-pubsub-howto.md %}})
+[streaming PubSub capability]({{% ref dotnet-messaging-pubsub-howto.md#subscribe-to-topics %}})
 
 Future Dapr .NET SDK releases will migrate existing messaging capabilities out from Dapr.Client to this 
 Dapr.Messaging package. This will be documented in the release notes, documentation and obsolete attributes in advance.

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-messaging/_index.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-messaging/_index.md
@@ -8,7 +8,7 @@ description: Get up and running with the Dapr Messaging .NET SDK
 
 With the Dapr Messaging package, you can interact with the Dapr messaging APIs from a .NET application. In the
 v1.15 release, this package only contains the functionality corresponding to the 
-[streaming PubSub capability](https://docs.dapr.io/developing-applications/building-blocks/pubsub/howto-publish-subscribe/#subscribe-to-topics).
+[streaming PubSub capability]({{% ref dotnet-messaging-pubsub-howto.md %}})
 
 Future Dapr .NET SDK releases will migrate existing messaging capabilities out from Dapr.Client to this 
 Dapr.Messaging package. This will be documented in the release notes, documentation and obsolete attributes in advance.


### PR DESCRIPTION
# Description

Link was using a static URL instead of the relative documentation format we generally expect in the documentation (e.g. to allow version shifts).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
