### PR TITLE
Refactoring serializer from Dapr.Workflow to Dapr.Common

### DIFF
--- a/src/Dapr.Common/Serialization/IDaprSerializer.cs
+++ b/src/Dapr.Common/Serialization/IDaprSerializer.cs
@@ -1,0 +1,59 @@
+// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  ------------------------------------------------------------------------
+
+namespace Dapr.Common.Serialization;
+
+/// <summary>
+/// Provides serialization and deserialization services for Dapr data payloads.
+/// </summary>
+/// <remarks>
+/// Implementations of this interface are responsible for converting objects to and from string representations.
+/// The default implementation uses System.Text.Json, but custom implementations can use any serialization
+/// format (Protobuf, MessagePack, XML, etc.).
+/// </remarks>
+public interface IDaprSerializer
+{
+    /// <summary>
+    /// Serializes an object to a string representation.
+    /// </summary>
+    /// <param name="value">The object to serialize. Can be null.</param>
+    /// <param name="inputType">
+    /// Optional type hint for the object being serialized. Some serializers may use this for better type fidelity.
+    /// If null, the serializer should use the runtime type of <paramref name="value"/>.
+    /// </param>
+    /// <returns>
+    /// A string representation of the object. Returns an empty string if <paramref name="value"/> is null.
+    /// </returns>
+    string Serialize(object? value, Type? inputType = null);
+
+    /// <summary>
+    /// Deserializes a string to an object of the specified type.
+    /// </summary>
+    /// <typeparam name="T">The target type to deserialize to.</typeparam>
+    /// <param name="data">The string data to deserialize. Can be null or empty.</param>
+    /// <returns>
+    /// The deserialized object of type <typeparamref name="T"/>, or <c>default(T)</c> if <paramref name="data"/> is null or empty.
+    /// </returns>
+    T? Deserialize<T>(string? data);
+
+    /// <summary>
+    /// Deserializes a string to an object of the specified type.
+    /// </summary>
+    /// <param name="data">The string data to deserialize. Can be null or empty.</param>
+    /// <param name="returnType">The target type to deserialize to.</param>
+    /// <returns>
+    /// The deserialized object, or <c>null</c> if <paramref name="data"/> is null or empty.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="returnType"/> is null.</exception>
+    object? Deserialize(string? data, Type returnType);
+}

--- a/src/Dapr.Common/Serialization/JsonDaprSerializer.cs
+++ b/src/Dapr.Common/Serialization/JsonDaprSerializer.cs
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  ------------------------------------------------------------------------
+
+using System.Text.Json;
+
+namespace Dapr.Common.Serialization;
+
+/// <summary>
+/// JSON-based implementation of <see cref="IDaprSerializer"/> using System.Text.Json.
+/// </summary>
+public class JsonDaprSerializer : IDaprSerializer
+{
+    private readonly JsonSerializerOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonDaprSerializer"/> class with default JSON options.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="JsonSerializerDefaults.Web"/> which provides camelCase naming and other web-friendly defaults.
+    /// Also enables <see cref="JsonSerializerOptions.IncludeFields"/> for compatibility with field-based types.
+    /// </remarks>
+    public JsonDaprSerializer() : this(new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        IncludeFields = true // https://github.com/dapr/dotnet-sdk/issues/1757
+    })
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonDaprSerializer"/> class with custom JSON options.
+    /// </summary>
+    /// <param name="options">The JSON serializer options to use for all serialization operations.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
+    public JsonDaprSerializer(JsonSerializerOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public string Serialize(object? value, Type? inputType = null)
+    {
+        if (value is null)
+            return string.Empty;
+
+        return inputType is not null
+            ? JsonSerializer.Serialize(value, inputType, _options)
+            : JsonSerializer.Serialize(value, _options);
+    }
+
+    /// <inheritdoc />
+    public T? Deserialize<T>(string? data) => string.IsNullOrEmpty(data) ? default : JsonSerializer.Deserialize<T>(data, _options);
+
+    /// <inheritdoc />
+    public object? Deserialize(string? data, Type returnType)
+    {
+        ArgumentNullException.ThrowIfNull(returnType);
+
+        return string.IsNullOrEmpty(data) ? null : JsonSerializer.Deserialize(data, returnType, _options);
+    }
+}

--- a/src/Dapr.Workflow/Client/ProtoConverters.cs
+++ b/src/Dapr.Workflow/Client/ProtoConverters.cs
@@ -12,8 +12,8 @@
 // ------------------------------------------------------------------------
 
 using System;
+using Dapr.Common.Serialization;
 using Dapr.DurableTask.Protobuf;
-using Dapr.Workflow.Serialization;
 
 namespace Dapr.Workflow.Client;
 
@@ -25,7 +25,7 @@ internal static class ProtoConverters
     /// <summary>
     /// Converts proto <see cref="OrchestrationState"/> to <see cref="WorkflowMetadata"/>.
     /// </summary>
-    public static WorkflowMetadata ToWorkflowMetadata(OrchestrationState state, IWorkflowSerializer serializer) =>
+    public static WorkflowMetadata ToWorkflowMetadata(OrchestrationState state, IDaprSerializer serializer) =>
         new(state.InstanceId, state.Name, ToRuntimeStatus(state.OrchestrationStatus),
             state.CreatedTimestamp?.ToDateTime() ?? DateTime.MinValue,
             state.LastUpdatedTimestamp?.ToDateTime() ?? DateTime.MinValue, serializer)

--- a/src/Dapr.Workflow/Client/RetryInterceptor.cs
+++ b/src/Dapr.Workflow/Client/RetryInterceptor.cs
@@ -2,8 +2,6 @@
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Dapr.Workflow;
-using Dapr.Workflow.Worker.Internal;
 
 namespace Dapr.Workflow.Client;
 

--- a/src/Dapr.Workflow/Client/WorkflowGrpcClient.cs
+++ b/src/Dapr.Workflow/Client/WorkflowGrpcClient.cs
@@ -17,7 +17,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Common;
-using Dapr.Workflow.Serialization;
+using Dapr.Common.Serialization;
 using Grpc.Core;
 using grpc = Dapr.DurableTask.Protobuf;
 using Microsoft.Extensions.Logging;
