### PR TITLE
chore: Address flaky integration tests

### DIFF
--- a/test/Dapr.IntegrationTest.Workflow/ActivityCompletionAcknowledgementTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ActivityCompletionAcknowledgementTests.cs
@@ -14,6 +14,7 @@
 using System.Collections.Concurrent;
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,7 +23,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ActivityCompletionAcknowledgementTests
 {
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ActivityCompletion_ShouldNotBeRetried_WhenAcknowledged()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ActivityCompletionAcknowledgementTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ActivityCompletionAcknowledgementTests.cs
@@ -22,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ActivityCompletionAcknowledgementTests
 {
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ActivityCompletion_ShouldNotBeRetried_WhenAcknowledged()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ActivityCompletionLoadTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ActivityCompletionLoadTests.cs
@@ -14,6 +14,7 @@
 using System.Collections.Concurrent;
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +24,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ActivityCompletionLoadTests
 {
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ActivityCompletions_ShouldBeAcknowledged_UnderLoad()
     {
         const int activityCount = 50;

--- a/test/Dapr.IntegrationTest.Workflow/ActivityCompletionLoadTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ActivityCompletionLoadTests.cs
@@ -23,7 +23,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ActivityCompletionLoadTests
 {
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ActivityCompletions_ShouldBeAcknowledged_UnderLoad()
     {
         const int activityCount = 50;

--- a/test/Dapr.IntegrationTest.Workflow/ActivitySleepTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ActivitySleepTests.cs
@@ -14,6 +14,7 @@
 using System.Diagnostics;
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,7 +23,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ActivitySleepTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleActivitySleep()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ChildWorkflowRetryPolicyBackoffTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ChildWorkflowRetryPolicyBackoffTests.cs
@@ -14,6 +14,7 @@
 using System.Collections.Concurrent;
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +28,7 @@ public sealed class ChildWorkflowRetryPolicyBackoffTests
     private static readonly TimeSpan FirstRetryInterval = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan AllowedSkew = TimeSpan.FromSeconds(1);
 
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldRetryChildWorkflowWithBackoff()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ChildWorkflowRetryPolicyBackoffTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ChildWorkflowRetryPolicyBackoffTests.cs
@@ -27,7 +27,7 @@ public sealed class ChildWorkflowRetryPolicyBackoffTests
     private static readonly TimeSpan FirstRetryInterval = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan AllowedSkew = TimeSpan.FromSeconds(1);
 
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldRetryChildWorkflowWithBackoff()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ContinueAsNewCarryoverEventsTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ContinueAsNewCarryoverEventsTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,7 +36,7 @@ public sealed class ContinueAsNewCarryoverEventsTests
     /// After the fix the full buffer is captured once all events are processed, so every
     /// signal survives as a carryover event and the workflow counts down to zero.
     /// </summary>
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ContinueAsNew_ShouldCarryOverEvents_WhenMultipleSignalsArriveTogether()
     {
         const int signalCount = 250;

--- a/test/Dapr.IntegrationTest.Workflow/ContinueAsNewTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ContinueAsNewTests.cs
@@ -21,7 +21,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ContinueAsNewTests
 {
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldContinueAsNewUntilComplete()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ContinueAsNewTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ContinueAsNewTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ContinueAsNewTests
 {
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldContinueAsNewUntilComplete()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/CurrentUtcDateTimeConsistencyTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/CurrentUtcDateTimeConsistencyTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,7 +54,7 @@ public sealed class CurrentUtcDateTimeConsistencyTests
     /// while checkpoint (2) returns the <em>second</em> turn's timestamp, so the
     /// sequence is not monotonically non-decreasing and the assertion fails.
     /// </summary>
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task CurrentUtcDateTime_IsMonotonicallyNonDecreasing_AcrossReplays()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/DaprApiTokenWorkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/DaprApiTokenWorkflowTests.cs
@@ -14,6 +14,7 @@
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Common.Options;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,7 +25,7 @@ public sealed class DaprApiTokenWorkflowTests
 {
     private const string DaprApiTokenEnvVarName = "DAPR_API_TOKEN";
 
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldRunWorkflowWithDaprApiTokenFromEnvVar()
     {
         const string daprApiToken = "workflow-env-token";

--- a/test/Dapr.IntegrationTest.Workflow/DaprApiTokenWorkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/DaprApiTokenWorkflowTests.cs
@@ -24,7 +24,7 @@ public sealed class DaprApiTokenWorkflowTests
 {
     private const string DaprApiTokenEnvVarName = "DAPR_API_TOKEN";
 
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldRunWorkflowWithDaprApiTokenFromEnvVar()
     {
         const string daprApiToken = "workflow-env-token";

--- a/test/Dapr.IntegrationTest.Workflow/ErrorHandlingTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ErrorHandlingTests.cs
@@ -63,7 +63,7 @@ public sealed class ErrorHandlingTests
         Assert.Equal("Success after retries", output);
     }
     
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldCancelTimerOnExternalEvent()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ErrorHandlingTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ErrorHandlingTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ErrorHandlingTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldRetryFailedActivityAndSucceed()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -63,7 +64,7 @@ public sealed class ErrorHandlingTests
         Assert.Equal("Success after retries", output);
     }
     
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldCancelTimerOnExternalEvent()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ExternalEventDoesNotBlockConcurrencySlotTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ExternalEventDoesNotBlockConcurrencySlotTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,7 +35,7 @@ public sealed class ExternalEventDoesNotBlockConcurrencySlotTests
     /// 3 workflows that each wait on an external event, then schedule a 4th workflow and
     /// confirm it completes before releasing the waiting ones.
     /// </summary>
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task FourthWorkflow_ShouldComplete_WhileFirstThreeAreWaitingOnExternalEvent()
     {
         const int concurrencyLimit = 3;

--- a/test/Dapr.IntegrationTest.Workflow/ExternalInputWorkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ExternalInputWorkflowTests.cs
@@ -30,7 +30,7 @@ public sealed partial class ExternalInputWorkflowTests
         new("Computers", 500, 100)
     ];
 
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleMultipleExternalEvents_Simple()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -173,7 +173,7 @@ public sealed partial class ExternalInputWorkflowTests
         Assert.True(resultValue.Processed);
     }
 
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleExternalEventTimeout()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -317,7 +317,7 @@ public sealed partial class ExternalInputWorkflowTests
         Rejected = 2
     }
 
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleMultipleExternalEvents()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ExternalInputWorkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ExternalInputWorkflowTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Client;
 using Dapr.Testcontainers.Common;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,7 +31,7 @@ public sealed partial class ExternalInputWorkflowTests
         new("Computers", 500, 100)
     ];
 
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleMultipleExternalEvents_Simple()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -77,7 +78,7 @@ public sealed partial class ExternalInputWorkflowTests
         Assert.Equal("FirstData-42-True", output);
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleStandardWorkflowsWithDependencyInjection()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -173,7 +174,7 @@ public sealed partial class ExternalInputWorkflowTests
         Assert.True(resultValue.Processed);
     }
 
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleExternalEventTimeout()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -216,7 +217,7 @@ public sealed partial class ExternalInputWorkflowTests
         Assert.Equal("Timeout", output);
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleExternalEventWithDefaultValue()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -317,7 +318,7 @@ public sealed partial class ExternalInputWorkflowTests
         Rejected = 2
     }
 
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleMultipleExternalEvents()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/FanOutFanInTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/FanOutFanInTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +24,7 @@ public sealed class FanOutFanInTests
 {
     private const string CompletedMessage = "Workflow completed!";
     
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldFanOutAndFanIn()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/MaxConcurrentActivitiesTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/MaxConcurrentActivitiesTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,7 +26,7 @@ public sealed class MaxConcurrentActivitiesTests
     /// Verifies that <see cref="WorkflowRuntimeOptions.MaxConcurrentActivities"/> = 1 limits
     /// activity execution to a single concurrent activity even when the workflow fans out more.
     /// </summary>
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldRespectMaxConcurrentActivitiesLimitOfOne()
     {
         const int limit = 1;
@@ -82,7 +83,7 @@ public sealed class MaxConcurrentActivitiesTests
     /// Verifies that <see cref="WorkflowRuntimeOptions.MaxConcurrentActivities"/> = 3 allows up to
     /// 3 concurrent activities and that all activities complete successfully.
     /// </summary>
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldRespectMaxConcurrentActivitiesLimitOfThree()
     {
         const int limit = 3;

--- a/test/Dapr.IntegrationTest.Workflow/MaxConcurrentWorkflowsTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/MaxConcurrentWorkflowsTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,7 +26,7 @@ public sealed class MaxConcurrentWorkflowsTests
     /// Verifies that setting <see cref="WorkflowRuntimeOptions.MaxConcurrentWorkflows"/> to 1
     /// does not deadlock the runtime and that all scheduled workflows eventually complete.
     /// </summary>
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldCompleteAllWorkflowsWhenLimitIsOne()
     {
         const int workflowCount = 3;
@@ -86,7 +87,7 @@ public sealed class MaxConcurrentWorkflowsTests
     /// Verifies that a custom <see cref="WorkflowRuntimeOptions.MaxConcurrentWorkflows"/> value
     /// greater than 1 does not deadlock the runtime and that all scheduled workflows complete.
     /// </summary>
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldCompleteAllWorkflowsWithCustomConcurrencyLimit()
     {
         const int limit = 2;

--- a/test/Dapr.IntegrationTest.Workflow/MultiAppActivityTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/MultiAppActivityTests.cs
@@ -22,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class MultiAppActivityTests
 {
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldScheduleActivityOnRemoteAppUsingAppId()
     {
         var guid = Guid.NewGuid().ToString("N");

--- a/test/Dapr.IntegrationTest.Workflow/MultiAppActivityTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/MultiAppActivityTests.cs
@@ -14,6 +14,7 @@
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Common.Options;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,7 +23,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class MultiAppActivityTests
 {
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldScheduleActivityOnRemoteAppUsingAppId()
     {
         var guid = Guid.NewGuid().ToString("N");

--- a/test/Dapr.IntegrationTest.Workflow/MultiAppChildWorkflowAndActivityTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/MultiAppChildWorkflowAndActivityTests.cs
@@ -14,6 +14,7 @@
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Common.Options;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +28,7 @@ public sealed class MultiAppChildWorkflowAndActivityTests
     private static readonly string App2Id = $"workflow-app-2-{UniqueId}";
     private static readonly string App3Id = $"workflow-app-3-{UniqueId}";
     
-    [Fact]
+    [MinimumDaprRuntimeFact("1.16")]
     public async Task ShouldScheduleChildWorkflowOnRemoteApp_ThatCallsActivityOnAnotherRemoteApp_UsingAppIds()
     {
         var options1 = new DaprRuntimeOptions().WithAppId(App1Id);

--- a/test/Dapr.IntegrationTest.Workflow/MultiAppChildWorkflowAndActivityTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/MultiAppChildWorkflowAndActivityTests.cs
@@ -28,7 +28,7 @@ public sealed class MultiAppChildWorkflowAndActivityTests
     private static readonly string App2Id = $"workflow-app-2-{UniqueId}";
     private static readonly string App3Id = $"workflow-app-3-{UniqueId}";
     
-    [MinimumDaprRuntimeFact("1.16")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldScheduleChildWorkflowOnRemoteApp_ThatCallsActivityOnAnotherRemoteApp_UsingAppIds()
     {
         var options1 = new DaprRuntimeOptions().WithAppId(App1Id);

--- a/test/Dapr.IntegrationTest.Workflow/MultiAppChildWorkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/MultiAppChildWorkflowTests.cs
@@ -23,7 +23,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class MultiAppChildWorkflowTests
 {
-    [MinimumDaprRuntimeFact("1.16")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldScheduleChildWorkflowOnRemoteAppUsingAppId()
     {
         var guid = Guid.NewGuid().ToString("N");

--- a/test/Dapr.IntegrationTest.Workflow/MultiAppChildWorkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/MultiAppChildWorkflowTests.cs
@@ -14,6 +14,7 @@
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Common.Options;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,7 +23,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class MultiAppChildWorkflowTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.16")]
     public async Task ShouldScheduleChildWorkflowOnRemoteAppUsingAppId()
     {
         var guid = Guid.NewGuid().ToString("N");

--- a/test/Dapr.IntegrationTest.Workflow/ParallelExecutionTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ParallelExecutionTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class ParallelExecutionTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17.0")]
     public async Task ShouldExecuteActivitiesInParallel()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ParallelExecutionTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ParallelExecutionTests.cs
@@ -71,7 +71,7 @@ public sealed class ParallelExecutionTests
         Assert.True(duration.TotalSeconds < 5, $"Expected parallel execution to complete in < 5 seconds, took {duration.TotalSeconds}");
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldFanOutFanInWithActivities()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/PauseResumeTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/PauseResumeTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class PauseResumeTests
 {
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldReportPausedStatusWhenWorkflowIsSuspended()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -63,7 +64,7 @@ public sealed class PauseResumeTests
         Assert.Equal(WorkflowRuntimeStatus.Suspended, pausedState.RuntimeStatus);
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldPauseAndResumeWorkflow()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/PauseResumeTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/PauseResumeTests.cs
@@ -21,7 +21,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class PauseResumeTests
 {
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldReportPausedStatusWhenWorkflowIsSuspended()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/PurgeTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/PurgeTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Grpc.Core;
 using Microsoft.Extensions.Configuration;
@@ -22,7 +23,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class PurgeTests
 {
-    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldPurgeCompletedWorkflowInstance()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -68,7 +69,7 @@ public sealed class PurgeTests
         Assert.Null(stateAfterPurge);
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task PurgeShouldNotWorkOnSuspendedWorkflowInstance()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -112,7 +113,7 @@ public sealed class PurgeTests
         await daprWorkflowClient.TerminateWorkflowAsync(workflowInstanceId, cancellation: TestContext.Current.CancellationToken);
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldPurgeTerminatedWorkflowInstance()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/PurgeTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/PurgeTests.cs
@@ -22,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class PurgeTests
 {
-    [Fact]
+    [Dapr.Testcontainers.Xunit.Attributes.MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldPurgeCompletedWorkflowInstance()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/ReplaySafetyTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/ReplaySafetyTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,7 +23,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed partial class ReplaySafetyTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ReplaySafeLogger_ShouldNotDuplicateLogsOnReplay()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -64,7 +65,7 @@ public sealed partial class ReplaySafetyTests
         Assert.Equal("Completed", output);
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task Workflow_ShouldUseDeterministicGuidGeneration()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -110,7 +111,7 @@ public sealed partial class ReplaySafetyTests
         Assert.All(guids, g => Assert.NotEqual(Guid.Empty, g));
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task NewGuid_ShouldRemainStableAcrossReplays()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/SubworkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/SubworkflowTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class SubworkflowTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleSubworkflow()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -68,7 +69,7 @@ public sealed class SubworkflowTests
         Assert.True(subworkflowResultValue);
     }
     
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleMultipleParallelSubworkflows()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/TaskChainingWorkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/TaskChainingWorkflowTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +24,7 @@ public sealed class TaskChainingWorkflowTests
 {
     private static readonly int[] expected = [43, 45, 90];
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleTaskChaining()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/TaskExecutionKeyTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/TaskExecutionKeyTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class TaskExecutionKeyTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ActivityContext_ShouldContainTaskExecutionKey()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/TerminateWorkflowTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/TerminateWorkflowTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class TerminateWorkflowTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldTerminateRunningWorkflow()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");
@@ -77,7 +78,7 @@ public sealed class TerminateWorkflowTests
         Assert.Equal(WorkflowRuntimeStatus.Terminated, result.RuntimeStatus);
     }
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldReturnFromTerminateGrpcCall()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/TimerTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/TimerTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,7 +25,7 @@ public sealed class TimerTests
     private const string InitialMessage = "Test1";
     private const string FinalMessage = "Test2";
     
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ValidateStatusMessagesWithDelay()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/WorkflowMonitorTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/WorkflowMonitorTests.cs
@@ -13,6 +13,7 @@
 
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,7 +22,7 @@ namespace Dapr.IntegrationTest.Workflow;
 
 public sealed class WorkflowMonitorTests
 {
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldHandleContinueAsNew()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");

--- a/test/Dapr.IntegrationTest.Workflow/WorkflowRetryPolicyBackoffTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/WorkflowRetryPolicyBackoffTests.cs
@@ -14,6 +14,7 @@
 using System.Collections.Concurrent;
 using Dapr.Testcontainers.Common;
 using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Xunit.Attributes;
 using Dapr.Workflow;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,7 +28,7 @@ public sealed class WorkflowRetryPolicyBackoffTests
     private static readonly TimeSpan FirstRetryInterval = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan AllowedSkew = TimeSpan.FromSeconds(1);
 
-    [Fact]
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ShouldRetryActivityWithBackoff()
     {
         var componentsDir = TestDirectoryManager.CreateTestDirectory("workflow-components");


### PR DESCRIPTION
# Description

Especially now that we're adding integration tests to N-2 stable versions + RCs (if any), it means that several of the integration tests are now running against less-optimized versions of the runtime and missing performance test benchmarks or using features not yet supported. This simply adds a skip flag to those tests so they don't run on the older versions as they aren't supported.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
