### PR TITLE
Adding support for keyed chat clients

### DIFF
--- a/src/Dapr.AI.Microsoft.Extensions/DaprChatClientExtensions.cs
+++ b/src/Dapr.AI.Microsoft.Extensions/DaprChatClientExtensions.cs
@@ -26,12 +26,104 @@ namespace Dapr.AI.Microsoft.Extensions;
 public static class DaprChatClientExtensions
 {
     /// <summary>
+    /// Registers a keyed <see cref="DaprChatClient"/> as a service that implements <see cref="IChatClient"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <param name="serviceKey">The key used to resolve the chat client.</param>
+    /// <param name="conversationComponentName">The name of the Dapr Conversation component.</param>
+    /// <param name="serviceLifetime">The <see cref="ServiceLifetime"/> of the service. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddDaprChatClient(
+        this IServiceCollection services,
+        string serviceKey,
+        string conversationComponentName,
+        ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+    {
+        ArgumentNullException.ThrowIfNull(services, nameof(services));
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceKey, nameof(serviceKey));
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationComponentName, nameof(conversationComponentName));
+
+        return AddKeyedDaprChatClient(services, serviceKey, options =>
+        {
+            options.ConversationComponentName = conversationComponentName;
+        }, serviceLifetime);
+    }
+
+    /// <summary>
+    /// Registers a keyed <see cref="DaprChatClient"/> as a service that implements <see cref="IChatClient"/>.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <param name="serviceKey">The key used to resolve the chat client.</param>
+    /// <param name="conversationComponentName">The name of the Dapr Conversation component.</param>
+    /// <param name="configure">An optional <see cref="Action{T}"/> to configure the <see cref="DaprChatClientOptions"/>.</param>
+    /// <param name="serviceLifetime">The <see cref="ServiceLifetime"/> of the service. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    public static IServiceCollection AddDaprChatClient(
+        this IServiceCollection services,
+        string serviceKey,
+        string conversationComponentName,
+        Action<DaprChatClientOptions>? configure,
+        ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+    {
+        ArgumentNullException.ThrowIfNull(services, nameof(services));
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceKey, nameof(serviceKey));
+        ArgumentException.ThrowIfNullOrWhiteSpace(conversationComponentName, nameof(conversationComponentName));
+
+        return AddKeyedDaprChatClient(services, serviceKey, options =>
+        {
+            options.ConversationComponentName = conversationComponentName;
+            configure?.Invoke(options);
+        }, serviceLifetime);
+    }
+
+    private static IServiceCollection AddKeyedDaprChatClient(
+        IServiceCollection services,
+        string serviceKey,
+        Action<DaprChatClientOptions> configure,
+        ServiceLifetime serviceLifetime)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceKey);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddOptions<DaprChatClientOptions>(serviceKey).Configure(configure);
+
+        static IChatClient Factory(IServiceProvider serviceProvider, string key)
+        {
+            var daprConversationClient = serviceProvider.GetRequiredService<DaprConversationClient>();
+            var optionsMonitor = serviceProvider.GetRequiredService<IOptionsMonitor<DaprChatClientOptions>>();
+            var options = optionsMonitor.Get(key);
+            return new DaprChatClient(daprConversationClient, serviceProvider, Options.Create(options));
+        }
+
+        switch (serviceLifetime)
+        {
+            case ServiceLifetime.Singleton:
+                services.AddKeyedSingleton<IChatClient>(serviceKey, (sp, _) => Factory(sp, serviceKey));
+                break;
+            case ServiceLifetime.Scoped:
+                services.AddKeyedScoped<IChatClient>(serviceKey, (sp, _) => Factory(sp, serviceKey));
+                break;
+            case ServiceLifetime.Transient:
+                services.AddKeyedTransient<IChatClient>(serviceKey, (sp, _) => Factory(sp, serviceKey));
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(serviceLifetime), serviceLifetime, "Unsupported service lifetime.");
+        }
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers <see cref="DaprChatClient"/> as a service that implements <see cref="IChatClient"/>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/>.</param>
     /// <param name="conversationComponentName">The name of the Dapr Conversation component.</param>
     /// <param name="serviceLifetime">The <see cref="ServiceLifetime"/> of the service. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <remarks>
+    /// This overload also registers a keyed <see cref="IChatClient"/> using the conversation component name as the key.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">
     /// Thrown at runtime if <see cref="DaprConversationClient"/> is not registered in the DI container.
     /// </exception>
@@ -40,10 +132,7 @@ public static class DaprChatClientExtensions
         ArgumentNullException.ThrowIfNull(services, nameof(services));
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationComponentName, nameof(conversationComponentName));
 
-        return services.AddDaprChatClient(options =>
-        {
-            options.ConversationComponentName = conversationComponentName;
-        }, serviceLifetime);
+        return services.AddDaprChatClient(conversationComponentName, configure: null, serviceLifetime);
     }
 
     /// <summary>
@@ -54,6 +143,9 @@ public static class DaprChatClientExtensions
     /// <param name="configure">An optional <see cref="Action{T}"/> to configure the <see cref="DaprChatClientOptions"/>.</param>
     /// <param name="serviceLifetime">The <see cref="ServiceLifetime"/> of the service. Defaults to <see cref="ServiceLifetime.Singleton"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+    /// <remarks>
+    /// This overload also registers a keyed <see cref="IChatClient"/> using the conversation component name as the key.
+    /// </remarks>
     /// <exception cref="InvalidOperationException">
     /// Thrown at runtime if <see cref="DaprConversationClient"/> is not registered in the DI container.
     /// </exception>
@@ -63,11 +155,14 @@ public static class DaprChatClientExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationComponentName);
 
-        return services.AddDaprChatClient(options =>
+        Action<DaprChatClientOptions> configureOptions = options =>
         {
             options.ConversationComponentName = conversationComponentName;
             configure?.Invoke(options);
-        }, serviceLifetime);
+        };
+
+        services.AddDaprChatClient(configureOptions, serviceLifetime);
+        return AddKeyedDaprChatClient(services, conversationComponentName, configureOptions, serviceLifetime);
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

While the `Dapr.AI.Microsoft.Extensions` has support for registering a `DaprChatClient`, this broadens that support to include keyed registrations (so more than one can be supported at a time).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
