### PR TITLE
fix(workflow): use server-blocking WaitForInstance* RPCs instead of client polling

### DIFF
--- a/src/Dapr.Workflow/Client/WorkflowGrpcClient.cs
+++ b/src/Dapr.Workflow/Client/WorkflowGrpcClient.cs
@@ -92,50 +92,43 @@ internal sealed class WorkflowGrpcClient(
     public override async Task<WorkflowMetadata> WaitForWorkflowStartAsync(string instanceId, bool getInputsAndOutputs = true,
         CancellationToken cancellationToken = default)
     {
-        // Poll until the workflow status (not Pending)
-        while (true)
+        var response = await WaitForInstanceAsync(
+            (request, callOptions) => grpcClient.WaitForInstanceStartAsync(request, callOptions),
+            instanceId,
+            getInputsAndOutputs,
+            cancellationToken);
+
+        if (!response.Exists)
         {
-            var metadata = await GetWorkflowMetadataAsync(instanceId, getInputsAndOutputs, cancellationToken);
-
-            if (metadata is null)
-            {
-                var ex = new InvalidOperationException($"Workflow instance '{instanceId}' does not exist");
-                logger.LogWaitForStartException(ex, instanceId);
-                throw ex;
-            }
-
-            if (metadata.RuntimeStatus != WorkflowRuntimeStatus.Pending)
-            {
-                logger.LogWaitForStartCompleted(instanceId, metadata.RuntimeStatus);
-                return metadata;
-            }
-
-            await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
+            var ex = new InvalidOperationException($"Workflow instance '{instanceId}' does not exist");
+            logger.LogWaitForStartException(ex, instanceId);
+            throw ex;
         }
+
+        var metadata = ProtoConverters.ToWorkflowMetadata(response.WorkflowState, serializer);
+        logger.LogWaitForStartCompleted(instanceId, metadata.RuntimeStatus);
+        return metadata;
     }
 
     /// <inheritdoc />
     public override async Task<WorkflowMetadata> WaitForWorkflowCompletionAsync(string instanceId, bool getInputsAndOutputs = true, CancellationToken cancellationToken = default)
     {
-        while (true)
+        var response = await WaitForInstanceAsync(
+            (request, callOptions) => grpcClient.WaitForInstanceCompletionAsync(request, callOptions),
+            instanceId,
+            getInputsAndOutputs,
+            cancellationToken);
+
+        if (!response.Exists)
         {
-            var metadata = await GetWorkflowMetadataAsync(instanceId, getInputsAndOutputs, cancellationToken);
-
-            if (metadata is null)
-            {
-                var ex = new InvalidOperationException($"Workflow instance '{instanceId}' does not exist");
-                logger.LogWaitForCompletionException(ex, instanceId);
-                throw ex;
-            }
-
-            if (IsTerminalStatus(metadata.RuntimeStatus))
-            {
-                logger.LogWaitForCompletionCompleted(instanceId, metadata.RuntimeStatus);
-                return metadata;
-            }
-
-            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            var ex = new InvalidOperationException($"Workflow instance '{instanceId}' does not exist");
+            logger.LogWaitForCompletionException(ex, instanceId);
+            throw ex;
         }
+
+        var metadata = ProtoConverters.ToWorkflowMetadata(response.WorkflowState, serializer);
+        logger.LogWaitForCompletionCompleted(instanceId, metadata.RuntimeStatus);
+        return metadata;
     }
 
     /// <inheritdoc />
@@ -333,8 +326,48 @@ internal sealed class WorkflowGrpcClient(
     private CallOptions CreateCallOptions(CancellationToken cancellationToken) =>
         DaprClientUtilities.ConfigureGrpcCallOptions(typeof(DaprWorkflowClient).Assembly, daprApiToken, cancellationToken);
 
-    private static bool IsTerminalStatus(WorkflowRuntimeStatus status) =>
-        status is WorkflowRuntimeStatus.Completed 
-            or WorkflowRuntimeStatus.Failed
-            or WorkflowRuntimeStatus.Terminated;
+    private static readonly TimeSpan MinWaitRetryDelay = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan MaxWaitRetryDelay = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Issues a server-side blocking wait RPC (<c>WaitForInstanceStart</c> /
+    /// <c>WaitForInstanceCompletion</c>), which returns the moment the instance reaches the
+    /// target state. The blocking call can be interrupted by a deadline or a transient
+    /// sidecar/connection drop; in that case it is re-issued with exponential backoff rather
+    /// than failing the wait — mirroring the durabletask-go client. The loop ends only when the
+    /// RPC succeeds or the caller cancels.
+    /// </summary>
+    private async Task<grpc.GetInstanceResponse> WaitForInstanceAsync(
+        Func<grpc.GetInstanceRequest, CallOptions, AsyncUnaryCall<grpc.GetInstanceResponse>> waitCall,
+        string instanceId,
+        bool getInputsAndOutputs,
+        CancellationToken cancellationToken)
+    {
+        var request = new grpc.GetInstanceRequest
+        {
+            InstanceId = instanceId,
+            GetInputsAndOutputs = getInputsAndOutputs
+        };
+
+        var delay = MinWaitRetryDelay;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var grpcCallOptions = CreateCallOptions(cancellationToken);
+                return await waitCall(request, grpcCallOptions);
+            }
+            catch (RpcException ex) when (
+                !cancellationToken.IsCancellationRequested &&
+                ex.StatusCode is StatusCode.DeadlineExceeded or StatusCode.Unavailable)
+            {
+                logger.LogWaitForInstanceRetry(ex, instanceId, ex.StatusCode, delay);
+                await Task.Delay(delay, cancellationToken);
+                delay = TimeSpan.FromMilliseconds(
+                    Math.Min(delay.TotalMilliseconds * 2, MaxWaitRetryDelay.TotalMilliseconds));
+            }
+        }
+    }
 }

