### PR TITLE
Adding minimum version tags to Jobs to reflect broader test coverage

### DIFF
--- a/test/Dapr.IntegrationTest.Jobs/Dapr.IntegrationTest.Jobs.csproj
+++ b/test/Dapr.IntegrationTest.Jobs/Dapr.IntegrationTest.Jobs.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Dapr.Jobs\Dapr.Jobs.csproj" />
+      <ProjectReference Include="..\..\src\Dapr.Testcontainers.Xunit\Dapr.Testcontainers.Xunit.csproj" />
       <ProjectReference Include="..\..\src\Dapr.Testcontainers\Dapr.Testcontainers.csproj" />
     </ItemGroup>
 

--- a/test/Dapr.IntegrationTest.Jobs/JobFailurePolicyTests.cs
+++ b/test/Dapr.IntegrationTest.Jobs/JobFailurePolicyTests.cs
@@ -17,6 +17,7 @@ using Dapr.Jobs.Models;
 using Dapr.Jobs.Models.Responses;
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,7 +26,7 @@ namespace Dapr.IntegrationTest.Jobs;
 
 public sealed class JobFailurePolicyTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldScheduleJobWithDropFailurePolicy()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("jobs-component");
@@ -80,7 +81,7 @@ public sealed class JobFailurePolicyTests
         Assert.Contains("job not found", ex.InnerException.Message);
     }
     
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldScheduleJobWithConstantFailurePolicy()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("jobs-component");


### PR DESCRIPTION
# Description

Adding minimum version flags for testing against specific runtime versions now that the range has been broadened per #1810

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
