### PR TITLE
fix(workflow): add missing FailureDetails property to proto converter

### DIFF
--- a/src/Dapr.Workflow/Client/ProtoConverters.cs
+++ b/src/Dapr.Workflow/Client/ProtoConverters.cs
@@ -32,7 +32,8 @@ internal static class ProtoConverters
         {
             SerializedInput = string.IsNullOrEmpty(state.Input) ? null : state.Input,
             SerializedOutput = string.IsNullOrEmpty(state.Output) ? null : state.Output,
-            SerializedCustomStatus = string.IsNullOrEmpty(state.CustomStatus) ? null : state.CustomStatus
+            SerializedCustomStatus = string.IsNullOrEmpty(state.CustomStatus) ? null : state.CustomStatus,
+            FailureDetails = ToWorkflowTaskFailureDetails(state.FailureDetails),
         };
 
     /// <summary>
@@ -91,4 +92,12 @@ internal static class ProtoConverters
             HistoryEvent.EventTypeOneofCase.DetachedWorkflowInstanceCreated => WorkflowHistoryEventType.SubOrchestrationInstanceCreated,
             _ => WorkflowHistoryEventType.Unknown
         };
+
+    private static Workflow.WorkflowTaskFailureDetails? ToWorkflowTaskFailureDetails(TaskFailureDetails? failureDetails)
+        => failureDetails is null
+            ? null
+            : new Workflow.WorkflowTaskFailureDetails(
+                failureDetails.ErrorType,
+                failureDetails.ErrorMessage,
+                string.IsNullOrEmpty(failureDetails.StackTrace) ? null : failureDetails.StackTrace);
 }

--- a/test/Dapr.Workflow.Test/Client/ProtoConvertersTests.cs
+++ b/test/Dapr.Workflow.Test/Client/ProtoConvertersTests.cs
@@ -126,6 +126,32 @@ public class ProtoConvertersTests
     }
 
     [Fact]
+    public void ToWorkflowMetadata_ShouldMapFailureDetails_WhenPresent()
+    {
+        var serializer = new JsonDaprSerializer();
+
+        var state = new Dapr.DurableTask.Protobuf.WorkflowState
+        {
+            InstanceId = "i",
+            Name = "n",
+            WorkflowStatus = OrchestrationStatus.Failed,
+            FailureDetails = new TaskFailureDetails
+            {
+                ErrorType = "System.InvalidOperationException",
+                ErrorMessage = "boom",
+                StackTrace = "trace"
+            }
+        };
+
+        var metadata = ProtoConverters.ToWorkflowMetadata(state, serializer);
+
+        Assert.NotNull(metadata.FailureDetails);
+        Assert.Equal("System.InvalidOperationException", metadata.FailureDetails!.ErrorType);
+        Assert.Equal("boom", metadata.FailureDetails.ErrorMessage);
+        Assert.Equal("trace", metadata.FailureDetails.StackTrace);
+    }
+
+    [Fact]
     public void ToWorkflowMetadata_ShouldKeepSerializedFields_WhenProtoStringsContainWhitespace()
     {
         var serializer = new JsonDaprSerializer();


### PR DESCRIPTION
# Description

_Please explain the changes you've made_

Adds the missing mapping of `FailureDetails` in `ProtoConverters`.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1830

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
