### PR TITLE
Modifying script tag retrieval script for build infra

### DIFF
--- a/.github/tools/tag-selector/action.yml
+++ b/.github/tools/tag-selector/action.yml
@@ -1,5 +1,5 @@
 name: "Dapr Version Tag Selector"
-description: "Extracts the latest 2 stable patches and latest optional RC"
+description: "Extracts the latest stable patch for each of N minor versions (N-2 policy) plus the latest RC if the newest minor is pre-release only"
 author: "Dapr Contributors"
 runs:
   using: "node20"
@@ -13,9 +13,9 @@ inputs:
     required: false
     default: ""
   stable_count:
-    description: "Number of latest stable patches to return"
+    description: "Number of distinct stable minor versions to return (one latest patch each)"
     required: false
-    default: "2"
+    default: "3"
   rc_count:
     description: "Number of latest RC versions to return"
     required: false

--- a/.github/tools/tag-selector/dist/index.js
+++ b/.github/tools/tag-selector/dist/index.js
@@ -25443,38 +25443,48 @@ function computeFromTags(input) {
     if (cleaned) versions.push(cleaned);
   }
   if (versions.length === 0) {
-    return {
-      matrix_json: []
-    };
+    return { matrix_json: [] };
   }
   const stable = versions.filter((v) => !import_semver.default.prerelease(v));
   const prerelease = versions.filter((v) => !!import_semver.default.prerelease(v));
-  let stableMinor = "";
-  let stablePatches = [];
+  const allSorted = [...versions].sort(import_semver.default.rcompare);
+  const highestOverall = allSorted[0];
+  const highestMajor = import_semver.default.major(highestOverall);
+  const highestMinor = import_semver.default.minor(highestOverall);
+  const highestMinorHasStable = stable.some(
+    (v) => import_semver.default.major(v) === highestMajor && import_semver.default.minor(v) === highestMinor
+  );
+  let latestRcs = [];
+  let stableBaseMinor = highestMinor;
+  if (!highestMinorHasStable && rcCount > 0) {
+    const stablePatchSet = new Set(
+      stable.map((v) => `${import_semver.default.major(v)}.${import_semver.default.minor(v)}.${import_semver.default.patch(v)}`)
+    );
+    const rcCandidates = prerelease.filter((v) => {
+      const pr = import_semver.default.prerelease(v) || [];
+      return import_semver.default.major(v) === highestMajor && import_semver.default.minor(v) === highestMinor && pr[0] === rcIdent && !stablePatchSet.has(`${import_semver.default.major(v)}.${import_semver.default.minor(v)}.${import_semver.default.patch(v)}`);
+    });
+    latestRcs = [...rcCandidates].sort(import_semver.default.rcompare).slice(0, rcCount);
+    stableBaseMinor = highestMinor - 1;
+  }
+  const stablePatches = [];
   if (stable.length > 0) {
     const stableSorted = [...stable].sort(import_semver.default.rcompare);
-    const newestStable = stableSorted[0];
-    const sMajor = import_semver.default.major(newestStable);
-    const sMinor = import_semver.default.minor(newestStable);
-    stableMinor = `${sMajor}.${sMinor}`;
-    stablePatches = stableSorted.filter((v) => import_semver.default.major(v) === sMajor && import_semver.default.minor(v) === sMinor).slice(0, stableCount);
-  }
-  const stablePatchSet = new Set(stable.map((v) => `${import_semver.default.major(v)}.${import_semver.default.minor(v)}.${import_semver.default.patch(v)}`));
-  const rcVersions = prerelease.filter((v) => {
-    if (stablePatchSet.has(`${import_semver.default.major(v)}.${import_semver.default.minor(v)}.${import_semver.default.patch(v)}`)) {
-      return false;
+    const stableMajor = import_semver.default.major(stableSorted[0]);
+    let minor = stableBaseMinor;
+    while (stablePatches.length < stableCount && minor >= 0) {
+      const best = stableSorted.find(
+        (v) => import_semver.default.major(v) === stableMajor && import_semver.default.minor(v) === minor
+      );
+      if (best) stablePatches.push(best);
+      minor--;
     }
-    const pr = import_semver.default.prerelease(v) || [];
-    return pr[0] === rcIdent;
-  });
-  const latestRcs = rcCount > 0 ? [...rcVersions].sort(import_semver.default.rcompare).slice(0, rcCount) : [];
+  }
   const matrix = [
     ...latestRcs.map((v) => ({ version: v, channel: "rc" })),
     ...stablePatches.map((v) => ({ version: v, channel: "stable" }))
   ];
