### PR TITLE
Fix build warnings about analyzer version in Dapr.Workflow

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <!-- Shipping analyzers must reference a Roslyn version that is no newer than supported consumer compilers. -->
+    <ShippingAnalyzerRoslynVersion>4.8.0</ShippingAnalyzerRoslynVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="A2A" Version="0.1.0-preview.2" />

--- a/src/Dapr.Common.Generators/Dapr.Common.Generators.csproj
+++ b/src/Dapr.Common.Generators/Dapr.Common.Generators.csproj
@@ -19,7 +19,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" VersionOverride="$(ShippingAnalyzerRoslynVersion)">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(ShippingAnalyzerRoslynVersion)">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>

--- a/src/Dapr.Workflow.Analyzers/Dapr.Workflow.Analyzers.csproj
+++ b/src/Dapr.Workflow.Analyzers/Dapr.Workflow.Analyzers.csproj
@@ -9,7 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" VersionOverride="$(ShippingAnalyzerRoslynVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(ShippingAnalyzerRoslynVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" VersionOverride="$(ShippingAnalyzerRoslynVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="$(ShippingAnalyzerRoslynVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Dapr.Workflow.Analyzers/WorkflowDependencyInjectionAnalyzer.cs
+++ b/src/Dapr.Workflow.Analyzers/WorkflowDependencyInjectionAnalyzer.cs
@@ -38,10 +38,7 @@ public sealed class WorkflowDependencyInjectionAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// Gets the diagnostics supported by this analyzer.
     /// </summary>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-    [
-        WorkflowDependencyInjectionDescriptor
-    ];
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(WorkflowDependencyInjectionDescriptor);
 
     /// <summary>
     /// Initializes analyzer actions.

--- a/src/Dapr.Workflow.Analyzers/WorkflowDependencyInjectionCodeFixProvider.cs
+++ b/src/Dapr.Workflow.Analyzers/WorkflowDependencyInjectionCodeFixProvider.cs
@@ -32,7 +32,7 @@ public sealed class WorkflowDependencyInjectionCodeFixProvider : CodeFixProvider
     /// <summary>
     /// Gets the diagnostic IDs that this provider can fix.
     /// </summary>
-    public override ImmutableArray<string> FixableDiagnosticIds => ["DAPR1305"];
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("DAPR1305");
 
     /// <summary>
     /// Registers the code fix for the diagnostic.

--- a/src/Dapr.Workflow.Analyzers/WorkflowTypeSafetyAnalyzer.cs
+++ b/src/Dapr.Workflow.Analyzers/WorkflowTypeSafetyAnalyzer.cs
@@ -32,11 +32,9 @@ public sealed class WorkflowTypeSafetyAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// Gets the diagnostics supported by this analyzer.
     /// </summary>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-    [
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
         InputTypeMismatchDescriptor,
-        OutputTypeMismatchDescriptor
-    ];
+        OutputTypeMismatchDescriptor);
 
     /// <summary>
     /// Initializes analyzer actions.

--- a/src/Dapr.Workflow.Versioning.Generators/Dapr.Workflow.Versioning.Generators.csproj
+++ b/src/Dapr.Workflow.Versioning.Generators/Dapr.Workflow.Versioning.Generators.csproj
@@ -17,7 +17,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" VersionOverride="$(ShippingAnalyzerRoslynVersion)" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(ShippingAnalyzerRoslynVersion)" PrivateAssets="all"/>
     </ItemGroup>
 
 

--- a/test/Dapr.Common.Generators.Tests/RoslynCompatibilityTests.cs
+++ b/test/Dapr.Common.Generators.Tests/RoslynCompatibilityTests.cs
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------------------
+// Copyright 2026 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Dapr.Common.Generators.Tests;
+
+public sealed class RoslynCompatibilityTests
+{
+    private static readonly Version MaximumSupportedRoslynReferenceVersion = new(4, 8, 0, 0);
+
+    [Fact]
+    public void ShippingGeneratorShouldNotReferenceRoslynNewerThanSupportedConsumerCompiler()
+    {
+        var references = typeof(DaprVersionAwareGenerator).Assembly.GetReferencedAssemblies()
+            .Where(IsRoslynAssembly)
+            .ToArray();
+
+        Assert.NotEmpty(references);
+
+        foreach (var reference in references)
+        {
+            Assert.True(
+                reference.Version <= MaximumSupportedRoslynReferenceVersion,
+                $"{typeof(DaprVersionAwareGenerator).Assembly.GetName().Name} references {reference.Name} {reference.Version}, which is newer than {MaximumSupportedRoslynReferenceVersion}.");
+        }
+    }
+
+    private static bool IsRoslynAssembly(AssemblyName reference) =>
+        reference.Name?.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal) == true;
+}

