### PR TITLE
feat(pubsub): add support for subscription names to enable multiple s…

### DIFF
--- a/examples/AspNetCore/ControllerSample/Controllers/SampleController.cs
+++ b/examples/AspNetCore/ControllerSample/Controllers/SampleController.cs
@@ -294,4 +294,30 @@ public class SampleController : ControllerBase
     {
         return Ok();
     }
+
+    /// <summary>
+    /// Example demonstrating multiple subscriptions to the same topic using subscription names.
+    /// This handler processes deposits for accounting purposes.
+    /// </summary>
+    [Topic("pubsub", "multisub-deposit", subscriptionName: "deposit-accounting-subscription")]
+    [HttpPost("multisub/deposit/accounting")]
+    public ActionResult<Account> MultiSubDepositAccounting(Transaction transaction)
+    {
+        logger.LogInformation("Accounting handler: Processing deposit {Id} for amount {Amount}",
+            transaction.Id, transaction.Amount);
+        return Ok(new { handler = "accounting", transactionId = transaction.Id });
+    }
+
+    /// <summary>
+    /// Example demonstrating multiple subscriptions to the same topic using subscription names.
+    /// This handler processes deposits for notification purposes.
+    /// </summary>
+    [Topic("pubsub", "multisub-deposit", subscriptionName: "deposit-notification-subscription")]
+    [HttpPost("multisub/deposit/notifications")]
+    public ActionResult<Account> MultiSubDepositNotifications(Transaction transaction)
+    {
+        logger.LogInformation("Notification handler: Processing deposit {Id} for amount {Amount}",
+            transaction.Id, transaction.Amount);
+        return Ok(new { handler = "notifications", transactionId = transaction.Id });
+    }
 }

--- a/examples/AspNetCore/ControllerSample/CustomTopicAttribute.cs
+++ b/examples/AspNetCore/ControllerSample/CustomTopicAttribute.cs
@@ -41,4 +41,7 @@ public class CustomTopicAttribute : Attribute, ITopicMetadata
 
     /// <inheritdoc/>
     public int Priority { get; }
+
+    /// <inheritdoc/>
+    public string SubscriptionName { get; }
 }

--- a/src/Dapr.AspNetCore/ITopicMetadata.cs
+++ b/src/Dapr.AspNetCore/ITopicMetadata.cs
@@ -37,4 +37,11 @@ public interface ITopicMetadata
     /// The priority in which this rule should be evaluated (lower to higher).
     /// </summary>
     int Priority { get; }
+
+    /// <summary>
+    /// Gets the subscription name. This is optional and allows multiple subscriptions
+    /// to the same topic within a single application. If not specified, the subscription
+    /// is identified by the combination of PubsubName and topic Name.
+    /// </summary>
+    string SubscriptionName { get; }
 }

--- a/src/Dapr.AspNetCore/Subscription.cs
+++ b/src/Dapr.AspNetCore/Subscription.cs
@@ -44,7 +44,7 @@ internal class Subscription
     /// Gets or sets the metadata.
     /// </summary>
     public Metadata Metadata { get; set; }
-        
+
     /// <summary>
     /// Gets or sets the deadletter topic.
     /// </summary>
@@ -54,6 +54,12 @@ internal class Subscription
     /// Gets or sets the bulk subscribe options.
     /// </summary>
     public DaprTopicBulkSubscribe BulkSubscribe { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subscription name. This is optional and allows multiple subscriptions
+    /// to the same topic within a single application.
+    /// </summary>
+    public string Name { get; set; }
 }
 
 /// <summary>

--- a/src/Dapr.AspNetCore/TopicAttribute.cs
+++ b/src/Dapr.AspNetCore/TopicAttribute.cs
@@ -28,7 +28,8 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
     /// <param name="name">The topic name.</param>
     /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
     /// <param name="metadataSeparator">Separator to use for metadata.</param>
