### PR TITLE
GetWorkflowStateAsync should always return `WorkflowState`

### DIFF
--- a/src/Dapr.Workflow/Client/WorkflowGrpcClient.cs
+++ b/src/Dapr.Workflow/Client/WorkflowGrpcClient.cs
@@ -73,9 +73,14 @@ internal sealed class WorkflowGrpcClient(
             var grpcCallOptions = CreateCallOptions(cancellationToken);
             var response = await grpcClient.GetInstanceAsync(request, grpcCallOptions);
 
-            if (!response.Exists)
+            if (response is null)
             {
                 logger.LogGetWorkflowMetadataInstanceNotFound(instanceId);
+                return null;
+            }
+
+            if (!response.Exists)
+            {
                 return null;
             }
 
@@ -83,7 +88,11 @@ internal sealed class WorkflowGrpcClient(
         }
         catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
         {
-            logger.LogGetWorkflowMetadataInstanceNotFound(ex, instanceId);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting workflow metadata for instance '{InstanceId}'", instanceId);
             return null;
         }
     }

--- a/src/Dapr.Workflow/DaprWorkflowClient.cs
+++ b/src/Dapr.Workflow/DaprWorkflowClient.cs
@@ -128,7 +128,7 @@ public sealed class DaprWorkflowClient : IDaprWorkflowClient
     /// exist or an error occurs retrieving the metadata.
     /// This method never throws.
     /// </returns>
-    public async Task<WorkflowState?> GetWorkflowStateAsync(
+    public async Task<WorkflowState> GetWorkflowStateAsync(
         string instanceId,
         bool getInputsAndOutputs = true,
         CancellationToken cancellation = default)

--- a/src/Dapr.Workflow/DaprWorkflowClient.cs
+++ b/src/Dapr.Workflow/DaprWorkflowClient.cs
@@ -138,12 +138,12 @@ public sealed class DaprWorkflowClient : IDaprWorkflowClient
         try
         {
             var metadata = await _innerClient.GetWorkflowMetadataAsync(instanceId, getInputsAndOutputs, cancellation);
-            return metadata is null ? null : new WorkflowState(metadata);    
+            return new WorkflowState(metadata);    
         }
         catch (RpcException)
         {
             // If the state doesn't exist, we typically get an `RpcException`, so this wraps this and just returns null
-            return null;
+            return new WorkflowState(null);
         }
     }
     

--- a/src/Dapr.Workflow/IDaprWorkflowClient.cs
+++ b/src/Dapr.Workflow/IDaprWorkflowClient.cs
@@ -91,7 +91,7 @@ public interface IDaprWorkflowClient: IDaprClient, IAsyncDisposable
     /// A <see cref="WorkflowMetadata"/> object, or <c>null</c> if the workflow instance does not exist.
     /// </returns>
     /// <exception cref="ArgumentException">Thrown if <paramref name="instanceId"/> is null or empty.</exception>
-    Task<WorkflowState?> GetWorkflowStateAsync(
+    Task<WorkflowState> GetWorkflowStateAsync(
         string instanceId,
         bool getInputsAndOutputs = true,
         CancellationToken cancellation = default);

--- a/test/Dapr.IntegrationTest.Workflow/PurgeTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/PurgeTests.cs
@@ -66,7 +66,8 @@ public sealed class PurgeTests
 
         // Verify workflow state no longer exists after purge
         var stateAfterPurge = await daprWorkflowClient.GetWorkflowStateAsync(workflowInstanceId, cancellation: TestContext.Current.CancellationToken);
-        Assert.Null(stateAfterPurge);
+        Assert.NotNull(stateAfterPurge);
+        Assert.False(stateAfterPurge.Exists);
     }
 
     [MinimumDaprRuntimeFact("1.17")]
@@ -153,15 +154,13 @@ public sealed class PurgeTests
         Assert.True(purged);
 
         var stateAfterPurge = await daprWorkflowClient.GetWorkflowStateAsync(workflowInstanceId, cancellation: TestContext.Current.CancellationToken);
-        Assert.Null(stateAfterPurge);
+        Assert.NotNull(stateAfterPurge);
+        Assert.False(stateAfterPurge.Exists);
     }
 
     private sealed class SimpleWorkflow : Workflow<string, string>
     {
-        public override Task<string> RunAsync(WorkflowContext context, string input)
-        {
-            return Task.FromResult($"Processed: {input}");
-        }
+        public override Task<string> RunAsync(WorkflowContext context, string input) => Task.FromResult($"Processed: {input}");
     }
 
     private sealed class LongRunningWorkflow : Workflow<object?, string>

--- a/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
+++ b/test/Dapr.Workflow.Test/DaprWorkflowClientTests.cs
@@ -85,20 +85,21 @@ public class DaprWorkflowClientTests
     }
 
     [Fact]
-    public async Task GetWorkflowStateAsync_ShouldReturnNull_WhenInnerReturnsNullMetadata()
+    public async Task GetWorkflowStateAsync_ShouldReflectNotExists_WhenInnerReturnsNullMetadata()
     {
         var inner = new CapturingWorkflowClient { GetWorkflowMetadataResult = null };
         var client = new DaprWorkflowClient(inner);
 
         var state = await client.GetWorkflowStateAsync("missing", cancellation: TestContext.Current.CancellationToken);
 
-        Assert.Null(state);
+        Assert.NotNull(state);
+        Assert.False(state.Exists);
         Assert.Equal("missing", inner.LastGetMetadataInstanceId);
         Assert.True(inner.LastGetMetadataGetInputsAndOutputs);
     }
 
     [Fact]
-    public async Task GetWorkflowStateAsync_ShouldReturnNull_WhenInnerThrowsRpcException()
+    public async Task GetWorkflowStateAsync_ShouldReflectNotExists_WhenInnerThrowsRpcException()
     {
         var inner = new CapturingWorkflowClient
         {
@@ -108,7 +109,8 @@ public class DaprWorkflowClientTests
 
         var state = await client.GetWorkflowStateAsync("i", cancellation: TestContext.Current.CancellationToken);
 
-        Assert.Null(state);
+        Assert.NotNull(state);
+        Assert.False(state.Exists);
     }
 
     [Fact]


### PR DESCRIPTION
# Description

Ensuring that GetWorkflowStateAsync always returns a `WorkflowState` so the `WorkflowState.Exists` properly reflects the presence of the value (or not). This was erroneously returning null if the metadata wasn't available when this is, in fact, a supported value in the `WorkflowState` object, so I'm applying this fix. The signature doesn't change, just the behavior, so this shouldn't be a dramatic breaking change.

Thank you to @atrauzzi for the helpful discussion in which this was pointed out.

Also, after a very long discussion with @atrauzzi about the merits of logging at the SDK level, he's won me over and I'm also removing the error that was previously logged when using `GetWorkflowStateAsync` when the workflow was returned as not existing. He's right in his assertion that an error was too severe for an operation that completed successfully. The error remains if the runtime returns an unexpected value (null or some other response shape), but will no longer log if it's just a matter of a workflow instance not existing in the runtime.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
