### PR TITLE
Added NoWarn property to ignore the use of a pre-requisite package in Dapr.AI.A2A for stable release

### DIFF
--- a/src/Dapr.AI.A2A/Dapr.AI.A2A.csproj
+++ b/src/Dapr.AI.A2A/Dapr.AI.A2A.csproj
@@ -10,6 +10,7 @@
     </PropertyGroup>
     
     <PropertyGroup>
+        <NoWarn>NU5104;</NoWarn>
         <SignAssembly>false</SignAssembly>
     </PropertyGroup>
 


### PR DESCRIPTION
# Description

Adding annotation to ignore pre-req warning blocking successful build in Dapr.AI.A2A

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