-    public TopicAttribute(string pubsubName, string name, string[] ownedMetadatas = null, string metadataSeparator = null)
+    /// <param name="subscriptionName">The subscription name (optional). Allows multiple subscriptions to the same topic.</param>
+    public TopicAttribute(string pubsubName, string name, string[] ownedMetadatas = null, string metadataSeparator = null, string subscriptionName = null)
     {
         ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
         ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -37,6 +38,7 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
         this.PubsubName = pubsubName;
         this.OwnedMetadatas = ownedMetadatas;
         this.MetadataSeparator = metadataSeparator;
+        this.SubscriptionName = subscriptionName;
     }
 
     /// <summary>
@@ -47,7 +49,8 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
     /// <param name="enableRawPayload">The enable/disable raw pay load flag.</param>
     /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
     /// <param name="metadataSeparator">Separator to use for metadata.</param>
-    public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string[] ownedMetadatas = null, string metadataSeparator = null)
+    /// <param name="subscriptionName">The subscription name (optional). Allows multiple subscriptions to the same topic.</param>
+    public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string[] ownedMetadatas = null, string metadataSeparator = null, string subscriptionName = null)
     {
         ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
         ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -57,6 +60,7 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
         this.EnableRawPayload = enableRawPayload;
         this.OwnedMetadatas = ownedMetadatas;
         this.MetadataSeparator = metadataSeparator;
+        this.SubscriptionName = subscriptionName;
     }
 
     /// <summary>
@@ -68,7 +72,8 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
     /// <param name="priority">The priority of the rule (low-to-high values).</param>
     /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
     /// <param name="metadataSeparator">Separator to use for metadata.</param>
-    public TopicAttribute(string pubsubName, string name, string match, int priority, string[] ownedMetadatas = null, string metadataSeparator = null)
+    /// <param name="subscriptionName">The subscription name (optional). Allows multiple subscriptions to the same topic.</param>
+    public TopicAttribute(string pubsubName, string name, string match, int priority, string[] ownedMetadatas = null, string metadataSeparator = null, string subscriptionName = null)
     {
         ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
         ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -79,6 +84,7 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
         this.Priority = priority;
         this.OwnedMetadatas = ownedMetadatas;
         this.MetadataSeparator = metadataSeparator;
+        this.SubscriptionName = subscriptionName;
     }
 
     /// <summary>
@@ -91,7 +97,8 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
     /// <param name="priority">The priority of the rule (low-to-high values).</param>
     /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
     /// <param name="metadataSeparator">Separator to use for metadata.</param>
-    public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string match, int priority, string[] ownedMetadatas = null, string metadataSeparator = null)
+    /// <param name="subscriptionName">The subscription name (optional). Allows multiple subscriptions to the same topic.</param>
+    public TopicAttribute(string pubsubName, string name, bool enableRawPayload, string match, int priority, string[] ownedMetadatas = null, string metadataSeparator = null, string subscriptionName = null)
     {
         ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
         ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -103,6 +110,7 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
         this.Priority = priority;
         this.OwnedMetadatas = ownedMetadatas;
         this.MetadataSeparator = metadataSeparator;
+        this.SubscriptionName = subscriptionName;
     }
 
     /// <summary>
@@ -114,7 +122,8 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
     /// <param name="enableRawPayload">The enable/disable raw pay load flag.</param>
     /// <param name="ownedMetadatas">The topic owned metadata ids.</param>
     /// <param name="metadataSeparator">Separator to use for metadata.</param>
-    public TopicAttribute(string pubsubName, string name, string deadLetterTopic, bool enableRawPayload, string[] ownedMetadatas = null, string metadataSeparator = null)
+    /// <param name="subscriptionName">The subscription name (optional). Allows multiple subscriptions to the same topic.</param>
+    public TopicAttribute(string pubsubName, string name, string deadLetterTopic, bool enableRawPayload, string[] ownedMetadatas = null, string metadataSeparator = null, string subscriptionName = null)
     {
         ArgumentVerifier.ThrowIfNullOrEmpty(pubsubName, nameof(pubsubName));
         ArgumentVerifier.ThrowIfNullOrEmpty(name, nameof(name));
@@ -125,6 +134,7 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
         this.EnableRawPayload = enableRawPayload;
         this.OwnedMetadatas = ownedMetadatas;
         this.MetadataSeparator = metadataSeparator;
+        this.SubscriptionName = subscriptionName;
     }
 
     /// <inheritdoc/>
