### PR TITLE
Ensuring TFMs populate in Dapr.Workflow.Versioning package

### DIFF
--- a/src/Dapr.Workflow.Versioning/Dapr.Workflow.Versioning.csproj
+++ b/src/Dapr.Workflow.Versioning/Dapr.Workflow.Versioning.csproj
@@ -32,6 +32,15 @@
         <TargetsForPack>$(TargetsForPack);_BuildGeneratorOnce;_AddAnalyzer</TargetsForPack>
     </PropertyGroup>
 
+    <!-- Fail fast if TargetFrameworks from src/Directory.Build.props is not applied -->
+    <Target Name="_EnsureTargetFrameworks" BeforeTargets="Pack">
+        <PropertyGroup>
+            <_ExpectedDirectoryBuildProps>$(MSBuildProjectDirectory)\..\Directory.Build.props</_ExpectedDirectoryBuildProps>
+        </PropertyGroup>
+        <Error Condition="'$(TargetFrameworks)' == ''"
+               Text="TargetFrameworks is empty. This project relies on $(_ExpectedDirectoryBuildProps) for its TFM list. Ensure ImportDirectoryBuildProps is enabled and the file is imported." />
+    </Target>
+
     <ItemGroup>
         <!-- Build children but do NOT turn them into NuGet dependencies -->
         <ProjectReference Include="..\Dapr.Workflow.Versioning.Abstractions\Dapr.Workflow.Versioning.Abstractions.csproj"


### PR DESCRIPTION
# Description

Ensure that the TFMs are populated for Dapr.Workflow.Versioning NuGet package - validated locally.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
