### PR TITLE
Fixed invalid package reference

### DIFF
--- a/src/Dapr.Workflow.Versioning.Runtime/Dapr.Workflow.Versioning.Runtime.csproj
+++ b/src/Dapr.Workflow.Versioning.Runtime/Dapr.Workflow.Versioning.Runtime.csproj
@@ -14,7 +14,7 @@
     <ItemGroup>
         <ProjectReference Include="..\Dapr.Workflow.Versioning.Abstractions\Dapr.Workflow.Versioning.Abstractions.csproj" />
         <ProjectReference Include="..\Dapr.Workflow\Dapr.Workflow.csproj" />
-        <ProjectReference Include="..\Dapr.Workflow\Dapr.Workflow.Abstractions.csproj" />
+        <ProjectReference Include="..\Dapr.Workflow.Abstractions\Dapr.Workflow.Abstractions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Dapr.Workflow.Versioning/Dapr.Workflow.Versioning.csproj
+++ b/src/Dapr.Workflow.Versioning/Dapr.Workflow.Versioning.csproj
@@ -117,7 +117,7 @@
                  Targets="Build"
                  Properties="Configuration=$(Configuration);TargetFramework=netstandard2.0" />
 
-        <!-- Resolve TargetPath (respects your Directory.Build.props OutputPath) -->
+        <!-- Resolve TargetPath (respects the Directory.Build.props OutputPath) -->
         <MSBuild Condition="'$(_IsFirstTfm)' == 'true'"
                  Projects="..\Dapr.Workflow.Versioning.Generators\Dapr.Workflow.Versioning.Generators.csproj"
                  Targets="GetTargetPath"


### PR DESCRIPTION
# Description

The `Dapr.Workflow.Versioning` was reporting a build failure locally. Upon investigation, it's because the `Dapr.Workflow.Versioning.Runtime` had an invalid path reference to the `Dapr.Workflow.Abstractions` project, so this fixes the issue.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