@@ -150,4 +160,7 @@ public class TopicAttribute : Attribute, ITopicMetadata, IRawTopicMetadata, IOwn
 
     /// <inheritdoc/>
     public string DeadLetterTopic { get; set; }
+
+    /// <inheritdoc/>
+    public string SubscriptionName { get; set; }
 }

--- a/test/Dapr.AspNetCore.IntegrationTest.App/CustomTopicAttribute.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/CustomTopicAttribute.cs
@@ -30,4 +30,6 @@ public class CustomTopicAttribute : Attribute, ITopicMetadata
     public new string Match { get; }
 
     public int Priority { get; }
+
+    public string SubscriptionName { get; }
 }

--- a/test/Dapr.AspNetCore.IntegrationTest.App/DaprController.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest.App/DaprController.cs
@@ -170,4 +170,17 @@ public class DaprController : ControllerBase
     {
         return user;
     }
+
+    // Test subscription names - multiple subscriptions to same topic
+    [Topic("pubsub", "H", subscriptionName: "subscription-h-1")]
+    [HttpPost("/H-Handler1")]
+    public void TopicHHandler1()
+    {
+    }
+
+    [Topic("pubsub", "H", subscriptionName: "subscription-h-2")]
+    [HttpPost("/H-Handler2")]
+    public void TopicHHandler2()
+    {
+    }
 }

--- a/test/Dapr.AspNetCore.IntegrationTest/SubscribeEndpointTest.cs
+++ b/test/Dapr.AspNetCore.IntegrationTest/SubscribeEndpointTest.cs
@@ -40,7 +40,7 @@ public class SubscribeEndpointTest
                 var json = await JsonSerializer.DeserializeAsync<JsonElement>(stream);
 
                 json.ValueKind.ShouldBe(JsonValueKind.Array);
-                json.GetArrayLength().ShouldBe(18);
+                json.GetArrayLength().ShouldBe(20);  // Updated from 18 to 20 to account for 2 new subscription name tests
 
                 var subscriptions = new List<(string PubsubName, string Topic, string Route, string rawPayload, 
                     string match, string metadata, string DeadLetterTopic, string bulkSubscribeMetadata)>();
@@ -131,6 +131,9 @@ public class SubscribeEndpointTest
                     "{\"enabled\":true,\"maxMessagesCount\":500,\"maxAwaitDurationMs\":2000}"));
                 subscriptions.ShouldContain(("pubsub", "splitMetadataTopicBuilder", "splitMetadataTopics", string.Empty, string.Empty, "n1=v1;n2=v1", string.Empty, String.Empty));
                 subscriptions.ShouldContain(("pubsub", "metadataseparatorbyemptytring", "topicmetadataseparatorattrbyemptytring", string.Empty, string.Empty, "n1=v1,", string.Empty, String.Empty));
+                // Test subscription names - multiple subscriptions to same topic
+                subscriptions.ShouldContain(("pubsub", "H", "H-Handler1", string.Empty, string.Empty, string.Empty, string.Empty, String.Empty));
+                subscriptions.ShouldContain(("pubsub", "H", "H-Handler2", string.Empty, string.Empty, string.Empty, string.Empty, String.Empty));
                 // Test priority route sorting
                 var eTopic = subscriptions.FindAll(e => e.Topic == "E");
                 eTopic.Count.ShouldBe(3);


### PR DESCRIPTION
#1656 

### The Issue

The Dapr .NET SDK currently does not support creating multiple subscriptions to the same topic within a single application using programmatic subscriptions (via the `/dapr/subscribe` endpoint). This limitation exists because:

1. **Subscriptions are uniquely identified only by `pubsubName + topic`** - There is no subscription name field
2. **Multiple handlers for the same topic are not supported** - Only the first endpoint is registered, others are ignored with an error
3. **The limitation only affects programmatic subscriptions** - Declarative subscriptions (YAML) support `metadata.name` but programmatic subscriptions do not

## Solution

Add subscription name support to allow multiple named subscriptions to the same topic within a single application.