### PR TITLE
Fix: API Token not recognized automatically from envvar during workflow registration

### DIFF
--- a/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
+++ b/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
@@ -165,6 +165,10 @@ public static class WorkflowServiceCollectionExtensions
         Action<IServiceProvider, DaprWorkflowClientBuilder>? configureClient,
         ServiceLifetime lifetime)
     {
+        // Validate that we have a valid service lifetime
+        if (lifetime is not (ServiceLifetime.Scoped or ServiceLifetime.Singleton or ServiceLifetime.Transient))
+            throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, "Invalid service lifetime");
+        
         // Configure workflow runtime options
         var options = new WorkflowRuntimeOptions();
         configure(options);
@@ -222,15 +226,8 @@ public static class WorkflowServiceCollectionExtensions
         // Register the workflow worker as a hosted service
         serviceCollection.AddHostedService<WorkflowWorker>();
 
-        // Register the workflow client - use builder pattern if custom configuration provided
-        if (configureClient != null)
-        {
-            RegisterWorkflowClientWithBuilder(serviceCollection, configureClient, lifetime);
-        }
-        else
-        {
-            RegisterWorkflowClient(serviceCollection, lifetime);
-        }
+        // Register the workflow client
+        RegisterWorkflowClientWithBuilder(serviceCollection, configureClient, lifetime);
     }
     
     private static void AddDaprWorkflowCore(IServiceCollection serviceCollection,
@@ -251,7 +248,7 @@ public static class WorkflowServiceCollectionExtensions
     
     private static void RegisterWorkflowClientWithBuilder(
         IServiceCollection serviceCollection,
-        Action<IServiceProvider, DaprWorkflowClientBuilder> configureClient,
+        Action<IServiceProvider, DaprWorkflowClientBuilder>? configureClient,
         ServiceLifetime lifetime)
     {
         var registration = new Func<IServiceProvider, DaprWorkflowClient>(provider =>
@@ -263,42 +260,12 @@ public static class WorkflowServiceCollectionExtensions
             builder.UseServiceProvider(provider);
 
             // Apply custom client configuration (endpoints, etc.)
-            configureClient(provider, builder);
+            configureClient?.Invoke(provider, builder);
 
             return builder.Build();
         });
 
         serviceCollection.Add(new ServiceDescriptor(typeof(DaprWorkflowClient), registration, lifetime));
-    }
-    
-    private static void RegisterWorkflowClient(IServiceCollection serviceCollection, ServiceLifetime lifetime)
-    {
-        switch (lifetime)
-        {
-            case ServiceLifetime.Singleton:
-                serviceCollection.TryAddSingleton<DaprWorkflowClient>(sp =>
-                {
-                    var inner = sp.GetRequiredService<WorkflowClient>();
-                    return new DaprWorkflowClient(inner);
-                });
-                break;
-            case ServiceLifetime.Scoped:
-                serviceCollection.TryAddScoped<DaprWorkflowClient>(sp =>
-                {
-                    var inner = sp.GetRequiredService<WorkflowClient>();
-                    return new DaprWorkflowClient(inner);
-                });
-                break;
-            case ServiceLifetime.Transient:
-                serviceCollection.TryAddTransient<DaprWorkflowClient>(sp =>
-                {
-                    var inner = sp.GetRequiredService<WorkflowClient>();
-                    return new DaprWorkflowClient(inner);
-                });
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(lifetime), lifetime, "Invalid service lifetime");
-        }
     }
     
     private static void ConfigureWorkflowGrpcMessageSizeLimits(

--- a/test/Dapr.Workflow.Test/WorkflowServiceCollectionExtensionsTests.cs
+++ b/test/Dapr.Workflow.Test/WorkflowServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Collections.Generic;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Abstractions;
 using Dapr.Workflow.Client;
@@ -7,6 +8,7 @@ using Dapr.Workflow.Worker;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Net.ClientFactory;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -325,6 +327,62 @@ public class WorkflowServiceCollectionExtensionsTests
         var grpcClient = sp.GetService<TaskHubSidecarService.TaskHubSidecarServiceClient>();
 
         Assert.NotNull(grpcClient);
+    }
+
+    [Fact]
+    public void AddDaprWorkflowBuilder_ShouldApplyDaprApiToken_FromConfiguration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddProvider(NullLoggerProvider.Instance));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DAPR_API_TOKEN"] = "workflow-test-token"
+            })
+            .Build();
+
+        services.AddSingleton<IConfiguration>(configuration);
+
+        string? observedToken = null;
+        services.AddDaprWorkflowBuilder(_ => { }, (_, builder) =>
+        {
+            observedToken = builder.DaprApiToken;
+        });
+
+        var sp = services.BuildServiceProvider();
+        _ = sp.GetRequiredService<DaprWorkflowClient>();
+
+        Assert.Equal("workflow-test-token", observedToken);
+    }
+
+    [Fact]
+    public void AddDaprWorkflowBuilder_ShouldApplyDaprApiToken_FromEnvironmentVariable()
+    {
+        var originalToken = Environment.GetEnvironmentVariable("DAPR_API_TOKEN");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("DAPR_API_TOKEN", "workflow-env-token");
+
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.AddProvider(NullLoggerProvider.Instance));
+
+            string? observedToken = null;
+            services.AddDaprWorkflowBuilder(_ => { }, (_, builder) =>
+            {
+                observedToken = builder.DaprApiToken;
+            });
+
+            var sp = services.BuildServiceProvider();
+            _ = sp.GetRequiredService<DaprWorkflowClient>();
+
+            Assert.Equal("workflow-env-token", observedToken);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DAPR_API_TOKEN", originalToken);
+        }
     }
     
     private sealed record SerializerDependency(string Value);


### PR DESCRIPTION
# Description

Simplified internal registration so that the API token is properly applied in all paths

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1729

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