@@ -30,7 +30,7 @@ namespace Dapr.Workflow.Client;
 internal sealed class WorkflowGrpcClient(
     grpc.TaskHubSidecarService.TaskHubSidecarServiceClient grpcClient,
     ILogger<WorkflowGrpcClient> logger,
-    IWorkflowSerializer serializer,
+    IDaprSerializer serializer,
     string? daprApiToken = null) : WorkflowClient
 {
     /// <inheritdoc />

--- a/src/Dapr.Workflow/Client/WorkflowMetadata.cs
+++ b/src/Dapr.Workflow/Client/WorkflowMetadata.cs
@@ -12,7 +12,7 @@
 // ------------------------------------------------------------------------
 
 using System;
-using Dapr.Workflow.Serialization;
+using Dapr.Common.Serialization;
 
 namespace Dapr.Workflow.Client;
 
@@ -31,7 +31,7 @@ internal sealed record WorkflowMetadata(
     WorkflowRuntimeStatus RuntimeStatus,
     DateTime CreatedAt,
     DateTime LastUpdatedAt,
-    IWorkflowSerializer Serializer)
+    IDaprSerializer Serializer)
 {
     /// <summary>
     /// Gets the serialized input of the workflow, if available.

--- a/src/Dapr.Workflow/Registration/DaprWorkflowClientBuilder.cs
+++ b/src/Dapr.Workflow/Registration/DaprWorkflowClientBuilder.cs
@@ -14,6 +14,7 @@
 using System;
 using System.Text.Json;
 using Dapr.Common;
+using Dapr.Common.Serialization;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Client;
 using Dapr.Workflow.Serialization;
@@ -29,7 +30,7 @@ namespace Dapr.Workflow.Registration;
 /// </summary>
 public sealed class DaprWorkflowClientBuilder(IConfiguration? configuration = null) : DaprGenericClientBuilder<DaprWorkflowClient>(configuration)
 {
-    private IWorkflowSerializer? _serializer;
+    private IDaprSerializer? _serializer;
     private IServiceProvider? _serviceProvider;
     private Func<IServiceProvider, IWorkflowSerializer>? _serializerFactory;
     
@@ -38,7 +39,7 @@ public sealed class DaprWorkflowClientBuilder(IConfiguration? configuration = nu
     /// </summary>
     /// <param name="serializer">The custom serializer instance to use.</param>
     /// <returns>The <see cref="DaprWorkflowClientBuilder" /> instance.</returns>
-    public DaprWorkflowClientBuilder UseSerializer(IWorkflowSerializer serializer)
+    public DaprWorkflowClientBuilder UseSerializer(IDaprSerializer serializer)
     {
         ArgumentNullException.ThrowIfNull(serializer);
         _serializer = serializer;
@@ -67,7 +68,7 @@ public sealed class DaprWorkflowClientBuilder(IConfiguration? configuration = nu
     public DaprWorkflowClientBuilder UseJsonSerializer(JsonSerializerOptions jsonOptions)
     {
         ArgumentNullException.ThrowIfNull(jsonOptions);
-        return UseSerializer(new JsonWorkflowSerializer(jsonOptions));
+        return UseSerializer(new JsonDaprSerializer(jsonOptions));
     }
 
     /// <summary>
@@ -107,7 +108,7 @@ public sealed class DaprWorkflowClientBuilder(IConfiguration? configuration = nu
         }
         
         // Resolve serializer
-        IWorkflowSerializer serializer;
+        IDaprSerializer serializer;
         if (_serializer is not null)
         {
             serializer = _serializer;
@@ -116,7 +117,7 @@ public sealed class DaprWorkflowClientBuilder(IConfiguration? configuration = nu
         {
             serializer = _serializerFactory is not null && _serviceProvider is not null
                 ? _serializerFactory(_serviceProvider)
-                : new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+                : new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         }
         
         // Resolve logger

--- a/src/Dapr.Workflow/Serialization/IWorkflowSerializer.cs
+++ b/src/Dapr.Workflow/Serialization/IWorkflowSerializer.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 // Copyright 2025 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // limitations under the License.
 //  ------------------------------------------------------------------------
 
-using System;
+using Dapr.Common.Serialization;
 
 namespace Dapr.Workflow.Serialization;
 
@@ -23,39 +23,6 @@ namespace Dapr.Workflow.Serialization;
 /// for transmission between workflows, activities, and the Dapr sidecar. The default implementation uses
 /// System.Text.Json, but custom implementations can use any serialization format (Protobuf, MessagePack, XML, etc.).
 /// </remarks>
-public interface IWorkflowSerializer
+public interface IWorkflowSerializer : IDaprSerializer
 {
-    /// <summary>
-    /// Serializes an object to a string representation.
-    /// </summary>
-    /// <param name="value">The object to serialize. Can be null.</param>
-    /// <param name="inputType">
-    /// Optional type hint for the object being serialized. Some serializers may use this for better type fidelity.
-    /// If null, the serializer should use the runtime type of <paramref name="value"/>.
-    /// </param>
-    /// <returns>
-    /// A string representation of the object. Returns an empty string if <paramref name="value"/> is null.
-    /// </returns>
-    string Serialize(object? value, Type? inputType = null);
-    
-    /// <summary>
-    /// Deserializes a string to an object of the specified type.
-    /// </summary>
-    /// <typeparam name="T">The target type to deserialize to.</typeparam>
-    /// <param name="data">The string data to deserialize. Can be null or empty.</param>
-    /// <returns>
-    /// The deserialized object of type <typeparamref name="T"/>, or <c>default(T)</c> if <paramref name="data"/> is null or empty.
-    /// </returns>
-    T? Deserialize<T>(string? data);
-    
-    /// <summary>
-    /// Deserializes a string to an object of the specified type.
-    /// </summary>
-    /// <param name="data">The string data to deserialize. Can be null or empty.</param>
-    /// <param name="returnType">The target type to deserialize to.</param>
-    /// <returns>
-    /// The deserialized object, or <c>null</c> if <paramref name="data"/> is null or empty.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="returnType"/> is null.</exception>
-    object? Deserialize(string? data, Type returnType);
 }

--- a/src/Dapr.Workflow/Serialization/JsonWorkflowSerializer.cs
+++ b/src/Dapr.Workflow/Serialization/JsonWorkflowSerializer.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------
+// ------------------------------------------------------------------------
 // Copyright 2025 The Dapr Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,59 +13,33 @@
 
 using System;
 using System.Text.Json;
+using Dapr.Common.Serialization;
 
 namespace Dapr.Workflow.Serialization;
 
 /// <summary>
 /// JSON-based implementation of <see cref="IWorkflowSerializer"/> using System.Text.Json.
 /// </summary>
-public sealed class JsonWorkflowSerializer : IWorkflowSerializer
+/// <remarks>
+/// This class extends <see cref="JsonDaprSerializer"/> from <c>Dapr.Common</c> and exists for
+/// backward compatibility. New code should prefer <see cref="JsonDaprSerializer"/> directly.
+/// </remarks>
+[Obsolete("The JsonWorkflowSerializer has been deprecated in favor of Dapr.Common.JsonDaprSerializer and will be removed with the SDK release coinciding with the release of the Dapr v1.20 runtime.")]
+public sealed class JsonWorkflowSerializer : JsonDaprSerializer, IWorkflowSerializer
 {
-    private readonly JsonSerializerOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonWorkflowSerializer"/> class with default JSON options.
     /// </summary>
-    /// <remarks>
-    /// Uses <see cref="JsonSerializerDefaults.Web"/> which provides camelCase naming and other web-friendly defaults.
-    /// </remarks>
-    public JsonWorkflowSerializer() : this(new JsonSerializerOptions(JsonSerializerDefaults.Web)
-    {
-        IncludeFields = true // https://github.com/dapr/dotnet-sdk/issues/1757
-    })
+    public JsonWorkflowSerializer()
     {
     }
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonWorkflowSerializer"/> class with custom JSON options.
     /// </summary>
     /// <param name="options">The JSON serializer options to use for all serialization operations.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> is null.</exception>
-    public JsonWorkflowSerializer(JsonSerializerOptions options)
+    public JsonWorkflowSerializer(JsonSerializerOptions options) : base(options)
     {
-        _options = options ?? throw new ArgumentNullException(nameof(options));
-    }
-    
-    /// <inheritdoc />
-    public string Serialize(object? value, Type? inputType = null)
-    {
-        if (value is null)
-            return string.Empty;
-
-        // Use provided type hint for better serialization fidelity
-        return inputType is not null 
-            ? JsonSerializer.Serialize(value, inputType, _options) 
-            : JsonSerializer.Serialize(value, _options);
-    }
-
-    /// <inheritdoc />
-    public T? Deserialize<T>(string? data) => string.IsNullOrEmpty(data) ? default : JsonSerializer.Deserialize<T>(data, _options);
-
-    /// <inheritdoc />
-    public object? Deserialize(string? data, Type returnType)
-    {
-        ArgumentNullException.ThrowIfNull(returnType);
-        
-        return string.IsNullOrEmpty(data) ? null : JsonSerializer.Deserialize(data, returnType, _options);
     }
 }

--- a/src/Dapr.Workflow/Worker/Internal/WorkflowOrchestrationContext.cs
+++ b/src/Dapr.Workflow/Worker/Internal/WorkflowOrchestrationContext.cs
@@ -17,6 +17,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Dapr.Common.Serialization;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Client;
 using Dapr.Workflow.Serialization;
@@ -49,7 +50,7 @@ internal sealed class WorkflowOrchestrationContext : WorkflowContext
     private readonly Dictionary<int, string> _taskIdToExecutionId = [];
     private readonly Dictionary<string, int> _executionIdToTaskId = new(StringComparer.Ordinal);
     private readonly SortedDictionary<int, OrchestratorAction> _pendingActions = [];
-    private readonly IWorkflowSerializer _workflowSerializer;
+    private readonly IDaprSerializer _workflowSerializer;
     private readonly ILogger<WorkflowOrchestrationContext> _logger;
     private readonly ILoggerFactory _loggerFactory;
     // Maps runtime sub-orchestration created EventId -> parent action/task id (our local task id).
@@ -79,7 +80,7 @@ internal sealed class WorkflowOrchestrationContext : WorkflowContext
     private bool _preserveUnprocessedEvents;
 
     public WorkflowOrchestrationContext(string name, string instanceId, DateTime currentUtcDateTime,
-        IWorkflowSerializer workflowSerializer, ILoggerFactory loggerFactory, WorkflowVersionTracker versionTracker,
+        IDaprSerializer workflowSerializer, ILoggerFactory loggerFactory, WorkflowVersionTracker versionTracker,
         string? appId = null, string? executionId = null)
     {
         _workflowSerializer = workflowSerializer;

--- a/src/Dapr.Workflow/Worker/WorkflowWorker.cs
+++ b/src/Dapr.Workflow/Worker/WorkflowWorker.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Common;
+using Dapr.Common.Serialization;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Abstractions;
 using Dapr.Workflow.Serialization;
@@ -38,8 +39,8 @@ internal sealed class WorkflowWorker(
     TaskHubSidecarService.TaskHubSidecarServiceClient grpcClient, 
     IWorkflowsFactory workflowsFactory, 
     ILoggerFactory loggerFactory, 
-    IWorkflowSerializer workflowSerializer, 
-    IServiceProvider serviceProvider, 
+    IDaprSerializer workflowSerializer,
+    IServiceProvider serviceProvider,
     WorkflowRuntimeOptions options,
     IConfiguration? configuration = null) : BackgroundService
 {
@@ -48,7 +49,7 @@ internal sealed class WorkflowWorker(
     private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     private readonly ILogger<WorkflowWorker> _logger = loggerFactory.CreateLogger<WorkflowWorker>() ?? throw new ArgumentNullException(nameof(loggerFactory));
     private readonly WorkflowRuntimeOptions _options = options ?? throw new ArgumentNullException(nameof(options));
-    private readonly IWorkflowSerializer _serializer = workflowSerializer ?? throw new ArgumentNullException(nameof(workflowSerializer));
+    private readonly IDaprSerializer _serializer = workflowSerializer ?? throw new ArgumentNullException(nameof(workflowSerializer));
     private readonly string? _daprApiToken = DaprDefaults.GetDefaultDaprApiToken(configuration);
     
     private GrpcProtocolHandler? _protocolHandler;

--- a/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
+++ b/src/Dapr.Workflow/WorkflowServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@
 
 using System;
 using System.Text.Json;
+using Dapr.Common.Serialization;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Client;
 using Dapr.Workflow.Grpc.Extensions;
@@ -45,16 +46,16 @@ public static class WorkflowServiceCollectionExtensions
         public IServiceCollection Services { get; }
 
         /// <summary>
-        /// Configures a custom workflow serializer to replace the default JSON serializer. 
+        /// Configures a custom workflow serializer to replace the default JSON serializer.
         /// </summary>
         /// <param name="serializer">The custom serializer instance to use.</param>
-        public DaprWorkflowBuilder WithSerializer(IWorkflowSerializer serializer)
+        public DaprWorkflowBuilder WithSerializer(IDaprSerializer serializer)
         {
             ArgumentNullException.ThrowIfNull(serializer);
-            Services.Replace(ServiceDescriptor.Singleton(typeof(IWorkflowSerializer), serializer));
+            Services.Replace(ServiceDescriptor.Singleton(typeof(IDaprSerializer), serializer));
             return this;
         }
-        
+
         /// <summary>
         /// Configures gRPC message size limits for the workflow sidecar client.
         /// </summary>
@@ -74,18 +75,18 @@ public static class WorkflowServiceCollectionExtensions
         {
             ArgumentNullException.ThrowIfNull(serializerFactory);
 
-            Services.Replace(ServiceDescriptor.Singleton(typeof(IWorkflowSerializer), serializerFactory));
+            Services.Replace(ServiceDescriptor.Singleton(typeof(IDaprSerializer), serializerFactory));
             return this;
         }
 
         /// <summary>
-        /// Configures the default System.Text.Json serializer with custom options. 
+        /// Configures the default System.Text.Json serializer with custom options.
         /// </summary>
         /// <param name="jsonOptions">The JSON serializer options to use.</param>
         public DaprWorkflowBuilder WithJsonSerializer(JsonSerializerOptions jsonOptions)
         {
             ArgumentNullException.ThrowIfNull(jsonOptions);
-            return WithSerializer(new JsonWorkflowSerializer(jsonOptions));
+            return WithSerializer(new JsonDaprSerializer(jsonOptions));
         }
     }
     
@@ -176,9 +177,11 @@ public static class WorkflowServiceCollectionExtensions
         // Register options as a singleton as they don't change at runtime
         serviceCollection.AddSingleton(options);
 
-        // Register default JSON serializer if no custom serializer is registered
-        serviceCollection.TryAddSingleton<IWorkflowSerializer>(
-            new JsonWorkflowSerializer());
+        // Register the serializer. The factory first checks for a legacy IWorkflowSerializer
+        // registration (backward compat) and falls back to the default JsonDaprSerializer.
+#pragma warning disable CS0618
+        RegisterIWorkflowSerializerBackwardCompat(serviceCollection);
+#pragma warning restore CS0618
 
         // Register the workflow factory
         serviceCollection.TryAddSingleton<IWorkflowsFactory>(sp =>
@@ -200,7 +203,7 @@ public static class WorkflowServiceCollectionExtensions
             var configuration = sp.GetService<IConfiguration>();
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger<WorkflowGrpcClient>();
-            var serializer = sp.GetRequiredService<IWorkflowSerializer>();
+            var serializer = sp.GetRequiredService<IDaprSerializer>();
             var daprApiToken = DaprDefaults.GetDefaultDaprApiToken(configuration);
             return new WorkflowGrpcClient(grpcClient, logger, serializer, daprApiToken);
         });
@@ -324,5 +327,17 @@ public static class WorkflowServiceCollectionExtensions
         {
             ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value.Value, 0, paramName);
         }
+    }
+
+    /// <summary>
+    /// Registers a backward-compatibility bridge that forwards an <see cref="IWorkflowSerializer"/>
+    /// DI registration to <see cref="IDaprSerializer"/>, so consumers who registered their serializer
+    /// under the old interface are still honored without code changes.
+    /// </summary>
+    [Obsolete("Support for IWorkflowSerializer DI registration has been deprecated in favor of IDaprSerializer and will be removed with the SDK release coinciding with the release of the Dapr v1.20 runtime. Register your serializer as IDaprSerializer instead.")]
+    private static void RegisterIWorkflowSerializerBackwardCompat(IServiceCollection serviceCollection)
+    {
+        serviceCollection.TryAddSingleton<IDaprSerializer>(
+            sp => (IDaprSerializer?)sp.GetService<IWorkflowSerializer>() ?? new JsonDaprSerializer());
     }
 }

--- a/test/Dapr.Workflow.Test/Client/ProtoConvertersTests.cs
+++ b/test/Dapr.Workflow.Test/Client/ProtoConvertersTests.cs
@@ -14,6 +14,7 @@
 using System.Text.Json;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Client;
+using Dapr.Common.Serialization;
 using Dapr.Workflow.Serialization;
 using Google.Protobuf.WellKnownTypes;
 
@@ -51,7 +52,7 @@ public class ProtoConvertersTests
     [Fact]
     public void ToWorkflowMetadata_ShouldMapCoreFields_AndPreserveSerializerInstance()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
         var createdUtc = new DateTime(2025, 01, 02, 03, 04, 05, DateTimeKind.Utc);
         var updatedUtc = new DateTime(2025, 02, 03, 04, 05, 06, DateTimeKind.Utc);
@@ -86,7 +87,7 @@ public class ProtoConvertersTests
     [Fact]
     public void ToWorkflowMetadata_ShouldSetMinValueTimestamps_WhenProtoTimestampsAreNull()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var state = new OrchestrationState
         {
@@ -106,7 +107,7 @@ public class ProtoConvertersTests
     [Fact]
     public void ToWorkflowMetadata_ShouldSetSerializedFieldsToNull_WhenProtoStringsAreNullOrEmpty()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var state = new OrchestrationState
         {
@@ -128,7 +129,7 @@ public class ProtoConvertersTests
     [Fact]
     public void ToWorkflowMetadata_ShouldKeepSerializedFields_WhenProtoStringsContainWhitespace()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var state = new OrchestrationState
         {
@@ -150,7 +151,7 @@ public class ProtoConvertersTests
     [Fact]
     public void ToWorkflowMetadata_ShouldMapRuntimeStatus_UsingToRuntimeStatus()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var state = new OrchestrationState
         {

--- a/test/Dapr.Workflow.Test/Client/WorkflowGrpcClientTests.cs
+++ b/test/Dapr.Workflow.Test/Client/WorkflowGrpcClientTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Client;
+using Dapr.Common.Serialization;
 using Dapr.Workflow.Serialization;
 using Grpc.Core;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -127,7 +128,7 @@ public class WorkflowGrpcClientTests
     [Fact]
     public async Task GetWorkflowMetadataAsync_ShouldPassThroughGetInputsAndOutputsFlag()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         GetInstanceRequest? captured = null;
 
@@ -153,7 +154,7 @@ public class WorkflowGrpcClientTests
     [Fact]
     public async Task WaitForWorkflowStartAsync_ShouldReturnImmediately_WhenStatusIsNotPending()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
@@ -180,7 +181,7 @@ public class WorkflowGrpcClientTests
     [Fact]
     public async Task WaitForWorkflowStartAsync_ShouldThrowInvalidOperationException_WhenInstanceDoesNotExist()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
@@ -195,7 +196,7 @@ public class WorkflowGrpcClientTests
     [Fact]
     public async Task WaitForWorkflowCompletionAsync_ShouldReturnImmediately_WhenStatusIsTerminal()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
@@ -537,7 +538,7 @@ public class WorkflowGrpcClientTests
     [Fact]
     public async Task WaitForWorkflowStartAsync_ShouldPollUntilStatusIsNotPending()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
 
@@ -581,7 +582,7 @@ public class WorkflowGrpcClientTests
     [Fact]
     public async Task WaitForWorkflowCompletionAsync_ShouldPollUntilTerminalStatus()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
 
@@ -631,7 +632,7 @@ public class WorkflowGrpcClientTests
         OrchestrationStatus protoStatus,
         WorkflowRuntimeStatus expectedStatus)
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
@@ -658,7 +659,7 @@ public class WorkflowGrpcClientTests
     [Fact]
     public async Task WaitForWorkflowCompletionAsync_ShouldThrowInvalidOperationException_WhenInstanceDoesNotExist()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
@@ -676,7 +677,7 @@ public class WorkflowGrpcClientTests
     [Fact]
     public async Task WaitForWorkflowCompletionAsync_ShouldRespectCancellationToken_WhileWaiting()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock

--- a/test/Dapr.Workflow.Test/DaprWorkflowClientBuilderTests.cs
+++ b/test/Dapr.Workflow.Test/DaprWorkflowClientBuilderTests.cs
@@ -13,6 +13,7 @@
 
 using System.Reflection;
 using System.Text.Json;
+using Dapr.Common.Serialization;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Client;
 using Dapr.Workflow.Registration;
@@ -27,38 +28,72 @@ namespace Dapr.Workflow.Test;
 
 public class DaprWorkflowClientBuilderTests
 {
+    // -------------------------------------------------------------------------
+    // UseSerializer(IDaprSerializer) overload
+    // -------------------------------------------------------------------------
+
     [Fact]
-    public void Build_ShouldUseServiceProviderGrpcClientLoggerAndSerializer()
+    public void UseSerializer_WithIDaprSerializer_SetsSerializer()
     {
-        var grpcClient = CreateGrpcClient();
-        var logger = new TestLogger();
+        var serializer = new StubDaprSerializer("dapr");
+        var builder = new DaprWorkflowClientBuilder().UseSerializer(serializer);
 
-        var services = new ServiceCollection();
-        services.AddSingleton(grpcClient);
-        services.AddSingleton<ILoggerFactory>(new StubLoggerFactory(logger));
+        var usedSerializer = BuildAndGetSerializer(builder);
 
-        var provider = services.BuildServiceProvider();
-
-        var serializer = new TrackingSerializer("custom");
-        var builder = new DaprWorkflowClientBuilder()
-            .UseServiceProvider(provider)
-            .UseSerializer(serializer);
-
-        var client = builder.Build();
-
-        var inner = GetInnerClient(client);
-        var usedGrpcClient = GetPrivateField<TaskHubSidecarService.TaskHubSidecarServiceClient>(inner);
-        var usedLogger = GetPrivateField<ILogger<WorkflowGrpcClient>>(inner);
-        var innerLogger = UnwrapLogger(usedLogger);
-        var usedSerializer = GetPrivateField<IWorkflowSerializer>(inner);
-
-        Assert.Same(grpcClient, usedGrpcClient);
-        Assert.Same(logger, innerLogger);
         Assert.Same(serializer, usedSerializer);
     }
 
     [Fact]
-    public void Build_ShouldUseSerializerFactory_WhenConfigured()
+    public void UseSerializer_WithJsonDaprSerializer_SetsSerializer()
+    {
+        var serializer = new JsonDaprSerializer();
+        var builder = new DaprWorkflowClientBuilder().UseSerializer(serializer);
+
+        var usedSerializer = BuildAndGetSerializer(builder);
+
+        Assert.Same(serializer, usedSerializer);
+    }
+
+    [Fact]
+    public void UseSerializer_WithIWorkflowSerializer_SetsSerializer()
+    {
+        // IWorkflowSerializer extends IDaprSerializer — backward compat path
+        var serializer = new StubWorkflowSerializer("workflow");
+        var builder = new DaprWorkflowClientBuilder().UseSerializer(serializer);
+
+        var usedSerializer = BuildAndGetSerializer(builder);
+
+        Assert.Same(serializer, usedSerializer);
+    }
+
+    [Fact]
+    public void UseSerializer_WithJsonWorkflowSerializer_SetsSerializer()
+    {
+        // JsonWorkflowSerializer extends JsonDaprSerializer — backward compat path
+#pragma warning disable CS0618
+        var serializer = new JsonWorkflowSerializer();
+#pragma warning restore CS0618
+        var builder = new DaprWorkflowClientBuilder().UseSerializer(serializer);
+
+        var usedSerializer = BuildAndGetSerializer(builder);
+
+        Assert.Same(serializer, usedSerializer);
+    }
+
+    [Fact]
+    public void UseSerializer_WithNullSerializer_ThrowsArgumentNullException()
+    {
+        var builder = new DaprWorkflowClientBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.UseSerializer((IDaprSerializer)null!));
+    }
+
+    // -------------------------------------------------------------------------
+    // UseSerializer(Func<IServiceProvider, IWorkflowSerializer>) overload
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void UseSerializer_WithFactory_ResolvesFromServiceProvider()
     {
         var grpcClient = CreateGrpcClient();
         var dependency = new SerializerDependency("dep");
@@ -71,54 +106,125 @@ public class DaprWorkflowClientBuilderTests
         var provider = services.BuildServiceProvider();
 
         SerializerDependency? seenDependency = null;
-        DependencySerializer? createdSerializer = null;
+        StubWorkflowSerializer? createdSerializer = null;
 
         var builder = new DaprWorkflowClientBuilder()
             .UseServiceProvider(provider)
             .UseSerializer(sp =>
             {
                 seenDependency = sp.GetRequiredService<SerializerDependency>();
-                createdSerializer = new DependencySerializer(seenDependency);
+                createdSerializer = new StubWorkflowSerializer(seenDependency.Value);
                 return createdSerializer;
             });
 
-        var client = builder.Build();
-        var inner = GetInnerClient(client);
-        var usedSerializer = GetPrivateField<IWorkflowSerializer>(inner);
+        var usedSerializer = BuildAndGetSerializer(builder);
 
         Assert.Same(dependency, seenDependency);
         Assert.Same(createdSerializer, usedSerializer);
     }
 
     [Fact]
-    public void Build_ShouldUseDefaultJsonSerializer_WhenNoSerializerConfigured()
+    public void UseSerializer_WithFactory_WhenNoServiceProvider_FallsBackToDefaultJsonDaprSerializer()
     {
-        var builder = new DaprWorkflowClientBuilder();
+        // Factory is set but there is no service provider — Build() falls back to JsonDaprSerializer
+        var builder = new DaprWorkflowClientBuilder()
+            .UseSerializer(_ => new StubWorkflowSerializer("unused"));
 
-        var client = builder.Build();
-        var inner = GetInnerClient(client);
-        var serializer = GetPrivateField<IWorkflowSerializer>(inner);
+        var usedSerializer = BuildAndGetSerializer(builder);
 
-        var json = Assert.IsType<JsonWorkflowSerializer>(serializer);
-        var payload = json.Serialize(new { MyValue = 1 });
-
-        Assert.Contains("\"myValue\"", payload);
+        Assert.IsType<JsonDaprSerializer>(usedSerializer);
     }
 
     [Fact]
-    public void Build_ShouldUseJsonSerializerOptions_WhenConfigured()
+    public void UseSerializer_WithNullFactory_ThrowsArgumentNullException()
     {
+        var builder = new DaprWorkflowClientBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.UseSerializer((Func<IServiceProvider, IWorkflowSerializer>)null!));
+    }
+
+    // -------------------------------------------------------------------------
+    // UseJsonSerializer(JsonSerializerOptions) overload
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void UseJsonSerializer_CreatesJsonDaprSerializer()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        var builder = new DaprWorkflowClientBuilder().UseJsonSerializer(options);
+
+        var usedSerializer = BuildAndGetSerializer(builder);
+
+        Assert.IsType<JsonDaprSerializer>(usedSerializer);
+    }
+
+    [Fact]
+    public void UseJsonSerializer_RespectsProvidedNamingPolicy()
+    {
+        // Default web options use camelCase; null policy preserves PascalCase
         var options = new JsonSerializerOptions { PropertyNamingPolicy = null };
         var builder = new DaprWorkflowClientBuilder().UseJsonSerializer(options);
 
+        var serializer = BuildAndGetSerializer(builder);
+
+        var payload = serializer.Serialize(new { MyValue = 1 });
+        Assert.Contains("\"MyValue\"", payload);
+        Assert.DoesNotContain("\"myValue\"", payload);
+    }
+
+    [Fact]
+    public void UseJsonSerializer_WithNullOptions_ThrowsArgumentNullException()
+    {
+        var builder = new DaprWorkflowClientBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.UseJsonSerializer(null!));
+    }
+
+    // -------------------------------------------------------------------------
+    // Build() default behavior
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Build_WithNoSerializer_UsesJsonDaprSerializerWithWebDefaults()
+    {
+        var builder = new DaprWorkflowClientBuilder();
+
+        var usedSerializer = BuildAndGetSerializer(builder);
+
+        Assert.IsType<JsonDaprSerializer>(usedSerializer);
+        // Web defaults use camelCase
+        var payload = usedSerializer.Serialize(new { MyValue = 1 });
+        Assert.Contains("\"myValue\"", payload);
+    }
+
+    // -------------------------------------------------------------------------
+    // gRPC client and logger resolution
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Build_ShouldUseServiceProviderGrpcClientAndLogger()
+    {
+        var grpcClient = CreateGrpcClient();
+        var logger = new TestLogger();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(grpcClient);
+        services.AddSingleton<ILoggerFactory>(new StubLoggerFactory(logger));
+
+        var provider = services.BuildServiceProvider();
+
+        var builder = new DaprWorkflowClientBuilder()
+            .UseServiceProvider(provider)
+            .UseSerializer(new StubDaprSerializer("x"));
+
         var client = builder.Build();
         var inner = GetInnerClient(client);
-        var serializer = GetPrivateField<IWorkflowSerializer>(inner);
 
-        var json = Assert.IsType<JsonWorkflowSerializer>(serializer);
-        var payload = json.Serialize(new { MyValue = 1 });
+        var usedGrpcClient = GetPrivateField<TaskHubSidecarService.TaskHubSidecarServiceClient>(inner);
+        var usedLogger = GetPrivateField<ILogger<WorkflowGrpcClient>>(inner);
 
-        Assert.Contains("\"MyValue\"", payload);
+        Assert.Same(grpcClient, usedGrpcClient);
+        Assert.Same(logger, UnwrapLogger(usedLogger));
     }
 
     [Fact]
@@ -129,13 +235,22 @@ public class DaprWorkflowClientBuilderTests
 
         var provider = services.BuildServiceProvider();
 
-        var builder = new DaprWorkflowClientBuilder().UseServiceProvider(provider);
-
-        var client = builder.Build();
+        var client = new DaprWorkflowClientBuilder().UseServiceProvider(provider).Build();
         var inner = GetInnerClient(client);
         var grpcClient = GetPrivateField<TaskHubSidecarService.TaskHubSidecarServiceClient>(inner);
 
         Assert.NotNull(grpcClient);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static IDaprSerializer BuildAndGetSerializer(DaprWorkflowClientBuilder builder)
+    {
+        var client = builder.Build();
+        var inner = GetInnerClient(client);
+        return GetPrivateField<IDaprSerializer>(inner);
     }
 
     private static TaskHubSidecarService.TaskHubSidecarServiceClient CreateGrpcClient()
@@ -174,56 +289,46 @@ public class DaprWorkflowClientBuilderTests
         return field?.GetValue(logger) as ILogger ?? logger;
     }
 
-    private sealed class TrackingSerializer(string name) : IWorkflowSerializer
-    {
-        private string Name { get; } = name;
+    // -------------------------------------------------------------------------
+    // Stub types
+    // -------------------------------------------------------------------------
 
-        public string Serialize(object? value, Type? inputType = null) => Name;
+    /// <summary>Custom IDaprSerializer stub — does not implement IWorkflowSerializer.</summary>
+    private sealed class StubDaprSerializer(string name) : IDaprSerializer
+    {
+        public string Serialize(object? value, Type? inputType = null) => name;
+        public T? Deserialize<T>(string? data) => default;
+        public object? Deserialize(string? data, Type returnType) => null;
+    }
+
+    /// <summary>Custom IWorkflowSerializer stub — exercises the backward-compat interface.</summary>
+    private sealed class StubWorkflowSerializer(string name) : IWorkflowSerializer
+    {
+        public string Serialize(object? value, Type? inputType = null) => name;
         public T? Deserialize<T>(string? data) => default;
         public object? Deserialize(string? data, Type returnType) => null;
     }
 
     private sealed record SerializerDependency(string Value);
 
-    private sealed class DependencySerializer(SerializerDependency dep) : IWorkflowSerializer
-    {
-        private SerializerDependency Dependency { get; } = dep;
-
-        public string Serialize(object? value, Type? inputType = null) => Dependency.Value;
-        public T? Deserialize<T>(string? data) => default;
-        public object? Deserialize(string? data, Type returnType) => null;
-    }
-
     private sealed class TestLogger : ILogger<WorkflowGrpcClient>
     {
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoopScope.Instance;
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-        }
+            Func<TState, Exception?, string> formatter) { }
     }
 
     private sealed class StubLoggerFactory(ILogger logger) : ILoggerFactory
     {
-        private ILogger Logger { get; } = logger;
-
-        public void AddProvider(ILoggerProvider provider)
-        {
-        }
-
-        public ILogger CreateLogger(string categoryName) => Logger;
-
-        public void Dispose()
-        {
-        }
+        public void AddProvider(ILoggerProvider provider) { }
+        public ILogger CreateLogger(string categoryName) => logger;
+        public void Dispose() { }
     }
 
     private sealed class NoopScope : IDisposable
     {
         public static NoopScope Instance { get; } = new();
-        public void Dispose()
-        {
-        }
+        public void Dispose() { }
     }
 }

--- a/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
+++ b/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
@@ -120,7 +120,7 @@ public class DaprWorkflowClientTests
             RuntimeStatus: WorkflowRuntimeStatus.Running,
             CreatedAt: DateTime.MinValue,
             LastUpdatedAt: DateTime.MinValue,
-            Serializer: new Serialization.JsonWorkflowSerializer());
+            Serializer: new Common.Serialization.JsonDaprSerializer());
 
         var inner = new CapturingWorkflowClient { GetWorkflowMetadataResult = metadata };
         var client = new DaprWorkflowClient(inner);
