### PR TITLE
DevEx: Remove need to wrap GetWorkflowStateAsync for non-existent state

### DIFF
--- a/src/Dapr.Workflow/DaprWorkflowClient.cs
+++ b/src/Dapr.Workflow/DaprWorkflowClient.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Workflow.Client;
+using Grpc.Core;
 
 namespace Dapr.Workflow;
 
@@ -123,17 +124,27 @@ public sealed class DaprWorkflowClient : IDaprWorkflowClient
     /// </param>
     /// <param name="cancellation">Token to cancel the retrieval operation.</param>
     /// <returns>
-    /// A <see cref="WorkflowMetadata"/> object, or <c>null</c> if the workflow instance does not exist.
+    /// A <see cref="WorkflowState"/> if the workflow instance exists, or <c>null</c> if the instance does not
+    /// exist or an error occurs retrieving the metadata.
+    /// This method never throws.
     /// </returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="instanceId"/> is null or empty.</exception>
     public async Task<WorkflowState?> GetWorkflowStateAsync(
         string instanceId,
         bool getInputsAndOutputs = true,
         CancellationToken cancellation = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(instanceId);
-        var metadata = await _innerClient.GetWorkflowMetadataAsync(instanceId, getInputsAndOutputs, cancellation);
-        return metadata is null ? null : new WorkflowState(metadata);
+        
+        try
+        {
+            var metadata = await _innerClient.GetWorkflowMetadataAsync(instanceId, getInputsAndOutputs, cancellation);
+            return metadata is null ? null : new WorkflowState(metadata);    
+        }
+        catch (RpcException)
+        {
+            // If the state doesn't exist, we typically get an `RpcException`, so this wraps this and just returns null
+            return null;
+        }
     }
     
     /// <summary>

--- a/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
+++ b/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
@@ -74,13 +74,18 @@ public class DaprWorkflowClientTests
         Assert.Equal(new DateTimeOffset(start), inner.LastScheduleOptions.StartAt);
     }
 
-    [Fact]
-    public async Task GetWorkflowStateAsync_ShouldThrowArgumentException_WhenInstanceIdIsNullOrEmpty()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task GetWorkflowStateAsync_ShouldReturnNull_WhenInstanceIdIsNullOrEmpty(string? instanceId)
     {
         var inner = new CapturingWorkflowClient();
         var client = new DaprWorkflowClient(inner);
 
-        await Assert.ThrowsAsync<ArgumentException>(() => client.GetWorkflowStateAsync("", cancellation: TestContext.Current.CancellationToken));
+        var state = await client.GetWorkflowStateAsync(instanceId!, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Null(state);
+        Assert.Null(inner.LastGetMetadataInstanceId);
     }
 
     [Fact]
@@ -94,6 +99,17 @@ public class DaprWorkflowClientTests
         Assert.Null(state);
         Assert.Equal("missing", inner.LastGetMetadataInstanceId);
         Assert.True(inner.LastGetMetadataGetInputsAndOutputs);
+    }
+
+    [Fact]
+    public async Task GetWorkflowStateAsync_ShouldReturnNull_WhenInnerThrows()
+    {
+        var inner = new CapturingWorkflowClient { GetWorkflowMetadataException = new InvalidOperationException("RPC error") };
+        var client = new DaprWorkflowClient(inner);
+
+        var state = await client.GetWorkflowStateAsync("i", cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Null(state);
     }
 
     [Fact]
@@ -341,6 +357,7 @@ public class DaprWorkflowClientTests
         public string? LastGetMetadataInstanceId { get; private set; }
         public bool LastGetMetadataGetInputsAndOutputs { get; private set; }
         public WorkflowMetadata? GetWorkflowMetadataResult { get; set; }
+        public Exception? GetWorkflowMetadataException { get; set; }
 
         public string? LastWaitForStartInstanceId { get; private set; }
         public bool LastWaitForStartGetInputsAndOutputs { get; private set; }
@@ -405,6 +422,8 @@ public class DaprWorkflowClientTests
         {
             LastGetMetadataInstanceId = instanceId;
             LastGetMetadataGetInputsAndOutputs = getInputsAndOutputs;
+            if (GetWorkflowMetadataException is not null)
+                return Task.FromException<WorkflowMetadata?>(GetWorkflowMetadataException);
             return Task.FromResult(GetWorkflowMetadataResult);
         }
 

--- a/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
+++ b/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
@@ -13,6 +13,7 @@
 
 using System.Collections.ObjectModel;
 using Dapr.Workflow.Client;
+using Grpc.Core;
 
 namespace Dapr.Workflow.Test;
 
@@ -74,18 +75,13 @@ public class DaprWorkflowClientTests
         Assert.Equal(new DateTimeOffset(start), inner.LastScheduleOptions.StartAt);
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    public async Task GetWorkflowStateAsync_ShouldReturnNull_WhenInstanceIdIsNullOrEmpty(string? instanceId)
+    [Fact]
+    public async Task GetWorkflowStateAsync_ShouldThrowArgumentException_WhenInstanceIdIsNullOrEmpty()
     {
         var inner = new CapturingWorkflowClient();
         var client = new DaprWorkflowClient(inner);
 
-        var state = await client.GetWorkflowStateAsync(instanceId!, cancellation: TestContext.Current.CancellationToken);
-
-        Assert.Null(state);
-        Assert.Null(inner.LastGetMetadataInstanceId);
+        await Assert.ThrowsAsync<ArgumentException>(() => client.GetWorkflowStateAsync("", cancellation: TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -102,9 +98,12 @@ public class DaprWorkflowClientTests
     }
 
     [Fact]
-    public async Task GetWorkflowStateAsync_ShouldReturnNull_WhenInnerThrows()
+    public async Task GetWorkflowStateAsync_ShouldReturnNull_WhenInnerThrowsRpcException()
     {
-        var inner = new CapturingWorkflowClient { GetWorkflowMetadataException = new InvalidOperationException("RPC error") };
+        var inner = new CapturingWorkflowClient
+        {
+            GetWorkflowMetadataException = new RpcException(new Status(StatusCode.NotFound, "not found"))
+        };
         var client = new DaprWorkflowClient(inner);
 
         var state = await client.GetWorkflowStateAsync("i", cancellation: TestContext.Current.CancellationToken);


### PR DESCRIPTION
# Description

Wrapping RpcException thrown when the SDK fails to retrieve the workflow state to improve DevEx.

Thanks to @olitomlinson for the suggestion!

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
