### PR TITLE
Removed 1.17 from CI testing temporarily

### DIFF
--- a/.github/tools/tag-selector/src/index.ts
+++ b/.github/tools/tag-selector/src/index.ts
@@ -22,7 +22,10 @@ async function run() {
             per_page: 100
         });
 
-        const tagNames = tags.map((t: { name: string }) => t.name);
+        // Temporary: skip Dapr 1.17.x while that version is blocked in testing.
+        const tagNames = tags
+            .map((t: { name: string }) => t.name)
+            .filter((name) => !name.includes("1.17."));
         const result = computeFromTags({
             tags: tagNames,
             tagPrefix,


### PR DESCRIPTION
# Description

The 1.17.10 runtime release is missing an unadorned container for both daprio/scheduler and daprio/placement, but 1.16 and 1.18 appear unaffected. As such, in the interest of getting the GA release out of the door, this patch temporarily pulls testing for the 1.17 release.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