@@ -151,7 +151,7 @@ public class DaprWorkflowClientTests
             RuntimeStatus: WorkflowRuntimeStatus.Running,
             CreatedAt: DateTime.MinValue,
             LastUpdatedAt: DateTime.MinValue,
-            Serializer: new Serialization.JsonWorkflowSerializer());
+            Serializer: new Common.Serialization.JsonDaprSerializer());
 
         var inner = new CapturingWorkflowClient { WaitForStartResult = metadata };
         var client = new DaprWorkflowClient(inner);
@@ -182,7 +182,7 @@ public class DaprWorkflowClientTests
             RuntimeStatus: WorkflowRuntimeStatus.Completed,
             CreatedAt: DateTime.MinValue,
             LastUpdatedAt: DateTime.MinValue,
-            Serializer: new Serialization.JsonWorkflowSerializer());
+            Serializer: new Common.Serialization.JsonDaprSerializer());
 
         var metadataWithInputs = new WorkflowMetadata(
             InstanceId: "i",
@@ -190,7 +190,7 @@ public class DaprWorkflowClientTests
             RuntimeStatus: WorkflowRuntimeStatus.Completed,
             CreatedAt: DateTime.MinValue,
             LastUpdatedAt: DateTime.MinValue,
-            Serializer: new Serialization.JsonWorkflowSerializer());
+            Serializer: new Common.Serialization.JsonDaprSerializer());
 
         var inner = new CapturingWorkflowClient
         {
@@ -217,7 +217,7 @@ public class DaprWorkflowClientTests
             RuntimeStatus: WorkflowRuntimeStatus.Completed,
             CreatedAt: DateTime.MinValue,
             LastUpdatedAt: DateTime.MinValue,
-            Serializer: new Serialization.JsonWorkflowSerializer());
+            Serializer: new Common.Serialization.JsonDaprSerializer());
 
         var inner = new CapturingWorkflowClient { WaitForCompletionResult = completionMetadata };
         var client = new DaprWorkflowClient(inner);