--- a/src/Dapr.Workflow/Logging.cs
+++ b/src/Dapr.Workflow/Logging.cs
@@ -155,6 +155,9 @@ internal static partial class Logging
     [LoggerMessage(LogLevel.Debug, "Workflow '{InstanceId}' completed with status '{Status}'")]
     public static partial void LogWaitForCompletionCompleted(this ILogger logger, string instanceId, WorkflowRuntimeStatus status);
 
+    [LoggerMessage(LogLevel.Debug, "Wait for workflow instance '{InstanceId}' was interrupted with status '{StatusCode}'; retrying in {Delay}")]
+    public static partial void LogWaitForInstanceRetry(this ILogger logger, RpcException ex, string instanceId, StatusCode statusCode, TimeSpan delay);
+
     [LoggerMessage(LogLevel.Information, "Raised event '{EventName}' to workflow '{InstanceId}'")]
     public static partial void LogRaisedEvent(this ILogger logger, string eventName, string instanceId);
     

--- a/test/Dapr.Workflow.Test/Client/WorkflowGrpcClientTests.cs
+++ b/test/Dapr.Workflow.Test/Client/WorkflowGrpcClientTests.cs
@@ -152,13 +152,13 @@ public class WorkflowGrpcClientTests
     }
 
     [Fact]
