### PR TITLE
Fixed weights to make two missing AI docs show up

### DIFF
--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-ai/dotnet-ai-conversation-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-ai/dotnet-ai-conversation-howto.md
@@ -2,7 +2,7 @@
 type: docs
 title: "How to: Create and use Dapr AI Conversations in the .NET SDK"
 linkTitle: "How to: Use the AI Conversations client"
-weight: 500100
+weight: 50010
 description: Learn how to create and use the Dapr Conversational AI client using the .NET SDK
 ---
 

--- a/daprdocs/content/en/dotnet-sdk-docs/dotnet-ai/dotnet-ai-extensions-howto.md
+++ b/daprdocs/content/en/dotnet-sdk-docs/dotnet-ai/dotnet-ai-extensions-howto.md
@@ -2,7 +2,7 @@
 type: docs
 title: "How to: Using Microsoft's AI extensions with Dapr's .NET Conversation SDK"
 linkTitle: "How to: Use Microsoft's AI extensions with Dapr"
-weight: 500200
+weight: 50020
 description: Learn how to create and use Dapr with Microsoft's AI extensions
 ---
 


### PR DESCRIPTION
# Description

Some of the weights for AI docs included an extra zero putting them out of range to display. This should fix this.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [X] Extended the documentation