@@ -361,13 +361,13 @@ public class DaprWorkflowClientTests
         public string? LastWaitForStartInstanceId { get; private set; }
         public bool LastWaitForStartGetInputsAndOutputs { get; private set; }
         public WorkflowMetadata WaitForStartResult { get; set; } =
-            new("i", "wf", WorkflowRuntimeStatus.Running, DateTime.MinValue, DateTime.MinValue, new Serialization.JsonWorkflowSerializer());
+            new("i", "wf", WorkflowRuntimeStatus.Running, DateTime.MinValue, DateTime.MinValue, new Common.Serialization.JsonDaprSerializer());
 
         public string? LastWaitForCompletionInstanceId { get; private set; }
         public bool LastWaitForCompletionGetInputsAndOutputs { get; private set; }
         public CancellationToken LastWaitForCompletionCancellationToken { get; private set; }
         public WorkflowMetadata WaitForCompletionResult { get; set; } =
-            new("i", "wf", WorkflowRuntimeStatus.Completed, DateTime.MinValue, DateTime.MinValue, new Serialization.JsonWorkflowSerializer());
+            new("i", "wf", WorkflowRuntimeStatus.Completed, DateTime.MinValue, DateTime.MinValue, new Common.Serialization.JsonDaprSerializer());
 
         public string? LastRaiseEventInstanceId { get; private set; }
         public string? LastRaiseEventName { get; private set; }

