### PR TITLE
bugfix: Workflow analyzer was pointing to incorrect diagnostic ID

### DIFF
--- a/src/Dapr.Workflow.Analyzers/WorkflowRegistrationCodeFixProvider.cs
+++ b/src/Dapr.Workflow.Analyzers/WorkflowRegistrationCodeFixProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Formatting;
 namespace Dapr.Workflow.Analyzers;
 
 /// <summary>
-/// Provides code fixes for DAPR1001 diagnostic.
+/// Provides code fixes for DAPR1301 diagnostic.
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(WorkflowRegistrationCodeFixProvider))]
 public sealed class WorkflowRegistrationCodeFixProvider : CodeFixProvider
@@ -17,7 +17,7 @@ public sealed class WorkflowRegistrationCodeFixProvider : CodeFixProvider
     /// <summary>
     /// Gets the diagnostic IDs that this provider can fix.
     /// </summary>
-    public override ImmutableArray<string> FixableDiagnosticIds => ["DAPR1001"];
+    public override ImmutableArray<string> FixableDiagnosticIds => ["DAPR1301"];
 
     /// <summary>
     /// Registers the code fix for the diagnostic.


### PR DESCRIPTION
# Description

Applying fix for mismatched analyzer codefix- was match for DAPR1001, needs to target DAPR1301

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
