### PR TITLE
Added method to override gRPC message size in workflow client

### DIFF
--- a/test/Dapr.Workflow.Test/WorkflowServiceCollectionExtensionsTests.cs
+++ b/test/Dapr.Workflow.Test/WorkflowServiceCollectionExtensionsTests.cs
@@ -313,6 +313,20 @@ public class WorkflowServiceCollectionExtensionsTests
         Assert.Equal(lifetime, descriptor!.Lifetime);
     }
     
+    [Fact]
+    public void AddDaprWorkflowClient_ShouldResolve_GrpcTypedClient()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddDaprWorkflowClient();
+
+        var sp = services.BuildServiceProvider();
+        var grpcClient = sp.GetService<TaskHubSidecarService.TaskHubSidecarServiceClient>();
+
+        Assert.NotNull(grpcClient);
+    }
+    
     private sealed record SerializerDependency(string Value);
 
     private sealed class DependencyBasedSerializer(SerializerDependency dep) : IWorkflowSerializer


### PR DESCRIPTION
# Description

Added a method to override the default gRPC message send/receive sizes in the Workflow client. 

Big thank you to @iddelacruz for pointing out this feature oversight in Discord!

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
