### PR TITLE
Adding logging message indicating workflow gRPC stream has been established

### DIFF
--- a/src/Dapr.Workflow/Logging.cs
+++ b/src/Dapr.Workflow/Logging.cs
@@ -88,6 +88,9 @@ internal static partial class Logging
     [LoggerMessage(LogLevel.Information, "Starting gRPC bidirectional stream with Dapr sidecar")]
     public static partial void LogGrpcProtocolHandlerStartStream(this ILogger logger);
 
+    [LoggerMessage(LogLevel.Information, "Established gRPC bidirectional stream with Dapr sidecar")]
+    public static partial void LogGrpcProtocolHandlerStreamEstablished(this ILogger logger);
+
     [LoggerMessage(LogLevel.Information, "gRPC stream canceled")]
     public static partial void LogGrpcProtocolHandlerStreamCanceled(this ILogger logger);
 

--- a/src/Dapr.Workflow/Worker/Grpc/GrpcProtocolHandler.cs
+++ b/src/Dapr.Workflow/Worker/Grpc/GrpcProtocolHandler.cs
@@ -68,10 +68,12 @@ internal sealed class GrpcProtocolHandler(TaskHubSidecarService.TaskHubSidecarSe
                 // Establish the server streaming call
                 _streamingCall = _grpcClient.GetWorkItems(request, cancellationToken: token);
 
+                _logger.LogGrpcProtocolHandlerStreamEstablished();
+
                 // Process work items from the stream
                 await ReceiveLoopAsync(_streamingCall.ResponseStream, workflowHandler, activityHandler, token);
 
-                // Stream ended gracefully => tradfe as an interrupted and reconnect unless shutting down
+                // Stream ended gracefully => treat as an interrupted and reconnect unless shutting down
                 if (!token.IsCancellationRequested)
                 {
                     await DelayOrStopAsync(ReconnectDelay, token);


### PR DESCRIPTION
# Description

Added logging line after the gRPC stream has been established without error with the sidecar from the workflow SDK

Thanks to @olitomlinson for calling out the need for this one!

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
