### PR TITLE
Fix workflow trace correlation

### DIFF
--- a/src/Dapr.Workflow/Worker/Grpc/GrpcProtocolHandler.cs
+++ b/src/Dapr.Workflow/Worker/Grpc/GrpcProtocolHandler.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Common;
 using Dapr.DurableTask.Protobuf;
+using Dapr.Workflow.Worker;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
@@ -281,6 +282,9 @@ internal sealed class GrpcProtocolHandler(
             _logger.LogGrpcProtocolHandlerActivityProcessorStart(request.WorkflowInstance.InstanceId, request.Name,
                 request.TaskId, activeCount);
 
+            // Restore the trace context provided by the sidecar so Activity.Current is non-null
+            using var traceScope = WorkflowTrace.StartActivityTrace(request);
+
             // Execute the activity and determine the result (success or application failure).
             // This try/catch must NOT include the CompleteActivityTaskAsync call below — a transport
             // failure during delivery must not be converted into an application-level activity failure,
@@ -297,6 +301,7 @@ internal sealed class GrpcProtocolHandler(
             }
             catch (Exception ex)
             {
+                WorkflowTrace.SetCurrentError(ex);
                 _logger.LogGrpcProtocolHandlerActivityProcessorError(ex, request.Name,
                     request.WorkflowInstance?.InstanceId);
                 result = CreateActivityFailureResult(request, completionToken, ex);

--- a/src/Dapr.Workflow/Worker/WorkflowTrace.cs
+++ b/src/Dapr.Workflow/Worker/WorkflowTrace.cs
@@ -1,0 +1,112 @@
+// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Dapr.DurableTask.Protobuf;
+
+namespace Dapr.Workflow.Worker;
+
+/// <summary>
+/// Restores workflow trace context as <see cref="Activity.Current"/> for workflow and activity dispatch.
+/// </summary>
+internal static class WorkflowTrace
+{
+    private static readonly ActivitySource WorkflowActivitySource = new("Dapr.Workflow");
+
+    public static TraceActivityScope StartActivityTrace(ActivityRequest request)
+    {
+        var previous = Activity.Current;
+        var activity = StartActivityFromRequest(request);
+        return new TraceActivityScope(activity, previous);
+    }
+
+    public static TraceActivityScope StartOrchestrationTrace(IEnumerable<HistoryEvent> events)
+    {
+        // WorkflowRequest does not carry trace context directly. It is stored in workflow history on
+        // the ExecutionStarted event, so recover it from the available events.
+        var parentTraceContext = events
+            .Reverse()
+            .FirstOrDefault(e => e.ExecutionStarted?.ParentTraceContext != null)
+            ?.ExecutionStarted
+            ?.ParentTraceContext;
+
+        var previous = Activity.Current;
+        var activity = StartActivityFromTraceContext(
+            parentTraceContext,
+            "WorkflowOrchestrationTurn",
+            emitSpan: false);
+        return new TraceActivityScope(activity, previous);
+    }
+
+    public static void SetCurrentError(Exception exception) =>
+        Activity.Current?.SetStatus(ActivityStatusCode.Error);
+
+    private static Activity? StartActivityFromRequest(ActivityRequest request) =>
+        StartActivityFromTraceContext(request.ParentTraceContext, $"WorkflowActivity {request.Name}");
+
+    private static Activity? StartActivityFromTraceContext(
+        TraceContext? traceContext,
+        string activityName,
+        bool emitSpan = true)
+    {
+        var traceParent = traceContext?.TraceParent;
+        if (string.IsNullOrEmpty(traceParent))
+            return null;
+
+        var traceState = traceContext?.TraceState;
+        if (emitSpan && ActivityContext.TryParse(traceParent, traceState, isRemote: true, out var parentCtx))
+        {
+            // Prefer ActivitySource so registered telemetry listeners (e.g. OpenTelemetry) receive the span.
+            var started = WorkflowActivitySource.StartActivity(
+                name: activityName,
+                kind: ActivityKind.Internal,
+                parentContext: parentCtx,
+                []);
+            if (started != null)
+                return started;
+
+            // ActivitySource.StartActivity returns null when no listener is registered for "Dapr.Workflow".
+            // Fall through to ensure Activity.Current is always non-null inside user activity code
+            // and workflow orchestration code,
+            // regardless of whether OpenTelemetry or another telemetry listener is configured.
+        }
+
+        // Always create an Activity directly (not via ActivitySource) so that Activity.Current is
+        // non-null in user activity code and workflow orchestration code even when no telemetry listener is registered.
+        var act = new Activity(activityName);
+        act.SetParentId(traceParent);
+        if (!string.IsNullOrEmpty(traceState))
+            act.TraceStateString = traceState;
+        act.Start();
+        return act;
+    }
+
+    /// <summary>
+    /// Restores the previous ambient activity when the workflow dispatch scope completes to prevent
+    /// leaking trace context to the outer scope.
+    /// </summary>
+    internal readonly struct TraceActivityScope(Activity? activity, Activity? previous) : IDisposable
+    {
+        public void Dispose()
+        {
+            if (activity is not null)
+            {
+                Activity.Current = previous;
+                activity.Dispose();
+            }
+        }
+    }
+}

--- a/src/Dapr.Workflow/Worker/WorkflowWorker.cs
+++ b/src/Dapr.Workflow/Worker/WorkflowWorker.cs
@@ -12,6 +12,7 @@
 // ------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -81,6 +82,7 @@ internal sealed class WorkflowWorker(
     {
         _logger.LogWorkerWorkflowHandleOrchestratorRequestStart(request.InstanceId);
 
+        TraceActivityScope traceScope = default;
         try
         {
             // Create a scope for DI
@@ -107,6 +109,7 @@ internal sealed class WorkflowWorker(
             // If the most recent event is `ExecutionTerminated`, acknowledge termination immediately.
             var timelineEvents = allPastEvents.Concat(request.NewEvents).ToList();
             var latestEvent = timelineEvents.Count > 0 ? timelineEvents[^1] : null;
+            traceScope = StartOrchestrationTrace(timelineEvents);
             
             if (latestEvent?.ExecutionTerminated != null)
             {
@@ -445,6 +448,7 @@ internal sealed class WorkflowWorker(
             catch (Exception ex)
             {
                 // Report the failure as an action so Dapr records the workflow as FAILED
+                traceScope.SetError();
                 response.Actions.Add(new WorkflowAction
                 {
                     CompleteWorkflow = new CompleteWorkflowAction
@@ -466,6 +470,7 @@ internal sealed class WorkflowWorker(
         }
         catch (Exception ex)
         {
+            traceScope.SetError();
             _logger.LogWorkerWorkflowHandleOrchestratorRequestFailed(ex, request.InstanceId);
 
             return new WorkflowResponse
@@ -490,12 +495,17 @@ internal sealed class WorkflowWorker(
                 }
             };
         }
+        finally
+        {
+            traceScope.Dispose();
+        }
     }
 
     private async Task<ActivityResponse> HandleActivityResponseAsync(ActivityRequest request, string completionToken)
     {
         _logger.LogWorkerWorkflowHandleActivityRequestStart(request.Name, request.WorkflowInstance?.InstanceId, request.TaskId);
 
+        var traceScope = StartActivityTrace(request);
         try
         {
             // Create a scope for DI
@@ -507,6 +517,7 @@ internal sealed class WorkflowWorker(
             {
                 if (activityActivationException != null)
                 {
+                    traceScope.SetError();
                     _logger.LogWorkerWorkflowHandleActivityRequestActivationFailed(activityActivationException, request.Name);
 
                     return new ActivityResponse
@@ -547,9 +558,6 @@ internal sealed class WorkflowWorker(
             var context = new WorkflowActivityContextImpl(activityIdentifier,
                 request.WorkflowInstance?.InstanceId ?? string.Empty, taskExecutionKey);
 
-            // Restore the trace context provided by the sidecar so Activity.Current is non-null
-            using var traceActivity = StartActivityFromRequest(request);
-
             // Deserialize the input
             object? input = null;
             if (!string.IsNullOrEmpty(request.Input))
@@ -577,6 +585,7 @@ internal sealed class WorkflowWorker(
         }
         catch (Exception ex)
         {
+            traceScope.SetError();
             _logger.LogWorkerWorkflowHandleActivityRequestFailed(ex, request.Name, request.WorkflowInstance?.InstanceId);
 
             return new ActivityResponse
@@ -591,6 +600,10 @@ internal sealed class WorkflowWorker(
                     StackTrace = ex.StackTrace ?? string.Empty
                 }
             };
+        }
+        finally
+        {
+            traceScope.Dispose();
         }
     }
 
@@ -609,18 +622,43 @@ internal sealed class WorkflowWorker(
     
     private static readonly ActivitySource WorkflowActivitySource = new ("Dapr.Workflow");
 
-    private static Activity? StartActivityFromRequest(ActivityRequest request)
+    private static TraceActivityScope StartActivityTrace(ActivityRequest request)
     {
-        var traceParent = request.ParentTraceContext?.TraceParent;
+        var previous = Activity.Current;
+        var activity = StartActivityFromRequest(request);
+        return new TraceActivityScope(activity, previous);
+    }
+
+    private static TraceActivityScope StartOrchestrationTrace(IEnumerable<HistoryEvent> events)
+    {
+        // WorkflowRequest does not carry trace context directly. It is stored in workflow history on
+        // the ExecutionStarted event, so recover it from the available events.
+        var parentTraceContext = events
+            .Reverse()
+            .FirstOrDefault(e => e.ExecutionStarted?.ParentTraceContext != null)
+            ?.ExecutionStarted
+            ?.ParentTraceContext;
+
+        var previous = Activity.Current;
+        var activity = StartActivityFromTraceContext(parentTraceContext, "WorkflowOrchestration");
+        return new TraceActivityScope(activity, previous);
+    }
+
+    private static Activity? StartActivityFromRequest(ActivityRequest request) =>
+        StartActivityFromTraceContext(request.ParentTraceContext, $"WorkflowActivity {request.Name}");
+
+    private static Activity? StartActivityFromTraceContext(TraceContext? traceContext, string activityName)
+    {
+        var traceParent = traceContext?.TraceParent;
         if (string.IsNullOrEmpty(traceParent))
             return null;
 
-        var traceState = request.ParentTraceContext?.TraceState;
+        var traceState = traceContext?.TraceState;
         if (ActivityContext.TryParse(traceParent, traceState, isRemote: true, out var parentCtx))
         {
             // Prefer ActivitySource so registered telemetry listeners (e.g. OpenTelemetry) receive the span.
             var started = WorkflowActivitySource.StartActivity(
-                name: $"WorkflowActivity {request.Name}",
+                name: activityName,
                 kind: ActivityKind.Internal,
                 parentContext: parentCtx,
                 []);
@@ -628,18 +666,36 @@ internal sealed class WorkflowWorker(
                 return started;
 
             // ActivitySource.StartActivity returns null when no listener is registered for "Dapr.Workflow".
-            // Fall through to ensure Activity.Current is always non-null inside user activity code,
+            // Fall through to ensure Activity.Current is always non-null inside user activity code
+            // and workflow orchestration code,
             // regardless of whether OpenTelemetry or another telemetry listener is configured.
         }
 
         // Always create an Activity directly (not via ActivitySource) so that Activity.Current is
-        // non-null in user activity code even when no telemetry listener is registered.
-        var act = new Activity($"WorkflowActivity {request.Name}");
+        // non-null in user activity code and workflow orchestration code even when no telemetry listener is registered.
+        var act = new Activity(activityName);
         act.SetParentId(traceParent);
         if (!string.IsNullOrEmpty(traceState))
             act.TraceStateString = traceState;
         act.Start();
         return act;
+    }
+
+    private readonly struct TraceActivityScope(Activity? activity, Activity? previous) : IDisposable
+    {
+        public void SetError()
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+        }
+
+        public void Dispose()
+        {
+            if (activity is not null)
+            {
+                Activity.Current = previous;
+                activity.Dispose();
+            }
+        }
     }
 
     private CallOptions CreateCallOptions(CancellationToken cancellationToken = default) =>

--- a/src/Dapr.Workflow/Worker/WorkflowWorker.cs
+++ b/src/Dapr.Workflow/Worker/WorkflowWorker.cs
@@ -13,7 +13,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -82,7 +81,7 @@ internal sealed class WorkflowWorker(
     {
         _logger.LogWorkerWorkflowHandleOrchestratorRequestStart(request.InstanceId);
 
-        TraceActivityScope traceScope = default;
+        WorkflowTrace.TraceActivityScope traceScope = default;
         try
         {
             // Create a scope for DI
@@ -109,7 +108,9 @@ internal sealed class WorkflowWorker(
             // If the most recent event is `ExecutionTerminated`, acknowledge termination immediately.
             var timelineEvents = allPastEvents.Concat(request.NewEvents).ToList();
             var latestEvent = timelineEvents.Count > 0 ? timelineEvents[^1] : null;
-            traceScope = StartOrchestrationTrace(timelineEvents);
+            
+            // Restore the trace context provided by the sidecar so Activity.Current is non-null
+            traceScope = WorkflowTrace.StartOrchestrationTrace(timelineEvents);
             
             if (latestEvent?.ExecutionTerminated != null)
             {
@@ -447,8 +448,9 @@ internal sealed class WorkflowWorker(
             }
             catch (Exception ex)
             {
+                WorkflowTrace.SetCurrentError(ex);
+                
                 // Report the failure as an action so Dapr records the workflow as FAILED
-                traceScope.SetError();
                 response.Actions.Add(new WorkflowAction
                 {
                     CompleteWorkflow = new CompleteWorkflowAction
@@ -470,7 +472,7 @@ internal sealed class WorkflowWorker(
         }
         catch (Exception ex)
         {
-            traceScope.SetError();
+            WorkflowTrace.SetCurrentError(ex);
             _logger.LogWorkerWorkflowHandleOrchestratorRequestFailed(ex, request.InstanceId);
 
             return new WorkflowResponse
@@ -505,7 +507,6 @@ internal sealed class WorkflowWorker(
     {
         _logger.LogWorkerWorkflowHandleActivityRequestStart(request.Name, request.WorkflowInstance?.InstanceId, request.TaskId);
 
-        var traceScope = StartActivityTrace(request);
         try
         {
             // Create a scope for DI
@@ -517,7 +518,7 @@ internal sealed class WorkflowWorker(
             {
                 if (activityActivationException != null)
                 {
-                    traceScope.SetError();
+                    WorkflowTrace.SetCurrentError(activityActivationException);
                     _logger.LogWorkerWorkflowHandleActivityRequestActivationFailed(activityActivationException, request.Name);
 
                     return new ActivityResponse
@@ -585,7 +586,7 @@ internal sealed class WorkflowWorker(
         }
         catch (Exception ex)
         {
-            traceScope.SetError();
+            WorkflowTrace.SetCurrentError(ex);
             _logger.LogWorkerWorkflowHandleActivityRequestFailed(ex, request.Name, request.WorkflowInstance?.InstanceId);
 
             return new ActivityResponse
@@ -601,10 +602,6 @@ internal sealed class WorkflowWorker(
                 }
             };
         }
-        finally
-        {
-            traceScope.Dispose();
-        }
     }
 
     /// <summary>
@@ -619,85 +616,6 @@ internal sealed class WorkflowWorker(
 
         await base.StopAsync(cancellationToken);
     }
-    
-    private static readonly ActivitySource WorkflowActivitySource = new ("Dapr.Workflow");
-
-    private static TraceActivityScope StartActivityTrace(ActivityRequest request)
-    {
-        var previous = Activity.Current;
-        var activity = StartActivityFromRequest(request);
-        return new TraceActivityScope(activity, previous);
-    }
-
-    private static TraceActivityScope StartOrchestrationTrace(IEnumerable<HistoryEvent> events)
-    {
-        // WorkflowRequest does not carry trace context directly. It is stored in workflow history on
-        // the ExecutionStarted event, so recover it from the available events.
-        var parentTraceContext = events
-            .Reverse()
-            .FirstOrDefault(e => e.ExecutionStarted?.ParentTraceContext != null)
-            ?.ExecutionStarted
-            ?.ParentTraceContext;
-
-        var previous = Activity.Current;
-        var activity = StartActivityFromTraceContext(parentTraceContext, "WorkflowOrchestration");
-        return new TraceActivityScope(activity, previous);
-    }
-
-    private static Activity? StartActivityFromRequest(ActivityRequest request) =>
-        StartActivityFromTraceContext(request.ParentTraceContext, $"WorkflowActivity {request.Name}");
-
-    private static Activity? StartActivityFromTraceContext(TraceContext? traceContext, string activityName)
-    {
-        var traceParent = traceContext?.TraceParent;
-        if (string.IsNullOrEmpty(traceParent))
-            return null;
-
-        var traceState = traceContext?.TraceState;
-        if (ActivityContext.TryParse(traceParent, traceState, isRemote: true, out var parentCtx))
-        {
-            // Prefer ActivitySource so registered telemetry listeners (e.g. OpenTelemetry) receive the span.
-            var started = WorkflowActivitySource.StartActivity(
-                name: activityName,
-                kind: ActivityKind.Internal,
-                parentContext: parentCtx,
-                []);
-            if (started != null)
-                return started;
-
-            // ActivitySource.StartActivity returns null when no listener is registered for "Dapr.Workflow".
-            // Fall through to ensure Activity.Current is always non-null inside user activity code
-            // and workflow orchestration code,
-            // regardless of whether OpenTelemetry or another telemetry listener is configured.
-        }
-
-        // Always create an Activity directly (not via ActivitySource) so that Activity.Current is
-        // non-null in user activity code and workflow orchestration code even when no telemetry listener is registered.
-        var act = new Activity(activityName);
-        act.SetParentId(traceParent);
-        if (!string.IsNullOrEmpty(traceState))
-            act.TraceStateString = traceState;
-        act.Start();
-        return act;
-    }
-
-    private readonly struct TraceActivityScope(Activity? activity, Activity? previous) : IDisposable
-    {
-        public void SetError()
-        {
-            activity?.SetStatus(ActivityStatusCode.Error);
-        }
-
-        public void Dispose()
-        {
-            if (activity is not null)
-            {
-                Activity.Current = previous;
-                activity.Dispose();
-            }
-        }
-    }
-
     private CallOptions CreateCallOptions(CancellationToken cancellationToken = default) =>
         DaprClientUtilities.ConfigureGrpcCallOptions(typeof(WorkflowWorker).Assembly, _daprApiToken, cancellationToken);
 }

--- a/test/Dapr.Workflow.Test/Worker/Grpc/GrpcProtocolHandlerTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/Grpc/GrpcProtocolHandlerTests.cs
@@ -185,6 +185,408 @@ public sealed class GrpcProtocolHandlerTests
     }
 
     [Fact]
+    public async Task StartAsync_ShouldKeepActivityTraceCurrent_ThroughActivityCompletion()
+    {
+        var grpcClientMock = CreateGrpcClientMock();
+        const string completionToken = "abc";
+        const string expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        const string traceParent = $"00-{expectedTraceId}-00f067aa0ba902b7-01";
+        Activity.Current = null;
+
+        var workItems = new[]
+        {
+            new WorkItem
+            {
+                ActivityRequest = new ActivityRequest
+                {
+                    Name = "act",
+                    TaskId = 42,
+                    WorkflowInstance = new WorkflowInstance { InstanceId = "i-2" },
+                    ParentTraceContext = new TraceContext { TraceParent = traceParent }
+                },
+                CompletionToken = completionToken
+            }
+        };
+
+        grpcClientMock
+            .Setup(x => x.GetWorkItems(It.IsAny<GetWorkItemsRequest>(), It.IsAny<CallOptions>()))
+            .Returns(CreateServerStreamingCall(workItems));
+
+        var completedTcs = CreateTcs<(string? HandlerTraceId, string? CompletionTraceId)>();
+        string? handlerTraceId = null;
+
+        grpcClientMock
+            .Setup(x => x.CompleteActivityTaskAsync(It.IsAny<ActivityResponse>(), It.IsAny<CallOptions>()))
+            .Callback<ActivityResponse, CallOptions>((_, _) =>
+                completedTcs.TrySetResult((handlerTraceId, Activity.Current?.TraceId.ToHexString())))
+            .Returns(CreateAsyncUnaryCall(new CompleteTaskResponse()));
+
+        var handler = new GrpcProtocolHandler(grpcClientMock.Object, NullLoggerFactory.Instance);
+
+        await RunHandlerUntilAsync(
+            handler,
+            workflowHandler: (_, _) => Task.FromResult(new WorkflowResponse()),
+            activityHandler: (req, tok) =>
+            {
+                handlerTraceId = Activity.Current?.TraceId.ToHexString();
+                return Task.FromResult(new ActivityResponse
+                {
+                    InstanceId = req.WorkflowInstance.InstanceId,
+                    TaskId = req.TaskId,
+                    Result = "ok",
+                    CompletionToken = tok
+                });
+            },
+            until: completedTcs.Task,
+            timeout: TimeSpan.FromSeconds(2));
+
+        var completed = await completedTcs.Task;
+        Assert.Equal(expectedTraceId, completed.HandlerTraceId);
+        Assert.Equal(expectedTraceId, completed.CompletionTraceId);
+        Assert.Null(Activity.Current);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldPopulateActivityCurrent_FromParentTraceContext()
+    {
+        using var listener = new ActivityListener();
+        listener.ShouldListenTo = src => src.Name == "Dapr.Workflow";
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
+        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
+        ActivitySource.AddActivityListener(listener);
+
+        var grpcClientMock = CreateGrpcClientMock();
+        const string completionToken = "abc";
+        const string expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
+        const string parentSpanId = "b7ad6b7169203331";
+        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
+        const string traceState = "vendor=value";
+        Activity.Current = null;
+
+        var workItems = new[]
+        {
+            new WorkItem
+            {
+                ActivityRequest = new ActivityRequest
+                {
+                    Name = "act",
+                    TaskId = 1,
+                    WorkflowInstance = new WorkflowInstance { InstanceId = "wf-1" },
+                    ParentTraceContext = new TraceContext
+                    {
+                        TraceParent = traceParent,
+                        TraceState = traceState
+                    }
+                },
+                CompletionToken = completionToken
+            }
+        };
+
+        grpcClientMock
+            .Setup(x => x.GetWorkItems(It.IsAny<GetWorkItemsRequest>(), It.IsAny<CallOptions>()))
+            .Returns(CreateServerStreamingCall(workItems));
+
+        var completedTcs = CreateTcs<bool>();
+        Activity? observedCurrent = null;
+        string? observedTraceId = null;
+        string? observedParentSpanId = null;
+        string? observedTraceState = null;
+
+        grpcClientMock
+            .Setup(x => x.CompleteActivityTaskAsync(It.IsAny<ActivityResponse>(), It.IsAny<CallOptions>()))
+            .Callback<ActivityResponse, CallOptions>((_, _) => completedTcs.TrySetResult(true))
+            .Returns(CreateAsyncUnaryCall(new CompleteTaskResponse()));
+
+        var handler = new GrpcProtocolHandler(grpcClientMock.Object, NullLoggerFactory.Instance);
+
+        await RunHandlerUntilAsync(
+            handler,
+            workflowHandler: (_, _) => Task.FromResult(new WorkflowResponse()),
+            activityHandler: (req, tok) =>
+            {
+                observedCurrent = Activity.Current;
+                observedTraceId = Activity.Current?.TraceId.ToHexString();
+                observedParentSpanId = Activity.Current?.ParentSpanId.ToHexString();
+                observedTraceState = Activity.Current?.TraceStateString;
+                return Task.FromResult(new ActivityResponse
+                {
+                    InstanceId = req.WorkflowInstance.InstanceId,
+                    TaskId = req.TaskId,
+                    Result = "ok",
+                    CompletionToken = tok
+                });
+            },
+            until: completedTcs.Task,
+            timeout: TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(observedCurrent);
+        Assert.Equal(expectedTraceId, observedTraceId);
+        Assert.Equal(parentSpanId, observedParentSpanId);
+        Assert.Equal(traceState, observedTraceState);
+        Assert.Null(Activity.Current);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldPropagateTraceId_ToDownstreamActivities()
+    {
+        using var listener = new ActivityListener();
+        listener.ShouldListenTo = _ => true;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
+        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
+        ActivitySource.AddActivityListener(listener);
+
+        using var userSource = new ActivitySource("User.Code");
+
+        var grpcClientMock = CreateGrpcClientMock();
+        const string completionToken = "abc";
+        const string expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        const string traceParent = $"00-{expectedTraceId}-00f067aa0ba902b7-01";
+
+        var workItems = new[]
+        {
+            new WorkItem
+            {
+                ActivityRequest = new ActivityRequest
+                {
+                    Name = "act",
+                    TaskId = 2,
+                    WorkflowInstance = new WorkflowInstance { InstanceId = "wf-2" },
+                    ParentTraceContext = new TraceContext { TraceParent = traceParent }
+                },
+                CompletionToken = completionToken
+            }
+        };
+
+        grpcClientMock
+            .Setup(x => x.GetWorkItems(It.IsAny<GetWorkItemsRequest>(), It.IsAny<CallOptions>()))
+            .Returns(CreateServerStreamingCall(workItems));
+
+        var completedTcs = CreateTcs<bool>();
+        string? downstreamTraceId = null;
+
+        grpcClientMock
+            .Setup(x => x.CompleteActivityTaskAsync(It.IsAny<ActivityResponse>(), It.IsAny<CallOptions>()))
+            .Callback<ActivityResponse, CallOptions>((_, _) => completedTcs.TrySetResult(true))
+            .Returns(CreateAsyncUnaryCall(new CompleteTaskResponse()));
+
+        var handler = new GrpcProtocolHandler(grpcClientMock.Object, NullLoggerFactory.Instance);
+
+        await RunHandlerUntilAsync(
+            handler,
+            workflowHandler: (_, _) => Task.FromResult(new WorkflowResponse()),
+            activityHandler: (req, tok) =>
+            {
+                using var downstream = userSource.StartActivity("downstream-http-call");
+                downstreamTraceId = downstream?.TraceId.ToHexString();
+                return Task.FromResult(new ActivityResponse
+                {
+                    InstanceId = req.WorkflowInstance.InstanceId,
+                    TaskId = req.TaskId,
+                    Result = "ok",
+                    CompletionToken = tok
+                });
+            },
+            until: completedTcs.Task,
+            timeout: TimeSpan.FromSeconds(2));
+
+        Assert.Equal(expectedTraceId, downstreamTraceId);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldLeaveActivityCurrentNull_WhenParentTraceContextIsMissing()
+    {
+        var grpcClientMock = CreateGrpcClientMock();
+        const string completionToken = "abc";
+        Activity.Current = null;
+
+        var workItems = new[]
+        {
+            new WorkItem
+            {
+                ActivityRequest = new ActivityRequest
+                {
+                    Name = "act",
+                    TaskId = 3,
+                    WorkflowInstance = new WorkflowInstance { InstanceId = "wf-3" }
+                },
+                CompletionToken = completionToken
+            }
+        };
+
+        grpcClientMock
+            .Setup(x => x.GetWorkItems(It.IsAny<GetWorkItemsRequest>(), It.IsAny<CallOptions>()))
+            .Returns(CreateServerStreamingCall(workItems));
+
+        var completedTcs = CreateTcs<bool>();
+        Activity? observedCurrent = null;
+
+        grpcClientMock
+            .Setup(x => x.CompleteActivityTaskAsync(It.IsAny<ActivityResponse>(), It.IsAny<CallOptions>()))
+            .Callback<ActivityResponse, CallOptions>((_, _) => completedTcs.TrySetResult(true))
+            .Returns(CreateAsyncUnaryCall(new CompleteTaskResponse()));
+
+        var handler = new GrpcProtocolHandler(grpcClientMock.Object, NullLoggerFactory.Instance);
+
+        await RunHandlerUntilAsync(
+            handler,
+            workflowHandler: (_, _) => Task.FromResult(new WorkflowResponse()),
+            activityHandler: (req, tok) =>
+            {
+                observedCurrent = Activity.Current;
+                return Task.FromResult(new ActivityResponse
+                {
+                    InstanceId = req.WorkflowInstance.InstanceId,
+                    TaskId = req.TaskId,
+                    Result = "ok",
+                    CompletionToken = tok
+                });
+            },
+            until: completedTcs.Task,
+            timeout: TimeSpan.FromSeconds(2));
+
+        Assert.Null(observedCurrent);
+        Assert.Null(Activity.Current);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldFallBackToSetParentId_WhenTraceParentIsMalformed()
+    {
+        using var listener = new ActivityListener();
+        listener.ShouldListenTo = src => src.Name == "Dapr.Workflow";
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
+        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
+        ActivitySource.AddActivityListener(listener);
+
+        var grpcClientMock = CreateGrpcClientMock();
+        const string completionToken = "abc";
+        const string malformedParentId = "not-a-valid-w3c-traceparent";
+        Activity.Current = null;
+
+        var workItems = new[]
+        {
+            new WorkItem
+            {
+                ActivityRequest = new ActivityRequest
+                {
+                    Name = "act",
+                    TaskId = 4,
+                    WorkflowInstance = new WorkflowInstance { InstanceId = "wf-4" },
+                    ParentTraceContext = new TraceContext { TraceParent = malformedParentId }
+                },
+                CompletionToken = completionToken
+            }
+        };
+
+        grpcClientMock
+            .Setup(x => x.GetWorkItems(It.IsAny<GetWorkItemsRequest>(), It.IsAny<CallOptions>()))
+            .Returns(CreateServerStreamingCall(workItems));
+
+        var completedTcs = CreateTcs<bool>();
+        string? observedParentId = null;
+
+        grpcClientMock
+            .Setup(x => x.CompleteActivityTaskAsync(It.IsAny<ActivityResponse>(), It.IsAny<CallOptions>()))
+            .Callback<ActivityResponse, CallOptions>((_, _) => completedTcs.TrySetResult(true))
+            .Returns(CreateAsyncUnaryCall(new CompleteTaskResponse()));
+
+        var handler = new GrpcProtocolHandler(grpcClientMock.Object, NullLoggerFactory.Instance);
+
+        await RunHandlerUntilAsync(
+            handler,
+            workflowHandler: (_, _) => Task.FromResult(new WorkflowResponse()),
+            activityHandler: (req, tok) =>
+            {
+                observedParentId = Activity.Current?.ParentId;
+                return Task.FromResult(new ActivityResponse
+                {
+                    InstanceId = req.WorkflowInstance.InstanceId,
+                    TaskId = req.TaskId,
+                    Result = "ok",
+                    CompletionToken = tok
+                });
+            },
+            until: completedTcs.Task,
+            timeout: TimeSpan.FromSeconds(2));
+
+        Assert.Equal(malformedParentId, observedParentId);
+        Assert.Null(Activity.Current);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldPopulateActivityCurrent_WithoutRegisteredListener()
+    {
+        var grpcClientMock = CreateGrpcClientMock();
+        const string completionToken = "abc";
+        const string expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
+        const string parentSpanId = "b7ad6b7169203331";
+        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
+        const string traceState = "vendor=value";
+        Activity.Current = null;
+
+        var workItems = new[]
+        {
+            new WorkItem
+            {
+                ActivityRequest = new ActivityRequest
+                {
+                    Name = "act",
+                    TaskId = 5,
+                    WorkflowInstance = new WorkflowInstance { InstanceId = "wf-5" },
+                    ParentTraceContext = new TraceContext
+                    {
+                        TraceParent = traceParent,
+                        TraceState = traceState
+                    }
+                },
+                CompletionToken = completionToken
+            }
+        };
+
+        grpcClientMock
+            .Setup(x => x.GetWorkItems(It.IsAny<GetWorkItemsRequest>(), It.IsAny<CallOptions>()))
+            .Returns(CreateServerStreamingCall(workItems));
+
+        var completedTcs = CreateTcs<bool>();
+        Activity? observedCurrent = null;
+        string? observedTraceId = null;
+        string? observedParentSpanId = null;
+        string? observedTraceState = null;
+
+        grpcClientMock
+            .Setup(x => x.CompleteActivityTaskAsync(It.IsAny<ActivityResponse>(), It.IsAny<CallOptions>()))
+            .Callback<ActivityResponse, CallOptions>((_, _) => completedTcs.TrySetResult(true))
+            .Returns(CreateAsyncUnaryCall(new CompleteTaskResponse()));
+
+        var handler = new GrpcProtocolHandler(grpcClientMock.Object, NullLoggerFactory.Instance);
+
+        await RunHandlerUntilAsync(
+            handler,
+            workflowHandler: (_, _) => Task.FromResult(new WorkflowResponse()),
+            activityHandler: (req, tok) =>
+            {
+                observedCurrent = Activity.Current;
+                observedTraceId = Activity.Current?.TraceId.ToHexString();
+                observedParentSpanId = Activity.Current?.ParentSpanId.ToHexString();
+                observedTraceState = Activity.Current?.TraceStateString;
+                return Task.FromResult(new ActivityResponse
+                {
+                    InstanceId = req.WorkflowInstance.InstanceId,
+                    TaskId = req.TaskId,
+                    Result = "ok",
+                    CompletionToken = tok
+                });
+            },
+            until: completedTcs.Task,
+            timeout: TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(observedCurrent);
+        Assert.Equal(expectedTraceId, observedTraceId);
+        Assert.Equal(parentSpanId, observedParentSpanId);
+        Assert.Equal(traceState, observedTraceState);
+        Assert.Null(Activity.Current);
+    }
+
+    [Fact]
     public async Task StartAsync_ShouldSendFailureResult_WhenOrchestratorHandlerThrows()
     {
         var grpcClientMock = CreateGrpcClientMock();

--- a/test/Dapr.Workflow.Test/Worker/WorkflowTraceTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/WorkflowTraceTests.cs
@@ -1,0 +1,82 @@
+// ------------------------------------------------------------------------
+// Copyright 2025 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Diagnostics;
+using Dapr.DurableTask.Protobuf;
+using Dapr.Workflow.Worker;
+
+namespace Dapr.Workflow.Test.Worker;
+
+public class WorkflowTraceTests
+{
+    [Fact]
+    public void StartActivityTrace_ShouldEmitActivitySourceSpan_WhenListenerIsRegistered()
+    {
+        using var listener = new ActivityListener();
+        var startedCount = 0;
+        listener.ShouldListenTo = src => src.Name == "Dapr.Workflow";
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
+        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
+        listener.ActivityStarted = _ => startedCount++;
+        ActivitySource.AddActivityListener(listener);
+
+        const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        var request = new ActivityRequest
+        {
+            Name = "act",
+            ParentTraceContext = new TraceContext { TraceParent = traceParent }
+        };
+
+        Activity.Current = null;
+
+        using var scope = WorkflowTrace.StartActivityTrace(request);
+
+        Assert.NotNull(Activity.Current);
+        Assert.Equal("Dapr.Workflow", Activity.Current.Source.Name);
+        Assert.Equal(1, startedCount);
+    }
+
+    [Fact]
+    public void StartOrchestrationTrace_ShouldRestoreAmbientTraceContext_WithoutEmittingActivitySourceSpan()
+    {
+        using var listener = new ActivityListener();
+        var startedCount = 0;
+        listener.ShouldListenTo = src => src.Name == "Dapr.Workflow";
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
+        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
+        listener.ActivityStarted = _ => startedCount++;
+        ActivitySource.AddActivityListener(listener);
+
+        const string expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
+        const string traceParent = $"00-{expectedTraceId}-b7ad6b7169203331-01";
+        var events = new[]
+        {
+            new HistoryEvent
+            {
+                ExecutionStarted = new ExecutionStartedEvent
+                {
+                    ParentTraceContext = new TraceContext { TraceParent = traceParent }
+                }
+            }
+        };
+
+        Activity.Current = null;
+
+        using var scope = WorkflowTrace.StartOrchestrationTrace(events);
+
+        Assert.NotNull(Activity.Current);
+        Assert.Equal(expectedTraceId, Activity.Current.TraceId.ToHexString());
+        Assert.Equal(string.Empty, Activity.Current.Source.Name);
+        Assert.Equal(0, startedCount);
+    }
+}

--- a/test/Dapr.Workflow.Test/Worker/WorkflowWorkerTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/WorkflowWorkerTests.cs
@@ -35,297 +35,6 @@ namespace Dapr.Workflow.Test.Worker;
 public class WorkflowWorkerTests
 {
     [Fact]
-    public async Task HandleActivityResponseAsync_ShouldPopulateActivityCurrent_FromParentTraceContext()
-    {
-        // Force ActivitySource.StartActivity to actually create Activities
-        // by attaching a sampler that always records.
-        using var listener = new ActivityListener();
-        listener.ShouldListenTo = src => src.Name == "Dapr.Workflow";
-        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
-        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
-        ActivitySource.AddActivityListener(listener);
-
-        var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
-
-        // W3C traceparent: version-traceId-spanId-flags
-        const string expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
-        const string parentSpanId = "b7ad6b7169203331";
-        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
-        const string traceState = "vendor=value";
-
-        Activity? observedCurrent = null;
-        string? observedTraceId = null;
-        string? observedParentSpanId = null;
-        string? observedTraceState = null;
-
-        var factory = new StubWorkflowsFactory();
-        factory.AddActivity("act", new InlineActivity(
-            inputType: typeof(int),
-            run: (_, _) =>
-            {
-                // User reports in #1749 that Activity.Current is null
-                // After fix, this should be non-null in the activity body
-                observedCurrent = Activity.Current;
-                observedTraceId = Activity.Current?.TraceId.ToHexString();
-                observedParentSpanId = Activity.Current?.ParentSpanId.ToHexString();
-                observedTraceState = Activity.Current?.TraceStateString;
-                return Task.FromResult<object?>(null);
-            }));
-
-        var worker = new WorkflowWorker(
-            CreateGrpcClientMock().Object,
-            factory,
-            NullLoggerFactory.Instance,
-            serializer,
-            sp);
-
-        var request = new ActivityRequest
-        {
-            Name = "act",
-            TaskId = 1,
-            Input = string.Empty,
-            WorkflowInstance = new WorkflowInstance { InstanceId = "wf-1" },
-            ParentTraceContext = new TraceContext
-            {
-                TraceParent = traceParent,
-                TraceState = traceState
-            }
-        };
-
-        var response = await InvokeHandleActivityResponseAsync(worker, request);
-
-        Assert.Null(response.FailureDetails);
-        Assert.NotNull(observedCurrent);
-        Assert.Equal(expectedTraceId, observedTraceId);
-        Assert.Equal(parentSpanId, observedParentSpanId);
-        Assert.Equal(traceState, observedTraceState);
-
-        // And, critically: after the activity returns, the ambient activity should have
-        // been restored (disposed) so we don't leak state onto the worker thread.
-        Assert.NotEqual(observedCurrent, Activity.Current);
-    }
-
-    [Fact]
-    public async Task HandleActivityResponseAsync_ShouldPropagateTraceId_ToDownstreamActivities()
-    {
-        // This is the actual user-visible symptom from issue #1749: downstream calls
-        // appearing under a different TraceId. Here we simulate a downstream
-        // ActivitySource.StartActivity call and assert that the TraceId matches the
-        // traceparent supplied by the sidecar.
-        using var listener = new ActivityListener();
-        listener.ShouldListenTo = _ => true;
-        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
-        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
-        ActivitySource.AddActivityListener(listener);
-
-        using var userSource = new ActivitySource("User.Code");
-
-        var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
-
-        const string expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
-        const string parentSpanId = "00f067aa0ba902b7";
-        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
-
-        string? downstreamTraceId = null;
-
-        var factory = new StubWorkflowsFactory();
-        factory.AddActivity("act", new InlineActivity(
-            inputType: typeof(int),
-            run: (_, _) =>
-            {
-                using var downstream = userSource.StartActivity("downstream-http-call");
-                downstreamTraceId = downstream?.TraceId.ToHexString();
-                return Task.FromResult<object?>(null);
-            }));
-
-        var worker = new WorkflowWorker(
-            CreateGrpcClientMock().Object,
-            factory,
-            NullLoggerFactory.Instance,
-            serializer,
-            sp);
-
-        var request = new ActivityRequest
-        {
-            Name = "act",
-            TaskId = 2,
-            Input = string.Empty,
-            WorkflowInstance = new WorkflowInstance { InstanceId = "wf-2" },
-            ParentTraceContext = new TraceContext { TraceParent = traceParent }
-        };
-
-        var response = await InvokeHandleActivityResponseAsync(worker, request);
-
-        Assert.Null(response.FailureDetails);
-        Assert.Equal(expectedTraceId, downstreamTraceId);
-    }
-
-    [Fact]
-    public async Task HandleActivityResponseAsync_ShouldLeaveActivityCurrentNull_WhenParentTraceContextIsMissing()
-    {
-        // Behavior must be unchanged (no ambient Activity) when the sidecar didn't
-        // supply a traceparent — the fix must not start spurious Activities.
-        using var listener = new ActivityListener();
-        listener.ShouldListenTo = src => src.Name == "Dapr.Workflow";
-        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
-        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
-        ActivitySource.AddActivityListener(listener);
-
-        var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
-
-        Activity? observedCurrent = null;
-
-        var factory = new StubWorkflowsFactory();
-        factory.AddActivity("act", new InlineActivity(
-            inputType: typeof(int),
-            run: (_, _) =>
-            {
-                observedCurrent = Activity.Current;
-                return Task.FromResult<object?>(null);
-            }));
-
-        var worker = new WorkflowWorker(
-            CreateGrpcClientMock().Object,
-            factory,
-            NullLoggerFactory.Instance,
-            serializer,
-            sp);
-
-        // Ensure the surrounding test runner hasn't left an ambient activity on this
-        // async context that could mask a regression.
-        Activity.Current = null;
-
-        var request = new ActivityRequest
-        {
-            Name = "act",
-            TaskId = 3,
-            Input = string.Empty,
-            WorkflowInstance = new WorkflowInstance { InstanceId = "wf-3" }
-        };
-
-        var response = await InvokeHandleActivityResponseAsync(worker, request);
-
-        Assert.Null(response.FailureDetails);
-        Assert.Null(observedCurrent);
-    }
-
-    [Fact]
-    public async Task HandleActivityResponseAsync_ShouldFallBackToSetParentId_WhenTraceParentIsMalformed()
-    {
-        // Covers the fallback branch in StartActivityFromRequest: a non-W3C parent id
-        // still yields a non-null Activity.Current whose raw ParentId matches input.
-        using var listener = new ActivityListener();
-        listener.ShouldListenTo = src => src.Name == "Dapr.Workflow";
-        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded;
-        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded;
-        ActivitySource.AddActivityListener(listener);
-
-        var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
-
-        const string malformedParentId = "not-a-valid-w3c-traceparent";
-
-        string? observedParentId = null;
-
-        var factory = new StubWorkflowsFactory();
-        factory.AddActivity("act", new InlineActivity(
-            inputType: typeof(int),
-            run: (_, _) =>
-            {
-                observedParentId = Activity.Current?.ParentId;
-                return Task.FromResult<object?>(null);
-            }));
-
-        var worker = new WorkflowWorker(
-            CreateGrpcClientMock().Object,
-            factory,
-            NullLoggerFactory.Instance,
-            serializer,
-            sp);
-
-        var request = new ActivityRequest
-        {
-            Name = "act",
-            TaskId = 4,
-            Input = string.Empty,
-            WorkflowInstance = new WorkflowInstance { InstanceId = "wf-4" },
-            ParentTraceContext = new TraceContext { TraceParent = malformedParentId }
-        };
-
-        var response = await InvokeHandleActivityResponseAsync(worker, request);
-
-        Assert.Null(response.FailureDetails);
-        Assert.Equal(malformedParentId, observedParentId);
-    }
-
-    [Fact]
-    public async Task HandleActivityResponseAsync_ShouldPopulateActivityCurrent_WithoutRegisteredListener()
-    {
-        // Regression test for issue #1749: Activity.Current must be non-null inside user activity
-        // code even when NO ActivityListener is registered for "Dapr.Workflow". The original patch
-        // in #1795 used WorkflowActivitySource.StartActivity(), which returns null when there is
-        // no listener — leaving Activity.Current null for users who haven't wired up OpenTelemetry.
-        // Explicitly do NOT register any ActivityListener here to reproduce the real-world scenario.
-        var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
-
-        const string expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
-        const string parentSpanId = "b7ad6b7169203331";
-        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
-        const string traceState = "vendor=value";
-
-        Activity? observedCurrent = null;
-        string? observedTraceId = null;
-        string? observedParentSpanId = null;
-        string? observedTraceState = null;
-
-        var factory = new StubWorkflowsFactory();
-        factory.AddActivity("act", new InlineActivity(
-            inputType: typeof(int),
-            run: (_, _) =>
-            {
-                observedCurrent = Activity.Current;
-                observedTraceId = Activity.Current?.TraceId.ToHexString();
-                observedParentSpanId = Activity.Current?.ParentSpanId.ToHexString();
-                observedTraceState = Activity.Current?.TraceStateString;
-                return Task.FromResult<object?>(null);
-            }));
-
-        var worker = new WorkflowWorker(
-            CreateGrpcClientMock().Object,
-            factory,
-            NullLoggerFactory.Instance,
-            serializer,
-            sp);
-
-        Activity.Current = null;
-
-        var request = new ActivityRequest
-        {
-            Name = "act",
-            TaskId = 5,
-            Input = string.Empty,
-            WorkflowInstance = new WorkflowInstance { InstanceId = "wf-5" },
-            ParentTraceContext = new TraceContext
-            {
-                TraceParent = traceParent,
-                TraceState = traceState
-            }
-        };
-
-        var response = await InvokeHandleActivityResponseAsync(worker, request);
-
-        Assert.Null(response.FailureDetails);
-        Assert.NotNull(observedCurrent);
-        Assert.Equal(expectedTraceId, observedTraceId);
-        Assert.Equal(parentSpanId, observedParentSpanId);
-        Assert.Equal(traceState, observedTraceState);
-    }
-
-    [Fact]
     public void Constructor_ShouldThrowArgumentNullException_WhenGrpcClientIsNull()
     {
         Assert.Throws<ArgumentNullException>(() =>
@@ -1414,12 +1123,13 @@ public class WorkflowWorkerTests
             ParentTraceContext = new TraceContext { TraceParent = traceParent }
         };
 
+        using var activity = StartAmbientActivity(traceParent);
         var response = await InvokeHandleActivityResponseAsync(worker, request);
 
         Assert.NotNull(response.FailureDetails);
         Assert.Contains("boom", response.FailureDetails.ErrorMessage);
         Assert.Equal(expectedTraceId, logProvider.ErrorLogTraceId);
-        Assert.Equal(ActivityStatusCode.Error, logProvider.ErrorLogStatus);
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
 
     [Fact]
@@ -1458,50 +1168,13 @@ public class WorkflowWorkerTests
             ParentTraceContext = new TraceContext { TraceParent = traceParent }
         };
 
+        using var activity = StartAmbientActivity(traceParent);
         var response = await InvokeHandleActivityResponseAsync(worker, request);
 
         Assert.NotNull(response.FailureDetails);
         Assert.Contains("activate-boom", response.FailureDetails.ErrorMessage);
         Assert.Equal(expectedTraceId, logProvider.GetTraceIdForMessage("Activity 'act' failed to activate"));
-    }
-
-    [Fact]
-    public async Task HandleActivityResponseAsync_ShouldKeepTraceContext_WhenLoggingActivityNotFound()
-    {
-        var sp = new ServiceCollection().BuildServiceProvider();
-        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
-
-        const string expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
-        const string parentSpanId = "00f067aa0ba902b7";
-        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
-
-        var logProvider = new ActivityCapturingLoggerProvider();
-        using var loggerFactory = LoggerFactory.Create(builder =>
-        {
-            builder.SetMinimumLevel(LogLevel.Trace);
-            builder.AddProvider(logProvider);
-        });
-
-        var worker = new WorkflowWorker(
-            CreateGrpcClientMock().Object,
-            new StubWorkflowsFactory(),
-            loggerFactory,
-            serializer,
-            sp);
-
-        var request = new ActivityRequest
-        {
-            Name = "missing",
-            TaskId = 7,
-            WorkflowInstance = new WorkflowInstance { InstanceId = "i" },
-            ParentTraceContext = new TraceContext { TraceParent = traceParent }
-        };
-
-        var response = await InvokeHandleActivityResponseAsync(worker, request);
-
-        Assert.NotNull(response.FailureDetails);
-        Assert.Equal("ActivityNotFoundException", response.FailureDetails.ErrorType);
-        Assert.Equal(expectedTraceId, logProvider.GetTraceIdForMessage("Activity 'missing' not found in registry"));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
     }
 
     [Fact]
@@ -2797,7 +2470,6 @@ public class WorkflowWorkerTests
         private readonly List<(string Message, string? TraceId)> _logs = [];
 
         public string? ErrorLogTraceId { get; private set; }
-        public ActivityStatusCode ErrorLogStatus { get; private set; }
 
         public ILogger CreateLogger(string categoryName) => new ActivityCapturingLogger(this);
 
@@ -2829,7 +2501,6 @@ public class WorkflowWorkerTests
                 }
 
                 provider.ErrorLogTraceId = Activity.Current?.TraceId.ToHexString();
-                provider.ErrorLogStatus = Activity.Current?.Status ?? ActivityStatusCode.Unset;
             }
         }
 
@@ -2841,6 +2512,14 @@ public class WorkflowWorkerTests
             {
             }
         }
+    }
+
+    private static Activity StartAmbientActivity(string traceParent)
+    {
+        var activity = new Activity("test");
+        activity.SetParentId(traceParent);
+        activity.Start();
+        return activity;
     }
 
     private static async IAsyncEnumerable<WorkItem> EmptyWorkItems()

--- a/test/Dapr.Workflow.Test/Worker/WorkflowWorkerTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/WorkflowWorkerTests.cs
@@ -1375,6 +1375,193 @@ public class WorkflowWorkerTests
         Assert.NotNull(response.FailureDetails);
         Assert.Contains("boom", response.FailureDetails.ErrorMessage);
     }
+
+    [Fact]
+    public async Task HandleActivityResponseAsync_ShouldKeepTraceContext_WhenLoggingActivityFailure()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        const string expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        const string parentSpanId = "00f067aa0ba902b7";
+        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
+
+        var logProvider = new ActivityCapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(logProvider);
+        });
+
+        var factory = new StubWorkflowsFactory();
+        factory.AddActivity("act", new InlineActivity(
+            inputType: typeof(int),
+            run: (_, _) => throw new InvalidOperationException("boom")));
+
+        var worker = new WorkflowWorker(
+            CreateGrpcClientMock().Object,
+            factory,
+            loggerFactory,
+            serializer,
+            sp);
+
+        var request = new ActivityRequest
+        {
+            Name = "act",
+            TaskId = 7,
+            WorkflowInstance = new WorkflowInstance { InstanceId = "i" },
+            Input = "1",
+            ParentTraceContext = new TraceContext { TraceParent = traceParent }
+        };
+
+        var response = await InvokeHandleActivityResponseAsync(worker, request);
+
+        Assert.NotNull(response.FailureDetails);
+        Assert.Contains("boom", response.FailureDetails.ErrorMessage);
+        Assert.Equal(expectedTraceId, logProvider.ErrorLogTraceId);
+        Assert.Equal(ActivityStatusCode.Error, logProvider.ErrorLogStatus);
+    }
+
+    [Fact]
+    public async Task HandleActivityResponseAsync_ShouldKeepTraceContext_WhenLoggingActivityActivationFailure()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        const string expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        const string parentSpanId = "00f067aa0ba902b7";
+        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
+
+        var logProvider = new ActivityCapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(logProvider);
+        });
+
+        var factory = new StubWorkflowsFactory();
+        factory.AddActivityActivationError("act", new InvalidOperationException("activate-boom"));
+
+        var worker = new WorkflowWorker(
+            CreateGrpcClientMock().Object,
+            factory,
+            loggerFactory,
+            serializer,
+            sp);
+
+        var request = new ActivityRequest
+        {
+            Name = "act",
+            TaskId = 7,
+            WorkflowInstance = new WorkflowInstance { InstanceId = "i" },
+            Input = "1",
+            ParentTraceContext = new TraceContext { TraceParent = traceParent }
+        };
+
+        var response = await InvokeHandleActivityResponseAsync(worker, request);
+
+        Assert.NotNull(response.FailureDetails);
+        Assert.Contains("activate-boom", response.FailureDetails.ErrorMessage);
+        Assert.Equal(expectedTraceId, logProvider.GetTraceIdForMessage("Activity 'act' failed to activate"));
+    }
+
+    [Fact]
+    public async Task HandleActivityResponseAsync_ShouldKeepTraceContext_WhenLoggingActivityNotFound()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        const string expectedTraceId = "4bf92f3577b34da6a3ce929d0e0e4736";
+        const string parentSpanId = "00f067aa0ba902b7";
+        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
+
+        var logProvider = new ActivityCapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(logProvider);
+        });
+
+        var worker = new WorkflowWorker(
+            CreateGrpcClientMock().Object,
+            new StubWorkflowsFactory(),
+            loggerFactory,
+            serializer,
+            sp);
+
+        var request = new ActivityRequest
+        {
+            Name = "missing",
+            TaskId = 7,
+            WorkflowInstance = new WorkflowInstance { InstanceId = "i" },
+            ParentTraceContext = new TraceContext { TraceParent = traceParent }
+        };
+
+        var response = await InvokeHandleActivityResponseAsync(worker, request);
+
+        Assert.NotNull(response.FailureDetails);
+        Assert.Equal("ActivityNotFoundException", response.FailureDetails.ErrorType);
+        Assert.Equal(expectedTraceId, logProvider.GetTraceIdForMessage("Activity 'missing' not found in registry"));
+    }
+
+    [Fact]
+    public async Task HandleOrchestratorResponseAsync_ShouldKeepTraceContext_ForWorkflowAndCompletionLogs()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var serializer = new JsonDaprSerializer(new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        const string expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
+        const string parentSpanId = "b7ad6b7169203331";
+        const string traceParent = $"00-{expectedTraceId}-{parentSpanId}-01";
+
+        var logProvider = new ActivityCapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddProvider(logProvider);
+        });
+
+        var factory = new StubWorkflowsFactory();
+        factory.AddWorkflow("wf", new InlineWorkflow(
+            inputType: typeof(object),
+            run: (context, _) =>
+            {
+                context.CreateReplaySafeLogger("test").LogInformation("workflow-user-log");
+                return Task.FromResult<object?>("done");
+            }));
+
+        var worker = new WorkflowWorker(
+            CreateGrpcClientMock().Object,
+            factory,
+            loggerFactory,
+            serializer,
+            sp);
+
+        var request = new WorkflowRequest
+        {
+            InstanceId = "i",
+            // Use NewEvents so the workflow executes in a live turn. ReplaySafeLogger suppresses
+            // user logs during replay, so PastEvents would hide "workflow-user-log" by design.
+            NewEvents =
+            {
+                new HistoryEvent
+                {
+                    ExecutionStarted = new ExecutionStartedEvent
+                    {
+                        Name = "wf",
+                        Input = "",
+                        ParentTraceContext = new TraceContext { TraceParent = traceParent }
+                    }
+                }
+            }
+        };
+
+        var response = await InvokeHandleWorkflowResponseAsync(worker, request);
+
+        Assert.Equal("i", response.InstanceId);
+        Assert.Equal(expectedTraceId, logProvider.GetTraceIdForMessage("workflow-user-log"));
+        Assert.Equal(expectedTraceId, logProvider.GetTraceIdForMessage("Workflow execution completed"));
+    }
     
     [Fact]
     public async Task ExecuteAsync_ShouldRetry_WhenGrpcProtocolHandlerStartFailsWithException()
@@ -2603,6 +2790,57 @@ public class WorkflowWorkerTests
         public Type OutputType => typeof(object);
 
         public Task<object?> RunAsync(WorkflowActivityContext context, object? input) => run(context, input);
+    }
+
+    private sealed class ActivityCapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<(string Message, string? TraceId)> _logs = [];
+
+        public string? ErrorLogTraceId { get; private set; }
+        public ActivityStatusCode ErrorLogStatus { get; private set; }
+
+        public ILogger CreateLogger(string categoryName) => new ActivityCapturingLogger(this);
+
+        public string? GetTraceIdForMessage(string messagePrefix)
+            => _logs.LastOrDefault(log => log.Message.StartsWith(messagePrefix, StringComparison.Ordinal)).TraceId;
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class ActivityCapturingLogger(ActivityCapturingLoggerProvider provider) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NoopDisposable.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                provider._logs.Add((formatter(state, exception), Activity.Current?.TraceId.ToHexString()));
+
+                if (logLevel != LogLevel.Error || exception?.Message != "boom")
+                {
+                    return;
+                }
+
+                provider.ErrorLogTraceId = Activity.Current?.TraceId.ToHexString();
+                provider.ErrorLogStatus = Activity.Current?.Status ?? ActivityStatusCode.Unset;
+            }
+        }
+
+        private sealed class NoopDisposable : IDisposable
+        {
+            public static readonly NoopDisposable Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
     }
 
     private static async IAsyncEnumerable<WorkItem> EmptyWorkItems()


### PR DESCRIPTION
# Description

Fix workflow trace correlation in the workflow worker so workflow/activity logs keep the expected trace context. 

- Keep trace context for:
  - activity failure logs
  - activity `CompleteActivityTaskAsync`
  - workflow replay-safe logs
  - workflow completion logs
- Set `ActivityStatusCode.Error` for failed activities


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1819 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