--- a/test/Dapr.IntegrationTest.Workflow.Versioning/RegistrationOrderRegressionIntegrationTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow.Versioning/RegistrationOrderRegressionIntegrationTests.cs
@@ -308,9 +308,38 @@ public sealed class RegistrationOrderRegressionIntegrationTests
         using var archive = ZipFile.OpenRead(packagePath);
         var entries = archive.Entries.Select(e => e.FullName).ToHashSet(StringComparer.Ordinal);
 
+        Assert.Contains("analyzers/dotnet/cs/Dapr.Workflow.Analyzers.dll", entries);
         Assert.Contains("analyzers/dotnet/cs/Dapr.Workflow.Versioning.Generators.dll", entries);
         Assert.Contains("lib/net8.0/Dapr.Workflow.Versioning.Abstractions.dll", entries);
         Assert.Contains("lib/net8.0/Dapr.Workflow.Versioning.Runtime.dll", entries);
+
+        AssertAnalyzerReferencesSupportedRoslynVersion(archive, "analyzers/dotnet/cs/Dapr.Workflow.Analyzers.dll");
+        AssertAnalyzerReferencesSupportedRoslynVersion(archive, "analyzers/dotnet/cs/Dapr.Workflow.Versioning.Generators.dll");
+    }
+
+    private static void AssertAnalyzerReferencesSupportedRoslynVersion(ZipArchive archive, string entryName)
+    {
+        var maximumSupportedRoslynReferenceVersion = new Version(4, 8, 0, 0);
+        var entry = archive.GetEntry(entryName)
+            ?? throw new InvalidOperationException($"Could not find package entry '{entryName}'.");
+
+        using var stream = entry.Open();
+        using var assemblyStream = new MemoryStream();
+        stream.CopyTo(assemblyStream);
+
+        var assembly = System.Reflection.Assembly.Load(assemblyStream.ToArray());
+        var references = assembly.GetReferencedAssemblies()
+            .Where(reference => reference.Name?.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal) == true)
+            .ToArray();
+
+        Assert.NotEmpty(references);
+
+        foreach (var reference in references)
+        {
+            Assert.True(
+                reference.Version <= maximumSupportedRoslynReferenceVersion,
+                $"{entryName} references {reference.Name} {reference.Version}, which is newer than {maximumSupportedRoslynReferenceVersion}.");
+        }
     }
 
     private static void RunDotNet(string workingDirectory, params string[] arguments) =>

--- a/test/Dapr.Workflow.Analyzers.Test/RoslynCompatibilityTests.cs
+++ b/test/Dapr.Workflow.Analyzers.Test/RoslynCompatibilityTests.cs
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------------------
+// Copyright 2026 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Dapr.Workflow.Analyzers.Test;
+
+public sealed class RoslynCompatibilityTests
+{
+    private static readonly Version MaximumSupportedRoslynReferenceVersion = new(4, 8, 0, 0);
+
+    [Fact]
+    public void ShippingAnalyzerShouldNotReferenceRoslynNewerThanSupportedConsumerCompiler()
+    {
+        var references = typeof(WorkflowTypeSafetyAnalyzer).Assembly.GetReferencedAssemblies()
+            .Where(IsRoslynAssembly)
+            .ToArray();
+
+        Assert.NotEmpty(references);
+
+        foreach (var reference in references)
+        {
+            Assert.True(
+                reference.Version <= MaximumSupportedRoslynReferenceVersion,
+                $"{typeof(WorkflowTypeSafetyAnalyzer).Assembly.GetName().Name} references {reference.Name} {reference.Version}, which is newer than {MaximumSupportedRoslynReferenceVersion}.");
+        }
+    }
+
+    private static bool IsRoslynAssembly(AssemblyName reference) =>
+        reference.Name?.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal) == true;
+}


### PR DESCRIPTION
# Description

Updating to remove collection expression syntax in analyzers that requires the newer immutable API so the assembly reference needn't be as high to remain compatible. Added test to prevent regression.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Thanks to @marcduiker for reporting this issue!

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