-  return {
-    matrix_json: matrix
-  };
+  return { matrix_json: matrix };
 }
 
 // src/index.ts

--- a/.github/tools/tag-selector/src/lib.ts
+++ b/.github/tools/tag-selector/src/lib.ts
@@ -3,7 +3,7 @@ import semver from "semver";
 export type ComputeInput = {
     tags: string[];         // raw tag names e.g., ["v1.16.8", "1.17.0-rc.3"]
     tagPrefix?: string;     // e.g., "v"
-    stableCount?: number;   // default: 2
+    stableCount?: number;   // number of distinct stable minor versions to include; default: 2
     rcCount?: number;       // default: 1
     rcIdent?: string;       // default: "rc"
 }
@@ -17,7 +17,18 @@ export function stripPrefix(tag: string, prefix?: string): string {
         return tag;
     return tag.startsWith(prefix) ? tag.slice(prefix.length) : tag;
 }
-/** Compute outputs from a set of tag names */
+
+/**
+ * Compute outputs from a set of tag names using an N-2 support policy:
+ *
+ * 1. Find the highest minor version across all tags.
+ * 2. If that minor is RC-only (no stable release exists for it), include up to
+ *    rcCount of its latest RC versions and shift the stable window down by one.
+ * 3. Collect the latest stable patch for each of stableCount distinct minor
+ *    versions, starting from the minor just below any RC-only newest minor (or
+ *    from the highest stable minor when there is no RC phase), and scanning
+ *    downwards — skipping gaps where a minor has no stable release.
+ */
 export function computeFromTags(input: ComputeInput): ComputeOutput {
     const tagPrefix = input.tagPrefix ?? "";
     const stableCount = input.stableCount ?? 2;
@@ -33,52 +44,64 @@ export function computeFromTags(input: ComputeInput): ComputeOutput {
     }
 
     if (versions.length === 0) {
-        return {
-            matrix_json: [],
-        };
+        return { matrix_json: [] };
     }
 
     const stable = versions.filter((v) => !semver.prerelease(v));
     const prerelease = versions.filter((v) => !!semver.prerelease(v));
 
-    // Newest stable minor and its top N patch releases
-    let stableMinor = "";
-    let stablePatches: string[] = [];
-    if (stable.length > 0) {
-        const stableSorted = [...stable].sort(semver.rcompare);
-        const newestStable = stableSorted[0];
-        const sMajor = semver.major(newestStable);
-        const sMinor = semver.minor(newestStable);
-        stableMinor = `${sMajor}.${sMinor}`;
-        stablePatches = stableSorted
-            .filter((v) => semver.major(v) === sMajor && semver.minor(v) === sMinor)
-            .slice(0, stableCount);
+    // Highest overall version determines whether we're in an RC phase
+    const allSorted = [...versions].sort(semver.rcompare);
+    const highestOverall = allSorted[0];
+    const highestMajor = semver.major(highestOverall);
+    const highestMinor = semver.minor(highestOverall);
+
+    const highestMinorHasStable = stable.some(
+        (v) => semver.major(v) === highestMajor && semver.minor(v) === highestMinor
+    );
+
+    // If the highest minor is RC-only, collect up to rcCount RCs from it
+    let latestRcs: string[] = [];
+    let stableBaseMinor = highestMinor;
+
+    if (!highestMinorHasStable && rcCount > 0) {
+        const stablePatchSet = new Set(
+            stable.map((v) => `${semver.major(v)}.${semver.minor(v)}.${semver.patch(v)}`)
+        );
+        const rcCandidates = prerelease.filter((v) => {
+            const pr = semver.prerelease(v) || [];
+            return (
+                semver.major(v) === highestMajor &&
+                semver.minor(v) === highestMinor &&
+                pr[0] === rcIdent &&
+                !stablePatchSet.has(`${semver.major(v)}.${semver.minor(v)}.${semver.patch(v)}`)
+            );
+        });
+        latestRcs = [...rcCandidates].sort(semver.rcompare).slice(0, rcCount);
+        // Stable window starts one minor below the RC-only minor
+        stableBaseMinor = highestMinor - 1;
     }
 
-    // Pick RC versions only for the same major.minor as the most recent stable release,
-    // excluding RCs for patch versions that already have a stable release
-    const stablePatchSet = new Set(stable.map((v) => `${semver.major(v)}.${semver.minor(v)}.${semver.patch(v)}`));
-    const rcVersions = prerelease.filter((v) => {
-        if (stablePatchSet.has(`${semver.major(v)}.${semver.minor(v)}.${semver.patch(v)}`)) {
-            return false;
+    // Collect the latest stable patch for each of stableCount distinct minor
+    // versions, scanning downwards from stableBaseMinor
+    const stablePatches: string[] = [];
+    if (stable.length > 0) {
+        const stableSorted = [...stable].sort(semver.rcompare);
+        const stableMajor = semver.major(stableSorted[0]);
+        let minor = stableBaseMinor;
+        while (stablePatches.length < stableCount && minor >= 0) {
+            const best = stableSorted.find(
+                (v) => semver.major(v) === stableMajor && semver.minor(v) === minor
+            );
+            if (best) stablePatches.push(best);
+            minor--;
         }
-        const pr = semver.prerelease(v) || [];
-        if (pr[0] !== rcIdent) return false;
-        // Restrict RCs to the same major.minor as the most recent stable release
-        if (stableMinor && `${semver.major(v)}.${semver.minor(v)}` !== stableMinor) {
-            return false;
-        }
-        return true;
-    });
-    const latestRcs =
-        rcCount > 0 ? [...rcVersions].sort(semver.rcompare).slice(0, rcCount) : [];
+    }
 
     const matrix = [
         ...latestRcs.map((v) => ({ version: v, channel: "rc" as const })),
         ...stablePatches.map((v) => ({ version: v, channel: "stable" as const })),
     ];
 
-    return {
-        matrix_json: matrix,
-    };
+    return { matrix_json: matrix };
 }

--- a/.github/tools/tag-selector/test/lib.test.ts
+++ b/.github/tools/tag-selector/test/lib.test.ts
@@ -13,35 +13,41 @@ describe("stripPrefix", () => {
 });
 
 describe("computeFromTags - core scenarios", () => {
-    test("stable latest minor has two patches; no RCs", () => {
+    test("N-2 policy: RC-only newest minor + three stable minors (today's Dapr scenario)", () => {
+        // 1.18 is RC-only; 1.17, 1.16, 1.15 each have stable patches
+        const tags = [
+            "v1.18.0-rc.1",
+            "v1.18.0-rc.2",
+            "v1.17.6",
+            "v1.17.5",
+            "v1.16.14",
+            "v1.16.13",
+            "v1.15.14",
+            "v1.15.13",
+        ];
+        const out = computeFromTags({
+            tags,
+            tagPrefix: "v",
+            stableCount: 3,
+            rcCount: 1,
+            rcIdent: "rc",
+        });
+
+        expect(out.matrix_json).toEqual([
+            { version: "1.18.0-rc.2", channel: "rc" },
+            { version: "1.17.6", channel: "stable" },
+            { version: "1.16.14", channel: "stable" },
+            { version: "1.15.14", channel: "stable" },
+        ]);
+    });
+
+    test("highest minor has stable: no RC output, return stableCount distinct minors", () => {
+        // 1.17 has a stable release, so its RC is ignored; return latest patch per minor
         const tags = [
             "v1.16.7",
             "v1.16.8",
             "v1.17.0",
-            "v1.17.0-rc.1"
-        ]
-        const out = computeFromTags({
-            tags,
-            tagPrefix: "v",
-            stableCount: 2,
-            rcIdent: "rc"
-        });
-
-        expect(out.matrix_json).toEqual([
-            { version: "1.17.0", channel: "stable" }
-        ]);
-    });
-
-    test("RCs from a newer unreleased minor are excluded", () => {
-        const tags = [
-            "v1.16.7",
-            "v1.16.8",
             "v1.17.0-rc.1",
-            "v1.17.0-rc.3",
-            // some older noise
-            "v1.15.9",
-            "junk-tag",
-            "refs/tags/v1.14.2" // ensure we handle refs/tags/ normalization
         ];
         const out = computeFromTags({
             tags,
@@ -51,18 +57,42 @@ describe("computeFromTags - core scenarios", () => {
         });
 
         expect(out.matrix_json).toEqual([
+            { version: "1.17.0", channel: "stable" },
             { version: "1.16.8", channel: "stable" },
-            { version: "1.16.7", channel: "stable" },
         ]);
     });
 
-    test("rc_count returns latest N RCs for the stable minor", () => {
+    test("RC-only newest minor: latest RC included, stable window shifts down", () => {
         const tags = [
             "v1.16.7",
             "v1.16.8",
-            "v1.16.9-rc.1",
-            "v1.16.9-rc.2",
-            "v1.16.9-rc.3",
+            "v1.17.0-rc.1",
+            "v1.17.0-rc.3",
+            "v1.15.9",
+            "junk-tag",
+            "refs/tags/v1.14.2",
+        ];
+        const out = computeFromTags({
+            tags,
+            tagPrefix: "v",
+            stableCount: 2,
+            rcIdent: "rc",
+        });
+
+        expect(out.matrix_json).toEqual([
+            { version: "1.17.0-rc.3", channel: "rc" },
+            { version: "1.16.8", channel: "stable" },
+            { version: "1.15.9", channel: "stable" },
+        ]);
+    });
+
+    test("rc_count=2 returns latest 2 RCs from RC-only newest minor", () => {
+        const tags = [
+            "v1.17.0-rc.1",
+            "v1.17.0-rc.2",
+            "v1.17.0-rc.3",
+            "v1.16.8",
+            "v1.15.5",
         ];
         const out = computeFromTags({
             tags,
@@ -73,17 +103,17 @@ describe("computeFromTags - core scenarios", () => {
         });
 
         expect(out.matrix_json).toEqual([
-            { version: "1.16.9-rc.3", channel: "rc" },
-            { version: "1.16.9-rc.2", channel: "rc" },
+            { version: "1.17.0-rc.3", channel: "rc" },
+            { version: "1.17.0-rc.2", channel: "rc" },
             { version: "1.16.8", channel: "stable" },
-            { version: "1.16.7", channel: "stable" },
+            { version: "1.15.5", channel: "stable" },
         ]);
     });
 
-    test("rc_count returns available RCs when fewer exist", () => {
+    test("rc_count returns available RCs when fewer than rcCount exist in RC-only minor", () => {
         const tags = [
+            "v1.17.0-rc.1",
             "v1.16.8",
-            "v1.16.9-rc.1",
         ];
         const out = computeFromTags({
             tags,
@@ -94,12 +124,13 @@ describe("computeFromTags - core scenarios", () => {
         });
 
         expect(out.matrix_json).toEqual([
-            { version: "1.16.9-rc.1", channel: "rc" },
+            { version: "1.17.0-rc.1", channel: "rc" },
             { version: "1.16.8", channel: "stable" },
         ]);
     });
 
-    test("RCs from older minors are excluded; only stable minor RCs are returned", () => {
+    test("highest minor has stable: no RC output even when prerelease versions exist for that minor", () => {
+        // 1.18.0 is stable, so 1.18.0-rc.1 and 1.18.1-rc.1 are irrelevant; 1.17 RCs are older minor, also ignored
         const tags = [
             "1.18.0",
             "1.18.0-rc.1",
@@ -115,12 +146,12 @@ describe("computeFromTags - core scenarios", () => {
         });
 
         expect(out.matrix_json).toEqual([
-            { version: "1.18.1-rc.1", channel: "rc" },
             { version: "1.18.0", channel: "stable" },
         ]);
     });
 
-    test("RCs for stable minor are included alongside stable patches; older minor excluded", () => {
+    test("each stable minor is represented by its single latest patch, not multiple patches", () => {
+        // 1.17 has stable patches; 1.17.2-rc.1 and 1.16.9-rc.1 are patch RCs within stable minors — ignored
         const tags = [
             "v1.17.0",
             "v1.17.1",
@@ -137,30 +168,41 @@ describe("computeFromTags - core scenarios", () => {
         });
 
         expect(out.matrix_json).toEqual([
-            { version: "1.17.2-rc.1", channel: "rc" },
             { version: "1.17.1", channel: "stable" },
-            { version: "1.17.0", channel: "stable" },
+            { version: "1.16.8", channel: "stable" },
         ]);
     });
 
-    test("no RC-only newest minor -> only stable outputs", () => {
-        const tags = ["1.16.7", "1.16.8", "1.17.0"]; // 1.17 has a stable, so not RC-only
-        const out = computeFromTags({ tags, stableCount: 2 });
+    test("stable gap: skips minors with no stable release when scanning backwards", () => {
+        // 1.16 has no stable releases; window skips it and picks 1.15
+        const tags = [
+            "v1.17.0",
+            "v1.16.0-rc.1",
+            "v1.15.3",
+            "v1.14.9",
+        ];
+        const out = computeFromTags({
+            tags,
+            tagPrefix: "v",
+            stableCount: 3,
+            rcIdent: "rc",
+        });
+
         expect(out.matrix_json).toEqual([
             { version: "1.17.0", channel: "stable" },
+            { version: "1.15.3", channel: "stable" },
+            { version: "1.14.9", channel: "stable" },
         ]);
     });
 
-    test("fewer than requested stableCount returns available", () => {
-        const tags = ["v2.5.1"]; // only one stable in newest stable minor
+    test("fewer stables than stableCount returns only what is available", () => {
+        const tags = ["v2.5.1"];
         const out = computeFromTags({ tags, tagPrefix: "v", stableCount: 3 });
         expect(out.matrix_json).toEqual([{ version: "2.5.1", channel: "stable" }]);
     });
 
     test("no versions at all", () => {
         const out = computeFromTags({ tags: [], stableCount: 2 });
-        expect(out).toEqual({
-            matrix_json: [],
-        });
+        expect(out).toEqual({ matrix_json: [] });
     });
 });

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -105,8 +105,8 @@ jobs:
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_TAG_PREFIX: "v"
-          INPUT_STABLE_COUNT: "2"
-          INPUT_RC_COUNT: "2"
+          INPUT_STABLE_COUNT: "3"
+          INPUT_RC_COUNT: "1"
           INPUT_RC_IDENTIFIER: "rc"
         run: |
           node .github/tools/tag-selector/dist/index.js

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -24,13 +24,13 @@ jobs:
     env:
       NUPKG_OUTDIR: bin/Release/nugets
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
         with:
           clean: true
       - name: Parse release version
         run: python ./.github/scripts/get_release_version.py
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
           dotnet-quality: 'ga'
@@ -41,7 +41,7 @@ jobs:
       - name: Generate Packages
         run: dotnet pack --configuration release
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: packages
           path: ${{ env.NUPKG_OUTDIR }}
@@ -51,7 +51,7 @@ jobs:
     outputs: 
       projects: ${{ steps.set-matrix.outputs.projects }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - id: set-matrix
         shell: bash
         run: |
@@ -80,7 +80,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - id: set-matrix
         run: |
           # Find all csproj files matching the pattern recursively
@@ -92,8 +92,8 @@ jobs:
     outputs:
       matrix_json: ${{ steps.compute.outputs.matrix_json }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -213,11 +213,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.compute-integration-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Parse release version
         run: python ./.github/scripts/get_release_version.py
       - name: Setup ${{ matrix.display-name }}
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.install-version }}
           dotnet-quality: 'ga' # Prefer a GA release, but use the RC if not available
@@ -287,11 +287,11 @@ jobs:
           install-version: '10.0.x'
           upload_coverage: true
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v6
     - name: Parse release version
       run: python ./.github/scripts/get_release_version.py
     - name: Setup ${{ matrix.display-name }}
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ matrix.install-version }}
         dotnet-quality: 'ga' # Prefer a GA release, but use the RC if not available
@@ -343,7 +343,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: packages
           path: packages
@@ -376,7 +376,7 @@ jobs:
         package: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: packages
           path: packages


### PR DESCRIPTION
# Description

Applying tweaks to the runtime tag retrieval script that determines which Dapr runtime versions to test against. It should use N-2 of stable versions. If any stable version exists in a version with an RC, it should ignore the RCs. Otherwise, only test against the latest patch for each of the minor versions (in other words it should always return either 3 or 4 versions)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
