### PR TITLE
Remove duplicate deprecation alert for Aspire.Hosting.Dapr

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-integrations/dotnet-development-dapr-aspire.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-integrations/dotnet-development-dapr-aspire.md
@@ -80,12 +80,6 @@ This package was previously called `Aspire.Hosting.Dapr`, which has been [marked
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-
-This package was previously called `Aspire.Hosting.Dapr`, which has been [marked as deprecated](https://www.nuget.org/packages/Aspire.Hosting.Dapr).
-
-{{% /alert %}}
-
 ```sh
 cd aspiredemo.AppHost
 dotnet add package CommunityToolkit.Aspire.Hosting.Dapr


### PR DESCRIPTION
# Description

On the Aspire page of the dotnet-sdk documentation, a duplicate alert was visible. This PR removes it.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Extended the documentation