-    public async Task WaitForWorkflowStartAsync_ShouldReturnImmediately_WhenStatusIsNotPending()
+    public async Task WaitForWorkflowStartAsync_ShouldUseServerBlockingRpc_AndReturnStartedState()
     {
         var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
-            .Setup(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Setup(x => x.WaitForInstanceStartAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
             .Returns(CreateAsyncUnaryCall(new GetInstanceResponse
             {
                 Exists = true,
@@ -176,6 +176,8 @@ public class WorkflowGrpcClientTests
 
         Assert.Equal("i", result.InstanceId);
         Assert.Equal(WorkflowRuntimeStatus.Running, result.RuntimeStatus);
+        grpcClientMock.Verify(x => x.WaitForInstanceStartAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()), Times.Once);
+        grpcClientMock.Verify(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()), Times.Never);
     }
 
     [Fact]
@@ -185,7 +187,7 @@ public class WorkflowGrpcClientTests
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
-            .Setup(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Setup(x => x.WaitForInstanceStartAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
             .Returns(CreateAsyncUnaryCall(new GetInstanceResponse { Exists = false }));
 
         var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
@@ -194,13 +196,13 @@ public class WorkflowGrpcClientTests
     }
 
     [Fact]
-    public async Task WaitForWorkflowCompletionAsync_ShouldReturnImmediately_WhenStatusIsTerminal()
+    public async Task WaitForWorkflowCompletionAsync_ShouldUseServerBlockingRpc_AndReturnTerminalState()
     {
         var serializer = new JsonDaprSerializer();
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
-            .Setup(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Setup(x => x.WaitForInstanceCompletionAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
             .Returns(CreateAsyncUnaryCall(new GetInstanceResponse
             {
                 Exists = true,
@@ -220,6 +222,79 @@ public class WorkflowGrpcClientTests
         Assert.Equal("i", result.InstanceId);
         Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
         Assert.Equal("{\"ok\":true}", result.SerializedOutput);
+        grpcClientMock.Verify(x => x.WaitForInstanceCompletionAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()), Times.Once);
+        grpcClientMock.Verify(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WaitForWorkflowCompletionAsync_ShouldRetry_WhenWaitIsInterruptedByTransientError()
+    {
+        var serializer = new JsonDaprSerializer();
+
+        var attempts = 0;
+        var grpcClientMock = CreateGrpcClientMock();
+        grpcClientMock
+            .Setup(x => x.WaitForInstanceCompletionAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Returns(() =>
+            {
+                attempts++;
+                if (attempts == 1)
+                {
+                    return CreateAsyncUnaryCallThrows<GetInstanceResponse>(
+                        new RpcException(new Status(StatusCode.DeadlineExceeded, "deadline")));
+                }
+
+                return CreateAsyncUnaryCall(new GetInstanceResponse
+                {
+                    Exists = true,
+                    WorkflowState = new Dapr.DurableTask.Protobuf.WorkflowState
+                    {
+                        InstanceId = "i",
+                        Name = "n",
+                        WorkflowStatus = OrchestrationStatus.Completed
+                    }
+                });
+            });
+
+        var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
+
+        var result = await client.WaitForWorkflowCompletionAsync("i", getInputsAndOutputs: true, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public async Task WaitForWorkflowCompletionAsync_ShouldNotRetry_WhenWaitFailsWithNonTransientError()
+    {
+        var serializer = new JsonDaprSerializer();
+
+        var grpcClientMock = CreateGrpcClientMock();
+        grpcClientMock
+            .Setup(x => x.WaitForInstanceCompletionAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Returns(CreateAsyncUnaryCallThrows<GetInstanceResponse>(
+                new RpcException(new Status(StatusCode.InvalidArgument, "bad"))));
+
+        var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.WaitForWorkflowCompletionAsync("i", getInputsAndOutputs: true, cancellationToken: TestContext.Current.CancellationToken));
+        Assert.Equal(StatusCode.InvalidArgument, ex.StatusCode);
+        grpcClientMock.Verify(x => x.WaitForInstanceCompletionAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task WaitForWorkflowCompletionAsync_ShouldThrowOperationCanceled_WhenCancelled()
+    {
+        var serializer = new JsonDaprSerializer();
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var grpcClientMock = CreateGrpcClientMock();
+
+        var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => client.WaitForWorkflowCompletionAsync("i", getInputsAndOutputs: true, cancellationToken: cts.Token));
     }
 
     [Fact]
@@ -535,100 +610,10 @@ public class WorkflowGrpcClientTests
         await client.DisposeAsync();
     }
     
-    [Fact]
-    public async Task WaitForWorkflowStartAsync_ShouldPollUntilStatusIsNotPending()
-    {
-        var serializer = new JsonDaprSerializer();
-
-        var grpcClientMock = CreateGrpcClientMock();
-
-        var requests = new List<GetInstanceRequest>();
-        var callCount = 0;
-
-        grpcClientMock
-            .Setup(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
-            .Returns((GetInstanceRequest request, CallOptions _) =>
-            {
-                requests.Add(request);
-                callCount++;
-
-                var status = callCount == 1 ? OrchestrationStatus.Pending : OrchestrationStatus.Running;
-
-                return CreateAsyncUnaryCall(new GetInstanceResponse
-                {
-                    Exists = true,
-                    WorkflowState = new Dapr.DurableTask.Protobuf.WorkflowState
-                    {
-                        InstanceId = "i",
-                        Name = "n",
-                        WorkflowStatus = status
-                    }
-                });
-            });
-
-        var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var result = await client.WaitForWorkflowStartAsync("i", getInputsAndOutputs: false, cancellationToken: cts.Token);
-
-        Assert.Equal("i", result.InstanceId);
-        Assert.Equal(WorkflowRuntimeStatus.Running, result.RuntimeStatus);
-
-        Assert.True(requests.Count >= 2);
-        Assert.All(requests, r => Assert.Equal("i", r.InstanceId));
-        Assert.All(requests, r => Assert.False(r.GetInputsAndOutputs));
-    }
-
-    [Fact]
-    public async Task WaitForWorkflowCompletionAsync_ShouldPollUntilTerminalStatus()
-    {
-        var serializer = new JsonDaprSerializer();
-
-        var grpcClientMock = CreateGrpcClientMock();
-
-        var requests = new List<GetInstanceRequest>();
-        var callCount = 0;
-
-        grpcClientMock
-            .Setup(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
-            .Returns((GetInstanceRequest request, CallOptions _) =>
-            {
-                requests.Add(request);
-                callCount++;
-
-                var status = callCount == 1 ? OrchestrationStatus.Running : OrchestrationStatus.Completed;
-
-                return CreateAsyncUnaryCall(new GetInstanceResponse
-                {
-                    Exists = true,
-                    WorkflowState = new Dapr.DurableTask.Protobuf.WorkflowState
-                    {
-                        InstanceId = "i",
-                        Name = "n",
-                        WorkflowStatus = status,
-                        Output = status == OrchestrationStatus.Completed ? "\"done\"" : string.Empty
-                    }
-                });
-            });
-
-        var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-        var result = await client.WaitForWorkflowCompletionAsync("i", getInputsAndOutputs: true, cancellationToken: cts.Token);
-
-        Assert.Equal("i", result.InstanceId);
-        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
-        Assert.Equal("\"done\"", result.SerializedOutput);
-
-        Assert.True(requests.Count >= 2);
-        Assert.All(requests, r => Assert.Equal("i", r.InstanceId));
-        Assert.All(requests, r => Assert.True(r.GetInputsAndOutputs));
-    }
-    
     [Theory]
     [InlineData(OrchestrationStatus.Failed, WorkflowRuntimeStatus.Failed)]
     [InlineData(OrchestrationStatus.Terminated, WorkflowRuntimeStatus.Terminated)]
-    public async Task WaitForWorkflowCompletionAsync_ShouldReturnImmediately_WhenStatusIsTerminalFailedOrTerminated(
+    public async Task WaitForWorkflowCompletionAsync_ShouldMapTerminalStatus_ForFailedOrTerminated(
         OrchestrationStatus protoStatus,
         WorkflowRuntimeStatus expectedStatus)
     {
@@ -636,7 +621,7 @@ public class WorkflowGrpcClientTests
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
-            .Setup(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Setup(x => x.WaitForInstanceCompletionAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
             .Returns(CreateAsyncUnaryCall(new GetInstanceResponse
             {
                 Exists = true,
@@ -663,7 +648,7 @@ public class WorkflowGrpcClientTests
 
         var grpcClientMock = CreateGrpcClientMock();
         grpcClientMock
-            .Setup(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Setup(x => x.WaitForInstanceCompletionAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
             .Returns(CreateAsyncUnaryCall(new GetInstanceResponse { Exists = false }));
 
         var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
@@ -672,33 +657,6 @@ public class WorkflowGrpcClientTests
             () => client.WaitForWorkflowCompletionAsync("missing", getInputsAndOutputs: true, cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Contains("missing", ex.Message);
-    }
-
-    [Fact]
-    public async Task WaitForWorkflowCompletionAsync_ShouldRespectCancellationToken_WhileWaiting()
-    {
-        var serializer = new JsonDaprSerializer();
-
-        var grpcClientMock = CreateGrpcClientMock();
-        grpcClientMock
-            .Setup(x => x.GetInstanceAsync(It.IsAny<GetInstanceRequest>(), It.IsAny<CallOptions>()))
-            .Returns(CreateAsyncUnaryCall(new GetInstanceResponse
-            {
-                Exists = true,
-                WorkflowState = new Dapr.DurableTask.Protobuf.WorkflowState
-                {
-                    InstanceId = "i",
-                    Name = "n",
-                    WorkflowStatus = OrchestrationStatus.Running
-                }
-            }));
-
-        var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
-
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => client.WaitForWorkflowCompletionAsync("i", getInputsAndOutputs: true, cancellationToken: cts.Token));
     }
 
     private static Mock<TaskHubSidecarService.TaskHubSidecarServiceClient> CreateGrpcClientMock()


### PR DESCRIPTION
## Description

`WorkflowGrpcClient.WaitForWorkflowStartAsync` and `WaitForWorkflowCompletionAsync` implemented the wait as a **client-side polling loop** over the unary `GetInstance` RPC (500 ms / 1 s cadence) rather than calling the **server-side blocking** RPCs the sidecar already exposes for exactly this purpose:

```protobuf
rpc WaitForInstanceStart(GetInstanceRequest) returns (GetInstanceResponse);
rpc WaitForInstanceCompletion(GetInstanceRequest) returns (GetInstanceResponse);
```

These return the moment the instance reaches the target state, so no client polling is needed. The generated `WaitForInstance*Async` stubs existed but were never called.

This PR switches both methods to the blocking RPCs, wrapped in an exponential-backoff retry that re-issues on transient interruptions (`DeadlineExceeded` / `Unavailable`) and propagates cancellation — mirroring the `dapr/durabletask-go` client (`WaitForOrchestrationStart` / `WaitForOrchestrationCompletion`), which is what the Dapr **go-sdk** uses. Calls continue to flow through `CreateCallOptions(...)` so the `dapr-api-token` is honored.

No public API change; behavior stays compatible (still returns `WorkflowMetadata`, still throws `InvalidOperationException` if the instance doesn't exist).

## Issue reference

Fixes #1838

## Impact / motivation

For short-lived workflows the fixed poll cadence dominated wall-clock latency. Local benchmark against Dapr 1.17.3 with a workflow that completes server-side in ~28 ms:

| Path | p50 | p95 |
| --- | --- | --- |
| Old `WaitForWorkflowCompletionAsync` (poll) | 1066 ms | 1078 ms |
| Server-blocking `WaitForInstanceCompletion` | 49 ms | 133 ms |

It also removes needless repeated `GetInstance` load on the sidecar for long-running instances.

## go-sdk parity

`dapr/durabletask-go` `client/client_grpc.go` already does this — single blocking call wrapped in a backoff retry that stops on context cancellation. The .NET SDK was the lone outlier still client-polling. This brings it in line.

## How tested

- Updated `WorkflowGrpcClientTests` to drive the blocking RPCs.
- Added coverage for: blocking-RPC happy path (start + completion), transient-error retry-then-succeed, non-transient error propagation (no retry), and cancellation.
- Removed the now-obsolete client-poll tests.
- `dotnet test test/Dapr.Workflow.Test` — 398 passing (net8.0 / net10.0).

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Tests pass locally
- [ ] Extended the documentation, if applicable
