### PR TITLE
use default constructor to register JsonWorkflowSerializer

### DIFF
--- a/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
+++ b/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
@@ -178,7 +178,7 @@ public static class WorkflowServiceCollectionExtensions
 
         // Register default JSON serializer if no custom serializer is registered
         serviceCollection.TryAddSingleton<IWorkflowSerializer>(
-            new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+            new JsonWorkflowSerializer());
 
         // Register the workflow factory
         serviceCollection.TryAddSingleton<IWorkflowsFactory>(sp =>


### PR DESCRIPTION
# Description

use default constructor to register JsonWorkflowSerializer

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[1757]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