--- a/test/Dapr.Workflow.Test/Serialziation/JsonWorkflowSerializerTests.cs
+++ b/test/Dapr.Workflow.Test/Serialziation/JsonWorkflowSerializerTests.cs
@@ -14,6 +14,8 @@
 using System.Text.Json;
 using Dapr.Workflow.Serialization;
 
+#pragma warning disable CS0618 // JsonWorkflowSerializer is tested here for backward-compatibility coverage
+
 namespace Dapr.Workflow.Test.Serialziation;
 
 public class JsonWorkflowSerializerTests

--- a/test/Dapr.Workflow.Test/Worker/Internal/TimerOriginTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/Internal/TimerOriginTests.cs
@@ -14,6 +14,7 @@
 using System.Reflection;
 using System.Text.Json;
 using Dapr.DurableTask.Protobuf;
+using Dapr.Common.Serialization;
 using Dapr.Workflow.Serialization;
 using Dapr.Workflow.Versioning;
 using Dapr.Workflow.Worker;
@@ -799,7 +800,7 @@ public class TimerOriginTests
 
     private static WorkflowOrchestrationContext CreateContext()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
         return new WorkflowOrchestrationContext(
             name: "wf",
@@ -813,7 +814,7 @@ public class TimerOriginTests
     private static (WorkflowWorker worker, StubWorkflowsFactory factory) CreateWorkerAndFactory()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
         var factory = new StubWorkflowsFactory();
 

--- a/test/Dapr.Workflow.Test/Worker/Internal/WorkflowOrchestrationContextTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/Internal/WorkflowOrchestrationContextTests.cs
@@ -13,6 +13,7 @@
 
 using System.Text.Json;
 using Dapr.DurableTask.Protobuf;
+using Dapr.Common.Serialization;
 using Dapr.Workflow.Serialization;
 using Dapr.Workflow.Versioning;
 using Dapr.Workflow.Worker.Internal;
@@ -27,7 +28,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldComplete_WhenCompletionCorrelationIdMatchesParentTaskId()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -66,7 +67,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldComplete_WhenRuntimeUsesCreatedEventIdAsCompletionCorrelationId()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -116,7 +117,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CallChildWorkflowAsync_ShouldPutRouterOnCreateSubOrchestrationAction_WhenAppIdProvided()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         const string sourceAppId = "workflow-app-1";
@@ -152,7 +153,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CallActivityAsync_ShouldNotSetRouter_WhenAppIdNotProvided()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
         var context = new WorkflowOrchestrationContext(
             name: "wf",
@@ -174,7 +175,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldComplete_WhenCompletionArrivesBeforeCall()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -209,7 +210,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CallActivityAsync_ShouldPutRouterOnScheduleTaskAction_WhenAppIdProvided()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         const string sourceAppId = "workflow-app-1";
@@ -244,7 +245,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CallActivityAsync_ShouldScheduleTaskAction_WhenNotReplaying()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -269,7 +270,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldReturnCompletedResult_FromHistoryTaskCompleted()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -306,7 +307,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldMatchCompletion_WhenTaskScheduledIdDoesNotMatch()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
         var context = new WorkflowOrchestrationContext(
             name: "wf",
@@ -343,7 +344,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldReturnCompletedResult_FromCallFooTaskCompletedFirst()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -402,7 +403,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldReturnCompletedResult_FromCallBarTaskCompletedFirst()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -461,7 +462,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldThrowWorkflowTaskFailedException_FromHistoryTaskFailed()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -505,7 +506,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldRetry_WhenRetryPolicyProvided()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -596,7 +597,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldRetry_WhenRetryPolicyProvided()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -687,7 +688,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task WaitForExternalEventAsync_ShouldReturnDeserializedValue_WhenEventInHistory_IgnoringCase()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -716,7 +717,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task WaitForExternalEventAsync_ShouldReturnCompletedTask_WhenEventInHistory()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -748,7 +749,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task WaitForExternalEventAsync_ShouldReturnUncompletedTask_WhenEventNotInHistory()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -769,7 +770,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task WaitForExternalEventAsync_WithTimeoutOverload_ShouldReturnCompletedTask_WhenEventReceived()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -800,7 +801,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task WaitForExternalEventAsync_WithTimeoutOverload_ShouldCancel_WhenEventNotReceived()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -832,7 +833,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void SetCustomStatus_ShouldUpdateCustomStatusProperty()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -858,7 +859,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void IsReplaying_ShouldBeTrue_WhenHistoryHasUnconsumedEvents_AndFalseAfterConsumption()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -889,7 +890,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CreateTimer_ShouldReturnCompletedTask_WhenTimerFiredInHistory()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -923,7 +924,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void SendEvent_ShouldAddSendEventAction_WithSerializedPayload()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -948,7 +949,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CreateReplaySafeLogger_ShouldReturnLoggerThatIsDisabledDuringReplay()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -982,7 +983,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CreateReplaySafeLogger_StringOverload_ShouldReturnReplaySafeLogger()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -1006,7 +1007,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CreateReplaySafeLogger_TypeOverload_ShouldReturnReplaySafeLogger()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
         var recordingFactory = new RecordingLoggerFactory();
 
@@ -1033,7 +1034,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CreateReplaySafeLogger_GenericOverload_ShouldReturnReplaySafeLogger()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
         var recordingFactory = new RecordingLoggerFactory();
 
@@ -1060,7 +1061,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void ContinueAsNew_ShouldAddCompleteOrchestrationAction_WithCarryoverEvents_WhenPreserveUnprocessedEventsIsTrue()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -1096,7 +1097,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void ContinueAsNew_ShouldNotCarryOverEvents_WhenPreserveUnprocessedEventsIsFalse()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -1127,7 +1128,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void NewGuid_ShouldBeDeterministic_ForSameInstanceIdAndTimestamp()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var now = new DateTime(2025, 01, 01, 0, 0, 0, DateTimeKind.Utc);
         var tracker = new WorkflowVersionTracker([]);
 
@@ -1146,7 +1147,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void NewGuid_ShouldVary_ForDifferentExecutionIds()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var c1 = new WorkflowOrchestrationContext("wf", "same-instance",
@@ -1166,7 +1167,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void NewGuid_ShouldBeDeterministic_ForNonGuidInstanceId()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var now = new DateTime(2025, 01, 01, 0, 0, 0, DateTimeKind.Utc);
         var tracker = new WorkflowVersionTracker([]);
 
@@ -1185,7 +1186,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldThrowArgumentException_WhenNameIsNullOrWhitespace()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -1202,7 +1203,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallActivityAsync_ShouldThrowInvalidOperationException_WhenHistoryEventIsUnexpectedType()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -1231,7 +1232,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task WaitForExternalEventAsync_ShouldReturnDefault_WhenEventInHistoryHasNullInput()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -1260,7 +1261,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task WaitForExternalEventAsync_WithTimeoutOverload_ShouldReturnResult_WhenEventIsInHistory()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -1289,7 +1290,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CallChildWorkflowAsync_ShouldScheduleSubOrchestration_WhenNotReplaying_AndUseProvidedInstanceId()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var context = new WorkflowOrchestrationContext(
@@ -1319,7 +1320,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldReturnCompletedResult_FromHistorySubOrchestrationCompleted()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -1353,7 +1354,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldThrowWorkflowTaskFailedException_FromHistorySubOrchestrationFailed()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -1397,7 +1398,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldThrowJsonDeserializationException_WhenHistoryEventIsUnexpectedType()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]
@@ -1426,7 +1427,7 @@ public class WorkflowOrchestrationContextTests
     [Fact]
     public void CreateReplaySafeLogger_TypeAndGenericOverloads_ShouldBehaveLikeCategoryOverload()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var tracker = new WorkflowVersionTracker([]);
 
         var history = new[]

--- a/test/Dapr.Workflow.Test/Worker/WorkflowWorkerTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/WorkflowWorkerTests.cs
@@ -16,6 +16,7 @@ using System.Reflection;
 using System.Text.Json;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Abstractions;
+using Dapr.Common.Serialization;
 using Dapr.Workflow.Serialization;
 using Dapr.Workflow.Versioning;
 using Dapr.Workflow.Worker;
@@ -45,7 +46,7 @@ public class WorkflowWorkerTests
         ActivitySource.AddActivityListener(listener);
 
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         // W3C traceparent: version-traceId-spanId-flags
@@ -123,7 +124,7 @@ public class WorkflowWorkerTests
         using var userSource = new ActivitySource("User.Code");
 
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         const string expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
@@ -177,7 +178,7 @@ public class WorkflowWorkerTests
         ActivitySource.AddActivityListener(listener);
 
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         Activity? observedCurrent = null;
@@ -229,7 +230,7 @@ public class WorkflowWorkerTests
         ActivitySource.AddActivityListener(listener);
 
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         const string malformedParentId = "not-a-valid-w3c-traceparent";
@@ -366,7 +367,7 @@ public class WorkflowWorkerTests
     public async Task ExecuteAsync_ShouldComplete_WhenGrpcStreamCompletesImmediately()
     {
         var services = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -402,7 +403,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldReturnTerminatedCompletion_WhenReplayLatestEventIsExecutionTerminated()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         // Intentionally no workflow registrations: this verifies the termination path
@@ -446,7 +447,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldNotReturnTerminatedCompletion_WhenReplayLatestEventIsNotExecutionTerminated()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         // Intentionally no workflow registrations. If the termination short-circuit does NOT trigger,
@@ -495,7 +496,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldReturnEmptyResponse_WhenLatestEventIsExecutionSuspended()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var worker = new WorkflowWorker(
@@ -535,7 +536,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldNotShortCircuit_WhenLatestEventIsExecutionResumed()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var worker = new WorkflowWorker(
@@ -577,7 +578,7 @@ public class WorkflowWorkerTests
     public async Task ExecuteAsync_ShouldSwallowOperationCanceledException_WhenStoppingTokenIsCanceled()
     {
         var services = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -609,7 +610,7 @@ public class WorkflowWorkerTests
     public async Task ExecuteAsync_ShouldRethrow_WhenOptionsHaveInvalidConcurrency()
     {
         var services = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         // Bypass property validation to simulate corrupted configuration.
@@ -632,7 +633,7 @@ public class WorkflowWorkerTests
     public void CreateCallOptions_ShouldIncludeUserAgentAndApiToken_WhenConfigured()
     {
         var services = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var configuration = new ConfigurationBuilder()
@@ -665,7 +666,7 @@ public class WorkflowWorkerTests
     public void CreateCallOptions_ShouldNotIncludeApiTokenHeader_WhenTokenIsEmpty()
     {
         var services = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var configuration = new ConfigurationBuilder()
@@ -693,7 +694,7 @@ public class WorkflowWorkerTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldComplete_WhenCompletionEventArrivesLater()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
 
         var context = new WorkflowOrchestrationContext(
             name: "wf",
@@ -744,7 +745,7 @@ public class WorkflowWorkerTests
         const string appId1 = "this-app";
         const string appId2 = "remote-app";
         
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var context = new WorkflowOrchestrationContext(
             "wf", "parent", new DateTime(2025, 01, 01, 0, 0, 0, DateTimeKind.Utc),
             serializer, NullLoggerFactory.Instance, new WorkflowVersionTracker([]), appId1);
@@ -761,7 +762,7 @@ public class WorkflowWorkerTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldComplete_WhenCompletionArrivedBeforeCall()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var context = new WorkflowOrchestrationContext(
             "wf", "parent", new DateTime(2025, 01, 01, 0, 0, 0, DateTimeKind.Utc),
             serializer, NullLoggerFactory.Instance, new WorkflowVersionTracker([]));
@@ -801,7 +802,7 @@ public class WorkflowWorkerTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldIgnoreDuplicateCompletionEvents()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var context = new WorkflowOrchestrationContext(
             "wf", "parent", new DateTime(2025, 01, 01, 0, 0, 0, DateTimeKind.Utc),
             serializer, NullLoggerFactory.Instance, new WorkflowVersionTracker([]));
@@ -842,7 +843,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldAllowWorkflowToComplete_OnSecondPass_WhenChildCompletionInHistory()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -920,7 +921,7 @@ public class WorkflowWorkerTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldOnlyCompleteAfterCreation_WhenCompletionArrivesFirst()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var context = new WorkflowOrchestrationContext(
             "wf", "parent", new DateTime(2025, 01, 01, 0, 0, 0, DateTimeKind.Utc),
             serializer, NullLoggerFactory.Instance, new WorkflowVersionTracker([]));
@@ -954,7 +955,7 @@ public class WorkflowWorkerTests
     [Fact]
     public async Task CallChildWorkflowAsync_ShouldCompleteOnlyForMatchingTaskScheduledId_WhenReplaySchedulesAgain()
     {
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var context = new WorkflowOrchestrationContext(
             "wf", "parent", new DateTime(2025, 01, 01, 0, 0, 0, DateTimeKind.Utc),
             serializer, NullLoggerFactory.Instance, new WorkflowVersionTracker([]));
@@ -1006,7 +1007,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldReturnEmptyActions_WhenWorkflowNameMissingInHistory()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var worker = new WorkflowWorker(
@@ -1035,7 +1036,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldReturnEmptyActions_WhenWorkflowNotInRegistry()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var worker = new WorkflowWorker(
@@ -1071,7 +1072,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldReturnActivationFailure_WhenWorkflowActivationFails()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1112,7 +1113,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldCompleteWorkflow_AndIncludeOutputAndCustomStatus()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1161,7 +1162,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldNotAddCompletedAction_WhenWorkflowContinuesAsNew()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1209,7 +1210,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldReturnFailedCompletion_WhenWorkflowThrows()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1252,7 +1253,7 @@ public class WorkflowWorkerTests
     public async Task HandleActivityResponseAsync_ShouldReturnNotFoundFailure_WhenActivityNotInRegistry()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var worker = new WorkflowWorker(
@@ -1284,7 +1285,7 @@ public class WorkflowWorkerTests
     public async Task HandleActivityResponseAsync_ShouldReturnActivationFailure_WhenActivityActivationFails()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1320,7 +1321,7 @@ public class WorkflowWorkerTests
     public async Task HandleActivityResponseAsync_ShouldExecuteActivity_AndSerializeResult()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1360,7 +1361,7 @@ public class WorkflowWorkerTests
     public async Task HandleActivityResponseAsync_ShouldReturnFailureDetails_WhenActivityThrows()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1396,7 +1397,7 @@ public class WorkflowWorkerTests
     public async Task ExecuteAsync_ShouldRetry_WhenGrpcProtocolHandlerStartFailsWithException()
     {
         var services = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1436,7 +1437,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldUseFirstEventTimestamp_WhenPresent_AndSerializeEmptyResult_WhenOutputIsNull()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1492,7 +1493,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldAdvanceCurrentUtcDateTime_WhenTimerFires()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
         var beginDateTime = new DateTime(2025, 01, 01, 12, 0, 0, DateTimeKind.Utc);
 
@@ -1574,7 +1575,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_CurrentUtcDateTime_IsConsistentBeforeFirstAwait_OnReplay()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var t1 = new DateTime(2025, 01, 01, 12, 0, 0, DateTimeKind.Utc); // workflow started
@@ -1669,7 +1670,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldCompleted_WhenEventReceived()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
         var beginDateTime = new DateTime(2025, 01, 01, 12, 0, 0, DateTimeKind.Utc);
 
@@ -1752,7 +1753,7 @@ public class WorkflowWorkerTests
     public async Task HandleOrchestratorResponseAsync_ShouldReturnFailureDetails_WhenTimerFires()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
         var beginDateTime = new DateTime(2025, 01, 01, 12, 0, 0, DateTimeKind.Utc);
 
@@ -1835,7 +1836,7 @@ public class WorkflowWorkerTests
     public async Task HandleActivityResponseAsync_ShouldUseEmptyInstanceId_WhenOrchestrationInstanceIsNull_AndReturnEmptyResult_WhenOutputIsNull()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1879,7 +1880,7 @@ public class WorkflowWorkerTests
         // running the workflow. Here we put the ExecutionStarted event inside the
         // stream (not in PastEvents) so the workflow can only complete if streaming works.
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1935,7 +1936,7 @@ public class WorkflowWorkerTests
         // When no ExecutionStarted event is present, the worker falls back to
         // HistoryState.OrchestrationState.Name to identify the workflow.
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -1981,7 +1982,7 @@ public class WorkflowWorkerTests
         // Third fallback: OrchestratorStarted.Version.Name when both ExecutionStarted
         // and HistoryState are absent or have no name.
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -2049,7 +2050,7 @@ public class WorkflowWorkerTests
             .AddSingleton(routerRegistry.Object)
             .BuildServiceProvider();
 
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var worker = new WorkflowWorker(
@@ -2099,7 +2100,7 @@ public class WorkflowWorkerTests
             .AddSingleton(routerRegistry.Object)
             .BuildServiceProvider();
 
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var worker = new WorkflowWorker(
@@ -2141,7 +2142,7 @@ public class WorkflowWorkerTests
             .AddSingleton(routerRegistry.Object)
             .BuildServiceProvider();
 
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var worker = new WorkflowWorker(
@@ -2184,7 +2185,7 @@ public class WorkflowWorkerTests
         // IncludeVersionInNextResponse=true and the worker stamps the version into
         // the OrchestratorResponse.
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         const string patchName = "my-feature-patch";
@@ -2236,7 +2237,7 @@ public class WorkflowWorkerTests
         // First turn: workflow awaits an activity but no completion event is present.
         // The response must contain a ScheduleTask action and no CompleteOrchestration.
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -2290,7 +2291,7 @@ public class WorkflowWorkerTests
         // returns an already-faulted Task exercises the inner try/catch around
         // `await runTask`, where IsNonRetriable is explicitly set to true.
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -2395,7 +2396,7 @@ public class WorkflowWorkerTests
         // be the TaskExecutionId string.  We verify this indirectly by confirming
         // the activity still executes successfully and the correct task id is echoed.
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();
@@ -2438,7 +2439,7 @@ public class WorkflowWorkerTests
     {
         // CompletionToken must be round-tripped back in every response path.
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
         var worker = new WorkflowWorker(
             CreateGrpcClientMock().Object,
@@ -2478,7 +2479,7 @@ public class WorkflowWorkerTests
     public async Task HandleActivityResponseAsync_ShouldEchoCompletionToken_InAllResponsePaths()
     {
         var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonWorkflowSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var options = new WorkflowRuntimeOptions();
 
         var factory = new StubWorkflowsFactory();

--- a/test/Dapr.Workflow.Test/WorkflowServiceCollectionExtensionsTests.cs
+++ b/test/Dapr.Workflow.Test/WorkflowServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Dapr.Common.Serialization;
 using Dapr.DurableTask.Protobuf;
 using Dapr.Workflow.Abstractions;
 using Dapr.Workflow.Client;
@@ -23,7 +24,7 @@ public class WorkflowServiceCollectionExtensionsTests
     public void AddDaprWorkflow_Parameterless_ShouldThrowArgumentNullException_WhenServiceCollectionIsNull()
     {
         IServiceCollection services = null!;
-        Assert.Throws<ArgumentNullException>(() => services.AddDaprWorkflow());
+        Assert.Throws<ArgumentNullException>(services.AddDaprWorkflow);
     }
 
     [Fact]
@@ -60,7 +61,7 @@ public class WorkflowServiceCollectionExtensionsTests
         var services = new ServiceCollection();
         var builder = services.AddDaprWorkflowBuilder(null);
 
-        Assert.Throws<ArgumentNullException>(() => builder.WithSerializer((IWorkflowSerializer)null!));
+        Assert.Throws<ArgumentNullException>(() => builder.WithSerializer((IDaprSerializer)null!));
     }
 
     [Fact]
@@ -82,18 +83,50 @@ public class WorkflowServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddDaprWorkflow_ShouldNotOverrideCustomSerializer_WhenUserRegistersSerializerBeforeCallingAddDaprWorkflow()
+    public void AddDaprWorkflow_ShouldNotOverrideCustomSerializer_WhenUserRegistersIDaprSerializerBeforeCallingAddDaprWorkflow()
     {
         var services = new ServiceCollection();
         services.AddLogging();
 
-        services.AddSingleton<IWorkflowSerializer>(MockSerializer.Instance);
+        services.AddSingleton<IDaprSerializer>(MockSerializer.Instance);
         services.AddDaprWorkflow(_ => { });
 
         var sp = services.BuildServiceProvider();
-        var serializer = sp.GetRequiredService<IWorkflowSerializer>();
+        var serializer = sp.GetRequiredService<IDaprSerializer>();
 
         Assert.Same(MockSerializer.Instance, serializer);
+    }
+
+    [Fact]
+    public void AddDaprWorkflow_ShouldForwardLegacyIWorkflowSerializer_WhenRegisteredInDI()
+    {
+        // Backward compat: consumers who registered IWorkflowSerializer directly in DI
+        // (rather than via WithSerializer) should have it honored via the forwarding factory.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+#pragma warning disable CS0618
+        services.AddSingleton<IWorkflowSerializer>(MockSerializer.Instance);
+#pragma warning restore CS0618
+        services.AddDaprWorkflow(_ => { });
+
+        var sp = services.BuildServiceProvider();
+        var serializer = sp.GetRequiredService<IDaprSerializer>();
+
+        Assert.Same(MockSerializer.Instance, serializer);
+    }
+
+    [Fact]
+    public void AddDaprWorkflow_ShouldUseDefaultJsonDaprSerializer_WhenNoSerializerRegistered()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDaprWorkflow(_ => { });
+
+        var sp = services.BuildServiceProvider();
+        var serializer = sp.GetRequiredService<IDaprSerializer>();
+
+        Assert.IsType<JsonDaprSerializer>(serializer);
     }
 
     [Fact]
@@ -107,9 +140,9 @@ public class WorkflowServiceCollectionExtensionsTests
             .WithJsonSerializer(new JsonSerializerOptions { PropertyNamingPolicy = null });
 
         var sp = services.BuildServiceProvider();
-        var serializer = sp.GetRequiredService<IWorkflowSerializer>();
+        var serializer = sp.GetRequiredService<IDaprSerializer>();
 
-        Assert.IsType<JsonWorkflowSerializer>(serializer);
+        Assert.IsType<JsonDaprSerializer>(serializer);
     }
 
     [Fact]
@@ -125,7 +158,7 @@ public class WorkflowServiceCollectionExtensionsTests
             .WithSerializer(serializer);
 
         var sp = services.BuildServiceProvider();
-        var resolved = sp.GetRequiredService<IWorkflowSerializer>();
+        var resolved = sp.GetRequiredService<IDaprSerializer>();
 
         Assert.Same(serializer, resolved);
     }
@@ -147,7 +180,7 @@ public class WorkflowServiceCollectionExtensionsTests
             });
 
         var sp = services.BuildServiceProvider();
-        var serializer = sp.GetRequiredService<IWorkflowSerializer>();
+        var serializer = sp.GetRequiredService<IDaprSerializer>();
 
         var typed = Assert.IsType<DependencyBasedSerializer>(serializer);
         Assert.Equal("dep-1", typed.Dep.Value);

--- a/test/Dapr.Workflow.Test/WorkflowStateTests.cs
+++ b/test/Dapr.Workflow.Test/WorkflowStateTests.cs
@@ -12,6 +12,7 @@
 //  ------------------------------------------------------------------------
 
 using Dapr.Workflow.Client;
+using Dapr.Common.Serialization;
 using Dapr.Workflow.Serialization;
 
 namespace Dapr.Workflow.Test;
@@ -39,7 +40,7 @@ public class WorkflowStateTests
     [Fact]
     public void Properties_ShouldReflectMetadata_WhenPresent()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
         var created = new DateTime(2025, 01, 01, 0, 0, 0, DateTimeKind.Utc);
         var updated = new DateTime(2025, 01, 02, 0, 0, 0, DateTimeKind.Utc);
 
@@ -64,7 +65,7 @@ public class WorkflowStateTests
     [Fact]
     public void CreatedAt_ShouldReturnDefault_WhenMetadataCreatedAtIsMinValue()
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
         var metadata = new WorkflowMetadata(
             InstanceId: "i",
             Name: "wf",
@@ -85,7 +86,7 @@ public class WorkflowStateTests
     [InlineData(WorkflowRuntimeStatus.Terminated)]
     public void IsWorkflowCompleted_ShouldBeTrue_ForTerminalStatuses(WorkflowRuntimeStatus status)
     {
-        var serializer = new JsonWorkflowSerializer();
+        var serializer = new JsonDaprSerializer();
         var metadata = new WorkflowMetadata("i", "wf", status, DateTime.MinValue, DateTime.MinValue, serializer);
 
         var state = new WorkflowState(metadata);


### PR DESCRIPTION
# Description

Migrating serializer from workflow into Dapr.Common so it can be used more widely. While the migration was made internally to use the serializer in Dapr.Common, changes were made to ensure this isn't a breaking change (for now, but I also added an obsolete flag to make it clear it will be a breaking change alongside the release of Dapr runtime v1.20).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
