### PR TITLE
Fix the workflow execution order

### DIFF
--- a/test/Dapr.Workflow.Test/Worker/Internal/WorkflowOrchestrationContextTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/Internal/WorkflowOrchestrationContextTests.cs
@@ -469,7 +469,7 @@ public class WorkflowOrchestrationContextTests
     }
 
     [Fact]
-    public async Task WaitForExternalEventAsync_ShouldReturnUncompletedTask_WhenEventInHistory()
+    public async Task WaitForExternalEventAsync_ShouldReturnCompletedTask_WhenEventInHistory()
     {
         var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
@@ -518,7 +518,7 @@ public class WorkflowOrchestrationContextTests
     }
 
     [Fact]
-    public async Task WaitForExternalEventAsync_WithTimeoutOverload_ShouldCancel_WhenEventReceived()
+    public async Task WaitForExternalEventAsync_WithTimeoutOverload_ShouldReturnCompletedTask_WhenEventReceived()
     {
         var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
 


### PR DESCRIPTION
# Description

First execute `workflow.RunAsync`, then execute `context.ProcessEvents`.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1683  

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
