### PR TITLE
Fix: Prevent race condition during GrpcProtocolHandler disposal

### DIFF
--- a/src/Dapr.Workflow/Worker/Grpc/GrpcProtocolHandler.cs
+++ b/src/Dapr.Workflow/Worker/Grpc/GrpcProtocolHandler.cs
@@ -47,6 +47,7 @@ internal sealed class GrpcProtocolHandler(
 
     private AsyncServerStreamingCall<WorkItem>? _streamingCall;
     private int _activeWorkItemCount;
+    private int _disposed;
 
     /// <summary>
     /// Starts the streaming connection with the Dapr sidecar.
@@ -372,12 +373,14 @@ internal sealed class GrpcProtocolHandler(
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        if (_disposalCts.IsCancellationRequested)
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
 
         _logger.LogGrpcProtocolHandlerDisposing();
 
-        await _disposalCts.CancelAsync();
+        try { await _disposalCts.CancelAsync(); }
+        catch (ObjectDisposedException) { }
+
         _streamingCall?.Dispose();
         _disposalCts.Dispose();
         _orchestrationSemaphore.Dispose();

--- a/test/Dapr.Workflow.Test/Worker/Grpc/GrpcProtocolHandlerTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/Grpc/GrpcProtocolHandlerTests.cs
@@ -254,6 +254,19 @@ public sealed class GrpcProtocolHandlerTests
         await handler.DisposeAsync();
         await handler.DisposeAsync();
     }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldNotThrow_WhenCalledConcurrently()
+    {
+        var grpcClientMock = CreateGrpcClientMock();
+        var handler = new GrpcProtocolHandler(grpcClientMock.Object, NullLoggerFactory.Instance);
+
+        // Fire both calls simultaneously so they race through the idempotency guard.
+        var t1 = handler.DisposeAsync().AsTask();
+        var t2 = handler.DisposeAsync().AsTask();
+
+        await Task.WhenAll(t1, t2);
+    }
     
     [Fact]
     public async Task StartAsync_ShouldSendGetWorkItemsRequest_WithConfiguredConcurrencyLimits()


### PR DESCRIPTION
# Description

Preventing race condition in `DisposeAsync` of GrpcProtocolHandler to prevent unhandled exception

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1797 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
