### PR TITLE
FIx for Dapr.Common not being transiently referenced by project

### DIFF
--- a/all.sln
+++ b/all.sln
@@ -310,6 +310,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapr.Metadata.Test", "test\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapr.IntegrationTests.Metadata", "test\Dapr.IntegrationTests.Metadata\Dapr.IntegrationTests.Metadata.csproj", "{2A1AC4BF-25B1-4901-9E8D-B59BCE8950D7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapr.Packaging.Test", "test\Dapr.Packaging.Test\Dapr.Packaging.Test.csproj", "{6C51B34B-F254-4972-A643-492FAE712D2C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1844,6 +1846,18 @@ Global
 		{2A1AC4BF-25B1-4901-9E8D-B59BCE8950D7}.Release|x64.Build.0 = Release|Any CPU
 		{2A1AC4BF-25B1-4901-9E8D-B59BCE8950D7}.Release|x86.ActiveCfg = Release|Any CPU
 		{2A1AC4BF-25B1-4901-9E8D-B59BCE8950D7}.Release|x86.Build.0 = Release|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Debug|x64.Build.0 = Debug|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Debug|x86.Build.0 = Debug|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Release|x64.ActiveCfg = Release|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Release|x64.Build.0 = Release|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Release|x86.ActiveCfg = Release|Any CPU
+		{6C51B34B-F254-4972-A643-492FAE712D2C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1995,6 +2009,7 @@ Global
 		{FDB10D1D-E614-4271-B747-F8D6991C2EFE} = {27C5D71D-0721-4221-9286-B94AB07B58CF}
 		{632C7482-8CEB-457F-9D4C-1EE41E05C0CC} = {0AF0FE8D-C234-4F04-8514-32206ACE01BD}
 		{2A1AC4BF-25B1-4901-9E8D-B59BCE8950D7} = {8462B106-175A-423A-BA94-BE0D39D0BD8E}
+		{6C51B34B-F254-4972-A643-492FAE712D2C} = {DD020B34-460F-455F-8D17-CF4A949F100B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {65220BF2-EAE1-4CB2-AA58-EBE80768CB40}

--- a/src/Dapr.Metadata/Dapr.Metadata.csproj
+++ b/src/Dapr.Metadata/Dapr.Metadata.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -11,10 +11,7 @@
         <!-- This aggregator produces no own binaries -->
         <IncludeBuildOutput>false</IncludeBuildOutput>
 
-        <!-- We embed children; do NOT emit dependency groups -->
-        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-
-        <!-- Aggregator package has lib assets but no dependencies -->
+        <!-- Aggregator package has lib assets from bundled child projects -->
         <NoWarn>$(NoWarn);NU5128</NoWarn>
 
         <!-- Avoid creating an empty .snupkg -->
@@ -38,18 +35,30 @@
     </Target>
 
     <ItemGroup>
-        <!-- Build children but do NOT turn them into NuGet dependencies -->
-        <ProjectReference Include="..\Dapr.Metadata.Abstractions\Dapr.Metadata.Abstractions.csproj"
+        <!-- Child projects whose outputs are bundled into this package but are NOT NuGet dependencies. -->
+        <_MetadataChildLib Include="..\Dapr.Metadata.Abstractions\Dapr.Metadata.Abstractions.csproj" />
+        <_MetadataChildLib Include="..\Dapr.Metadata.Runtime\Dapr.Metadata.Runtime.csproj" />
+
+        <ProjectReference Include="@(_MetadataChildLib)"
                           PrivateAssets="all"
                           ReferenceOutputAssembly="false" />
-        <ProjectReference Include="..\Dapr.Metadata.Runtime\Dapr.Metadata.Runtime.csproj"
-                          PrivateAssets="all"
-                          ReferenceOutputAssembly="false" />
+
+        <!-- Dapr.Common remains a visible dependency because the bundled assemblies expose and use
+             its public types, and consumers need it as a compile/runtime asset. -->
+        <ProjectReference Include="..\Dapr.Common\Dapr.Common.csproj" />
+    </ItemGroup>
+
+    <!-- Package references required by the bundled runtime assembly. These must remain visible to
+         consumers because the runtime project is bundled privately instead of published separately. -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
     </ItemGroup>
 
     <!-- Build child libs for the current TFM -->
     <Target Name="_BuildChildrenForCurrentTFM">
-        <MSBuild Projects="@(ProjectReference)"
+        <MSBuild Projects="@(_MetadataChildLib)"
                  Targets="Build"
                  Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)"
                  BuildInParallel="true" />
@@ -58,7 +67,7 @@
     <!-- Create per-TFM content items mapped to lib/<tfm>/ -->
     <Target Name="_CollectChildOutputsForCurrentTFM" DependsOnTargets="_BuildChildrenForCurrentTFM">
         <!-- Ask children for their TargetPath for THIS TFM -->
-        <MSBuild Projects="@(ProjectReference)"
+        <MSBuild Projects="@(_MetadataChildLib)"
                  Targets="GetTargetPath"
                  Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)">
             <Output TaskParameter="TargetOutputs" ItemName="_BuiltChildOutputs" />

--- a/src/Dapr.SecretsManagement/Dapr.SecretsManagement.csproj
+++ b/src/Dapr.SecretsManagement/Dapr.SecretsManagement.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -11,10 +11,7 @@
         <!-- This aggregator produces no own binaries -->
         <IncludeBuildOutput>false</IncludeBuildOutput>
 
-        <!-- We embed children; do NOT emit dependency groups -->
-        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-
-        <!-- Aggregator package has lib assets but no dependencies -->
+        <!-- Aggregator package has lib assets from bundled child projects -->
         <NoWarn>$(NoWarn);NU5128</NoWarn>
 
         <!-- Avoid creating an empty .snupkg -->
@@ -42,16 +39,30 @@
     </Target>
 
     <ItemGroup>
-        <!-- Build children but do NOT turn them into NuGet dependencies -->
-        <ProjectReference Include="..\Dapr.SecretsManagement.Abstractions\Dapr.SecretsManagement.Abstractions.csproj"
+        <!-- Child projects whose outputs are bundled into this package but are NOT NuGet dependencies. -->
+        <_SecretsManagementChildLib Include="..\Dapr.SecretsManagement.Abstractions\Dapr.SecretsManagement.Abstractions.csproj" />
+        <_SecretsManagementChildLib Include="..\Dapr.SecretsManagement.Runtime\Dapr.SecretsManagement.Runtime.csproj" />
+
+        <ProjectReference Include="@(_SecretsManagementChildLib)"
                           PrivateAssets="all" ReferenceOutputAssembly="false" />
-        <ProjectReference Include="..\Dapr.SecretsManagement.Runtime\Dapr.SecretsManagement.Runtime.csproj"
-                          PrivateAssets="all" ReferenceOutputAssembly="false" />
+
+        <!-- Dapr.Common remains a visible dependency because the bundled assemblies expose and use
+             its public types, and consumers need it as a compile/runtime asset. -->
+        <ProjectReference Include="..\Dapr.Common\Dapr.Common.csproj" />
+    </ItemGroup>
+
+    <!-- Package references required by the bundled runtime assembly. These must remain visible to
+         consumers because the runtime project is bundled privately instead of published separately. -->
+    <ItemGroup>
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Net.Client" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
     </ItemGroup>
 
     <!-- Build child libs for the current TFM -->
     <Target Name="_BuildChildrenForCurrentTFM">
-        <MSBuild Projects="@(ProjectReference)"
+        <MSBuild Projects="@(_SecretsManagementChildLib)"
                  Targets="Build"
                  Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)"
                  BuildInParallel="true" />
@@ -61,7 +72,7 @@
 
     <Target Name="_CollectChildOutputsForCurrentTFM" DependsOnTargets="_BuildChildrenForCurrentTFM">
         <!-- Ask children for their TargetPath for THIS TFM -->
-        <MSBuild Projects="@(ProjectReference)"
+        <MSBuild Projects="@(_SecretsManagementChildLib)"
                  Targets="GetTargetPath"
                  Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)">
             <Output TaskParameter="TargetOutputs" ItemName="_BuiltChildOutputs" />

--- a/src/Dapr.StateManagement/Dapr.StateManagement.csproj
+++ b/src/Dapr.StateManagement/Dapr.StateManagement.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
@@ -11,10 +11,7 @@
         <!-- This aggregator produces no own binaries -->
         <IncludeBuildOutput>false</IncludeBuildOutput>
 
-        <!-- We embed children; do NOT emit dependency groups -->
-        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-
-        <!-- Aggregator package has lib assets but no dependencies -->
+        <!-- Aggregator package has lib assets from bundled child projects -->
         <NoWarn>$(NoWarn);NU5128</NoWarn>
 
         <!-- Avoid creating an empty .snupkg -->
@@ -43,16 +40,30 @@
     </Target>
 
     <ItemGroup>
-        <!-- Build children but do NOT turn them into NuGet dependencies -->
-        <ProjectReference Include="..\Dapr.StateManagement.Abstractions\Dapr.StateManagement.Abstractions.csproj"
+        <!-- Child projects whose outputs are bundled into this package but are NOT NuGet dependencies. -->
+        <_StateManagementChildLib Include="..\Dapr.StateManagement.Abstractions\Dapr.StateManagement.Abstractions.csproj" />
+        <_StateManagementChildLib Include="..\Dapr.StateManagement.Runtime\Dapr.StateManagement.Runtime.csproj" />
+
+        <ProjectReference Include="@(_StateManagementChildLib)"
                           PrivateAssets="all" ReferenceOutputAssembly="false" />
-        <ProjectReference Include="..\Dapr.StateManagement.Runtime\Dapr.StateManagement.Runtime.csproj"
-                          PrivateAssets="all" ReferenceOutputAssembly="false" />
+
+        <!-- Dapr.Common remains a visible dependency because the bundled assemblies expose and use
+             its public types, and consumers need it as a compile/runtime asset. -->
+        <ProjectReference Include="..\Dapr.Common\Dapr.Common.csproj" />
+    </ItemGroup>
+
+    <!-- Package references required by the bundled child assemblies. These must remain visible to
+         consumers because the child projects are bundled privately instead of published separately. -->
+    <ItemGroup>
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Grpc.Net.Client" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
     </ItemGroup>
 
     <!-- Build child libs for the current TFM -->
     <Target Name="_BuildChildrenForCurrentTFM">
-        <MSBuild Projects="@(ProjectReference)"
+        <MSBuild Projects="@(_StateManagementChildLib)"
                  Targets="Build"
                  Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)"
                  BuildInParallel="true" />
@@ -61,7 +72,7 @@
     <!-- Collect per-TFM outputs and map them into lib/<tfm>/ in the package -->
     <Target Name="_CollectChildOutputsForCurrentTFM" DependsOnTargets="_BuildChildrenForCurrentTFM">
         <!-- Ask children for their TargetPath for THIS TFM -->
-        <MSBuild Projects="@(ProjectReference)"
+        <MSBuild Projects="@(_StateManagementChildLib)"
                  Targets="GetTargetPath"
                  Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)">
             <Output TaskParameter="TargetOutputs" ItemName="_BuiltChildOutputs" />

--- a/test/Dapr.IntegrationTest.Workflow.Versioning/VersioningIntegrationTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow.Versioning/VersioningIntegrationTests.cs
@@ -121,8 +121,7 @@ public sealed class VersioningIntegrationTests
                 }
             }
 
-            var startedState = await client1.GetWorkflowStateAsync(instanceId, getInputsAndOutputs: false);
-            Assert.True(startedState?.Exists, "Expected workflow instance to exist before shutdown.");
+            await WaitForWorkflowExistsAsync(client1, instanceId, TimeSpan.FromMinutes(1));
         }
 
         await using (var appV2 = await StartNonVersionedAppAsync(componentsDirV2, environment, options))

--- a/test/Dapr.Packaging.Test/AggregatorPackageTests.cs
+++ b/test/Dapr.Packaging.Test/AggregatorPackageTests.cs
@@ -1,265 +1,196 @@
-using System.Diagnostics;
-using System.IO.Compression;
 using System.Xml.Linq;
 
 namespace Dapr.Packaging.Test;
 
+#if NET10_0
 public sealed class AggregatorPackageTests
 {
-    private static readonly string[] TargetFrameworks = ["net8.0", "net9.0", "net10.0"];
-
-    public static TheoryData<PackageWithBundledAssetsCase> PackagesWithBundledAssets => new()
+    public static TheoryData<PackageContractCase> PackagesWithBundledAssets => new()
     {
-        new PackageWithBundledAssetsCase(
+        new PackageContractCase(
             PackageId: "Dapr.SecretsManagement",
             ProjectPath: Path.Combine("src", "Dapr.SecretsManagement", "Dapr.SecretsManagement.csproj"),
-            RequiredDependencies:
+            RequiredProjectReferences:
             [
-                "Dapr.Common",
+                "Dapr.Common.csproj",
+            ],
+            RequiredPackageReferences:
+            [
                 "Google.Protobuf",
                 "Grpc.Net.Client",
                 "Microsoft.Extensions.DependencyInjection.Abstractions",
                 "Microsoft.Extensions.Http",
             ],
-            RequiredLibAssets:
+            RequiredBundledProjects:
             [
-                "Dapr.SecretsManagement.Abstractions.dll",
-                "Dapr.SecretsManagement.Runtime.dll",
+                "Dapr.SecretsManagement.Abstractions.csproj",
+                "Dapr.SecretsManagement.Runtime.csproj",
             ],
-            ForbiddenLibAssets:
+            RequiredAnalyzerProjects:
             [
-                "Dapr.SecretsManagement.dll",
+                "Dapr.SecretsManagement.Generators.csproj",
             ],
-            RequiredAnalyzerAssets:
-            [
-                "Dapr.SecretsManagement.Generators.dll",
-            ]),
+            IncludeBuildOutput: false),
 
-        new PackageWithBundledAssetsCase(
+        new PackageContractCase(
             PackageId: "Dapr.StateManagement",
             ProjectPath: Path.Combine("src", "Dapr.StateManagement", "Dapr.StateManagement.csproj"),
-            RequiredDependencies:
+            RequiredProjectReferences:
             [
-                "Dapr.Common",
+                "Dapr.Common.csproj",
+            ],
+            RequiredPackageReferences:
+            [
                 "Google.Protobuf",
                 "Grpc.Net.Client",
                 "Microsoft.Extensions.DependencyInjection.Abstractions",
                 "Microsoft.Extensions.Http",
             ],
-            RequiredLibAssets:
+            RequiredBundledProjects:
             [
-                "Dapr.StateManagement.Abstractions.dll",
-                "Dapr.StateManagement.Runtime.dll",
+                "Dapr.StateManagement.Abstractions.csproj",
+                "Dapr.StateManagement.Runtime.csproj",
             ],
-            ForbiddenLibAssets:
+            RequiredAnalyzerProjects:
             [
-                "Dapr.StateManagement.dll",
+                "Dapr.StateManagement.Generators.csproj",
             ],
-            RequiredAnalyzerAssets:
-            [
-                "Dapr.StateManagement.Generators.dll",
-            ]),
+            IncludeBuildOutput: false),
 
-        new PackageWithBundledAssetsCase(
+        new PackageContractCase(
             PackageId: "Dapr.Metadata",
             ProjectPath: Path.Combine("src", "Dapr.Metadata", "Dapr.Metadata.csproj"),
-            RequiredDependencies:
+            RequiredProjectReferences:
             [
-                "Dapr.Common",
+                "Dapr.Common.csproj",
+            ],
+            RequiredPackageReferences:
+            [
                 "Microsoft.Extensions.DependencyInjection.Abstractions",
                 "Microsoft.Extensions.Hosting.Abstractions",
                 "Microsoft.Extensions.Http",
             ],
-            RequiredLibAssets:
+            RequiredBundledProjects:
             [
-                "Dapr.Metadata.Abstractions.dll",
-                "Dapr.Metadata.Runtime.dll",
+                "Dapr.Metadata.Abstractions.csproj",
+                "Dapr.Metadata.Runtime.csproj",
             ],
-            ForbiddenLibAssets:
+            RequiredAnalyzerProjects:
             [
-                "Dapr.Metadata.dll",
             ],
-            RequiredAnalyzerAssets:
-            [
-            ]),
+            IncludeBuildOutput: false),
 
-        new PackageWithBundledAssetsCase(
+        new PackageContractCase(
             PackageId: "Dapr.Workflow",
             ProjectPath: Path.Combine("src", "Dapr.Workflow", "Dapr.Workflow.csproj"),
-            RequiredDependencies:
+            RequiredProjectReferences:
             [
-                "Dapr.Common",
+                "Dapr.Common.csproj",
+            ],
+            RequiredPackageReferences:
+            [
                 "Google.Protobuf",
                 "Grpc.Net.Client",
                 "Grpc.Net.ClientFactory",
                 "Microsoft.Extensions.Hosting",
                 "Microsoft.Extensions.Http",
             ],
-            RequiredLibAssets:
+            RequiredBundledProjects:
             [
-                "Dapr.Workflow.dll",
-                "Dapr.Workflow.Abstractions.dll",
-                "Dapr.Workflow.Grpc.dll",
-                "Dapr.Workflow.Versioning.Abstractions.dll",
-                "Dapr.Workflow.Versioning.Runtime.dll",
+                "Dapr.Workflow.Abstractions.csproj",
+                "Dapr.Workflow.Grpc.csproj",
+                "Dapr.Workflow.Versioning.Abstractions.csproj",
+                "Dapr.Workflow.Versioning.Runtime.csproj",
             ],
-            ForbiddenLibAssets:
+            RequiredAnalyzerProjects:
             [
+                "Dapr.Workflow.Analyzers.csproj",
+                "Dapr.Workflow.Versioning.Generators.csproj",
             ],
-            RequiredAnalyzerAssets:
-            [
-                "Dapr.Workflow.Analyzers.dll",
-                "Dapr.Workflow.Versioning.Generators.dll",
-            ]),
-
+            IncludeBuildOutput: true),
     };
 
     [Theory]
     [MemberData(nameof(PackagesWithBundledAssets))]
-    public async Task Package_ExposesConsumerDependenciesAndExpectedAssets(PackageWithBundledAssetsCase package)
+    public void AggregatorPackage_ProjectFilePreservesPackagingContract(PackageContractCase package)
     {
         var repoRoot = FindRepoRoot();
-        var packageOutput = await PackPackageAsync(repoRoot, package.PackageId, package.ProjectPath);
+        var projectPath = Path.Combine(repoRoot, package.ProjectPath);
+        var project = XDocument.Load(projectPath);
+        var elements = project.Descendants().ToArray();
 
-        try
+        Assert.Equal(package.PackageId, GetPropertyValue(elements, "PackageId"));
+        Assert.DoesNotContain(elements, element => element.Name.LocalName == "SuppressDependenciesWhenPacking");
+        Assert.Equal(package.IncludeBuildOutput, GetBooleanPropertyValue(elements, "IncludeBuildOutput", defaultValue: true));
+
+        var projectReferences = GetItemIncludes(elements, "ProjectReference");
+        var packageReferences = GetItemIncludes(elements, "PackageReference");
+        var bundledProjectReferences = GetItemIncludes(elements, element => element.Name.LocalName.EndsWith("ChildLib", StringComparison.Ordinal));
+        var projectPathMentions = GetProjectPathMentions(elements);
+
+        foreach (var requiredProjectReference in package.RequiredProjectReferences)
         {
-            using var archive = ZipFile.OpenRead(packageOutput.PackagePath);
-            var entryNames = archive.Entries.Select(entry => entry.FullName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var nuspec = ReadNuspec(archive, package.PackageId);
-
-            foreach (var requiredAnalyzerAsset in package.RequiredAnalyzerAssets)
-            {
-                Assert.Contains($"analyzers/dotnet/cs/{requiredAnalyzerAsset}", entryNames);
-            }
-
-            foreach (var targetFramework in TargetFrameworks)
-            {
-                var dependencies = GetDependencyIds(nuspec, targetFramework);
-
-                foreach (var requiredDependency in package.RequiredDependencies)
-                {
-                    Assert.Contains(requiredDependency, dependencies);
-                }
-
-                foreach (var requiredLibAsset in package.RequiredLibAssets)
-                {
-                    Assert.Contains($"lib/{targetFramework}/{requiredLibAsset}", entryNames);
-                }
-
-                foreach (var forbiddenLibAsset in package.ForbiddenLibAssets)
-                {
-                    Assert.DoesNotContain($"lib/{targetFramework}/{forbiddenLibAsset}", entryNames);
-                }
-            }
+            Assert.Contains(projectReferences, reference => Path.GetFileName(reference) == requiredProjectReference);
         }
-        finally
+
+        foreach (var requiredPackageReference in package.RequiredPackageReferences)
         {
-            packageOutput.Dispose();
+            Assert.Contains(requiredPackageReference, packageReferences);
         }
+
+        foreach (var requiredBundledProject in package.RequiredBundledProjects)
+        {
+            Assert.Contains(bundledProjectReferences, reference => Path.GetFileName(reference) == requiredBundledProject);
+        }
+
+        foreach (var requiredAnalyzerProject in package.RequiredAnalyzerProjects)
+        {
+            Assert.Contains(projectPathMentions, reference => Path.GetFileName(reference) == requiredAnalyzerProject);
+        }
+
+        AssertTargetsTfmSpecificPackageFiles(elements);
     }
 
-    private static async Task<PackageOutput> PackPackageAsync(string repoRoot, string packageId, string projectPath)
-    {
-        var outputDirectory = Path.Combine(Path.GetTempPath(), "dapr-packaging-tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(outputDirectory);
+    private static string? GetPropertyValue(IEnumerable<XElement> elements, string propertyName) =>
+        elements.SingleOrDefault(element => element.Name.LocalName == propertyName)?.Value;
 
-        return await PackPackageToDirectoryAsync(repoRoot, packageId, projectPath, outputDirectory, ownsDirectory: true);
+    private static bool GetBooleanPropertyValue(IEnumerable<XElement> elements, string propertyName, bool defaultValue)
+    {
+        var value = GetPropertyValue(elements, propertyName);
+
+        return value is null
+            ? defaultValue
+            : bool.Parse(value);
     }
 
-    private static async Task<PackageOutput> PackPackageToDirectoryAsync(
-        string repoRoot,
-        string packageId,
-        string projectPath,
-        string outputDirectory,
-        bool ownsDirectory = false)
-    {
-        var fullProjectPath = Path.Combine(repoRoot, projectPath);
-        var result = await RunDotnetAsync(
-            repoRoot,
-            "pack",
-            fullProjectPath,
-            "--configuration",
-            "Debug",
-            "--no-restore",
-            "--output",
-            outputDirectory);
+    private static string[] GetItemIncludes(IEnumerable<XElement> elements, string itemName) =>
+        GetItemIncludes(elements, element => element.Name.LocalName == itemName);
 
-        Assert.True(
-            result.ExitCode == 0,
-            $"dotnet pack failed for {packageId}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
-
-        var packages = Directory
-            .GetFiles(outputDirectory, $"{packageId}.*.nupkg")
-            .OrderByDescending(File.GetLastWriteTimeUtc)
+    private static string[] GetItemIncludes(IEnumerable<XElement> elements, Func<XElement, bool> predicate) =>
+        elements
+            .Where(predicate)
+            .Select(element => (string?)element.Attribute("Include"))
+            .Where(include => !string.IsNullOrWhiteSpace(include))
+            .Select(include => include!)
             .ToArray();
 
-        return new PackageOutput(Assert.Single(packages), ownsDirectory ? outputDirectory : null);
-    }
+    private static string[] GetProjectPathMentions(IEnumerable<XElement> elements) =>
+        elements
+            .SelectMany(element => element.Attributes())
+            .Where(attribute => attribute.Name.LocalName is "Include" or "Projects")
+            .Select(attribute => attribute.Value)
+            .SelectMany(value => value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Where(value => value.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
 
-    private static async Task<ProcessResult> RunDotnetAsync(string workingDirectory, params string[] arguments)
+    private static void AssertTargetsTfmSpecificPackageFiles(IEnumerable<XElement> elements)
     {
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(90));
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "dotnet",
-            WorkingDirectory = workingDirectory,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
+        var packagePaths = elements
+            .Where(element => element.Name.LocalName == "PackagePath")
+            .Select(element => element.Value)
+            .ToArray();
 
-        foreach (var argument in arguments)
-        {
-            startInfo.ArgumentList.Add(argument);
-        }
-
-        using var process = Process.Start(startInfo);
-        Assert.NotNull(process);
-
-        var standardOutput = process.StandardOutput.ReadToEndAsync();
-        var standardError = process.StandardError.ReadToEndAsync();
-        try
-        {
-            await process.WaitForExitAsync(cancellation.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            process.Kill(entireProcessTree: true);
-            throw new TimeoutException($"dotnet {string.Join(" ", arguments)} timed out.");
-        }
-
-        return new ProcessResult(
-            process.ExitCode,
-            await standardOutput,
-            await standardError);
-    }
-
-    private static XDocument ReadNuspec(ZipArchive archive, string packageId)
-    {
-        var nuspecEntry = archive.GetEntry($"{packageId}.nuspec");
-        Assert.NotNull(nuspecEntry);
-
-        using var stream = nuspecEntry.Open();
-        return XDocument.Load(stream);
-    }
-
-    private static HashSet<string> GetDependencyIds(XDocument nuspec, string targetFramework)
-    {
-        XNamespace ns = nuspec.Root?.Name.Namespace ?? XNamespace.None;
-        var group = nuspec
-            .Descendants(ns + "group")
-            .SingleOrDefault(element => string.Equals(
-                (string?)element.Attribute("targetFramework"),
-                targetFramework,
-                StringComparison.OrdinalIgnoreCase));
-
-        Assert.NotNull(group);
-
-        return group
-            .Elements(ns + "dependency")
-            .Select(element => (string?)element.Attribute("id"))
-            .Where(id => id is not null)
-            .Select(id => id!)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        Assert.Contains(packagePaths, path => path.Contains("lib/", StringComparison.OrdinalIgnoreCase) || path.Contains("lib\\", StringComparison.OrdinalIgnoreCase));
     }
 
     private static string FindRepoRoot()
@@ -281,27 +212,16 @@ public sealed class AggregatorPackageTests
         throw new InvalidOperationException("Could not locate the repository root.");
     }
 
-    public sealed record PackageWithBundledAssetsCase(
+    public sealed record PackageContractCase(
         string PackageId,
         string ProjectPath,
-        string[] RequiredDependencies,
-        string[] RequiredLibAssets,
-        string[] ForbiddenLibAssets,
-        string[] RequiredAnalyzerAssets)
+        string[] RequiredProjectReferences,
+        string[] RequiredPackageReferences,
+        string[] RequiredBundledProjects,
+        string[] RequiredAnalyzerProjects,
+        bool IncludeBuildOutput)
     {
         public override string ToString() => PackageId;
     }
-
-    private sealed record PackageOutput(string PackagePath, string? OwnedDirectory) : IDisposable
-    {
-        public void Dispose()
-        {
-            if (OwnedDirectory is not null && Directory.Exists(OwnedDirectory))
-            {
-                Directory.Delete(OwnedDirectory, recursive: true);
-            }
-        }
-    }
-
-    private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
 }
+#endif

--- a/test/Dapr.Packaging.Test/AggregatorPackageTests.cs
+++ b/test/Dapr.Packaging.Test/AggregatorPackageTests.cs
@@ -8,9 +8,9 @@ public sealed class AggregatorPackageTests
 {
     private static readonly string[] TargetFrameworks = ["net8.0", "net9.0", "net10.0"];
 
-    public static TheoryData<AggregatorPackageCase> AggregatorPackages => new()
+    public static TheoryData<PackageWithBundledAssetsCase> PackagesWithBundledAssets => new()
     {
-        new AggregatorPackageCase(
+        new PackageWithBundledAssetsCase(
             PackageId: "Dapr.SecretsManagement",
             ProjectPath: Path.Combine("src", "Dapr.SecretsManagement", "Dapr.SecretsManagement.csproj"),
             RequiredDependencies:
@@ -29,21 +29,108 @@ public sealed class AggregatorPackageTests
             ForbiddenLibAssets:
             [
                 "Dapr.SecretsManagement.dll",
+            ],
+            RequiredAnalyzerAssets:
+            [
+                "Dapr.SecretsManagement.Generators.dll",
             ]),
+
+        new PackageWithBundledAssetsCase(
+            PackageId: "Dapr.StateManagement",
+            ProjectPath: Path.Combine("src", "Dapr.StateManagement", "Dapr.StateManagement.csproj"),
+            RequiredDependencies:
+            [
+                "Dapr.Common",
+                "Google.Protobuf",
+                "Grpc.Net.Client",
+                "Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.Http",
+            ],
+            RequiredLibAssets:
+            [
+                "Dapr.StateManagement.Abstractions.dll",
+                "Dapr.StateManagement.Runtime.dll",
+            ],
+            ForbiddenLibAssets:
+            [
+                "Dapr.StateManagement.dll",
+            ],
+            RequiredAnalyzerAssets:
+            [
+                "Dapr.StateManagement.Generators.dll",
+            ]),
+
+        new PackageWithBundledAssetsCase(
+            PackageId: "Dapr.Metadata",
+            ProjectPath: Path.Combine("src", "Dapr.Metadata", "Dapr.Metadata.csproj"),
+            RequiredDependencies:
+            [
+                "Dapr.Common",
+                "Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.Hosting.Abstractions",
+                "Microsoft.Extensions.Http",
+            ],
+            RequiredLibAssets:
+            [
+                "Dapr.Metadata.Abstractions.dll",
+                "Dapr.Metadata.Runtime.dll",
+            ],
+            ForbiddenLibAssets:
+            [
+                "Dapr.Metadata.dll",
+            ],
+            RequiredAnalyzerAssets:
+            [
+            ]),
+
+        new PackageWithBundledAssetsCase(
+            PackageId: "Dapr.Workflow",
+            ProjectPath: Path.Combine("src", "Dapr.Workflow", "Dapr.Workflow.csproj"),
+            RequiredDependencies:
+            [
+                "Dapr.Common",
+                "Google.Protobuf",
+                "Grpc.Net.Client",
+                "Grpc.Net.ClientFactory",
+                "Microsoft.Extensions.Hosting",
+                "Microsoft.Extensions.Http",
+            ],
+            RequiredLibAssets:
+            [
+                "Dapr.Workflow.dll",
+                "Dapr.Workflow.Abstractions.dll",
+                "Dapr.Workflow.Grpc.dll",
+                "Dapr.Workflow.Versioning.Abstractions.dll",
+                "Dapr.Workflow.Versioning.Runtime.dll",
+            ],
+            ForbiddenLibAssets:
+            [
+            ],
+            RequiredAnalyzerAssets:
+            [
+                "Dapr.Workflow.Analyzers.dll",
+                "Dapr.Workflow.Versioning.Generators.dll",
+            ]),
+
     };
 
     [Theory]
-    [MemberData(nameof(AggregatorPackages))]
-    public async Task AggregatorPackage_ExposesConsumerDependenciesAndBundledAssets(AggregatorPackageCase package)
+    [MemberData(nameof(PackagesWithBundledAssets))]
+    public async Task Package_ExposesConsumerDependenciesAndExpectedAssets(PackageWithBundledAssetsCase package)
     {
         var repoRoot = FindRepoRoot();
-        var packagePath = await PackPackageAsync(repoRoot, package);
+        var packageOutput = await PackPackageAsync(repoRoot, package.PackageId, package.ProjectPath);
 
         try
         {
-            using var archive = ZipFile.OpenRead(packagePath);
+            using var archive = ZipFile.OpenRead(packageOutput.PackagePath);
             var entryNames = archive.Entries.Select(entry => entry.FullName).ToHashSet(StringComparer.OrdinalIgnoreCase);
             var nuspec = ReadNuspec(archive, package.PackageId);
+
+            foreach (var requiredAnalyzerAsset in package.RequiredAnalyzerAssets)
+            {
+                Assert.Contains($"analyzers/dotnet/cs/{requiredAnalyzerAsset}", entryNames);
+            }
 
             foreach (var targetFramework in TargetFrameworks)
             {
@@ -67,36 +154,51 @@ public sealed class AggregatorPackageTests
         }
         finally
         {
-            Directory.Delete(Path.GetDirectoryName(packagePath)!, recursive: true);
+            packageOutput.Dispose();
         }
     }
 
-    private static async Task<string> PackPackageAsync(string repoRoot, AggregatorPackageCase package)
+    private static async Task<PackageOutput> PackPackageAsync(string repoRoot, string packageId, string projectPath)
     {
         var outputDirectory = Path.Combine(Path.GetTempPath(), "dapr-packaging-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(outputDirectory);
 
-        var projectPath = Path.Combine(repoRoot, package.ProjectPath);
+        return await PackPackageToDirectoryAsync(repoRoot, packageId, projectPath, outputDirectory, ownsDirectory: true);
+    }
+
+    private static async Task<PackageOutput> PackPackageToDirectoryAsync(
+        string repoRoot,
+        string packageId,
+        string projectPath,
+        string outputDirectory,
+        bool ownsDirectory = false)
+    {
+        var fullProjectPath = Path.Combine(repoRoot, projectPath);
         var result = await RunDotnetAsync(
             repoRoot,
             "pack",
-            projectPath,
+            fullProjectPath,
             "--configuration",
             "Debug",
+            "--no-restore",
             "--output",
             outputDirectory);
 
         Assert.True(
             result.ExitCode == 0,
-            $"dotnet pack failed for {package.PackageId}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
+            $"dotnet pack failed for {packageId}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
 
-        var packages = Directory.GetFiles(outputDirectory, $"{package.PackageId}.*.nupkg");
-        return Assert.Single(packages);
+        var packages = Directory
+            .GetFiles(outputDirectory, $"{packageId}.*.nupkg")
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .ToArray();
+
+        return new PackageOutput(Assert.Single(packages), ownsDirectory ? outputDirectory : null);
     }
 
     private static async Task<ProcessResult> RunDotnetAsync(string workingDirectory, params string[] arguments)
     {
-        using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(90));
         var startInfo = new ProcessStartInfo
         {
             FileName = "dotnet",
@@ -179,14 +281,26 @@ public sealed class AggregatorPackageTests
         throw new InvalidOperationException("Could not locate the repository root.");
     }
 
-    public sealed record AggregatorPackageCase(
+    public sealed record PackageWithBundledAssetsCase(
         string PackageId,
         string ProjectPath,
         string[] RequiredDependencies,
         string[] RequiredLibAssets,
-        string[] ForbiddenLibAssets)
+        string[] ForbiddenLibAssets,
+        string[] RequiredAnalyzerAssets)
     {
         public override string ToString() => PackageId;
+    }
+
+    private sealed record PackageOutput(string PackagePath, string? OwnedDirectory) : IDisposable
+    {
+        public void Dispose()
+        {
+            if (OwnedDirectory is not null && Directory.Exists(OwnedDirectory))
+            {
+                Directory.Delete(OwnedDirectory, recursive: true);
+            }
+        }
     }
 
     private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);

--- a/test/Dapr.Packaging.Test/AggregatorPackageTests.cs
+++ b/test/Dapr.Packaging.Test/AggregatorPackageTests.cs
@@ -1,0 +1,193 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Xml.Linq;
+
+namespace Dapr.Packaging.Test;
+
+public sealed class AggregatorPackageTests
+{
+    private static readonly string[] TargetFrameworks = ["net8.0", "net9.0", "net10.0"];
+
+    public static TheoryData<AggregatorPackageCase> AggregatorPackages => new()
+    {
+        new AggregatorPackageCase(
+            PackageId: "Dapr.SecretsManagement",
+            ProjectPath: Path.Combine("src", "Dapr.SecretsManagement", "Dapr.SecretsManagement.csproj"),
+            RequiredDependencies:
+            [
+                "Dapr.Common",
+                "Google.Protobuf",
+                "Grpc.Net.Client",
+                "Microsoft.Extensions.DependencyInjection.Abstractions",
+                "Microsoft.Extensions.Http",
+            ],
+            RequiredLibAssets:
+            [
+                "Dapr.SecretsManagement.Abstractions.dll",
+                "Dapr.SecretsManagement.Runtime.dll",
+            ],
+            ForbiddenLibAssets:
+            [
+                "Dapr.SecretsManagement.dll",
+            ]),
+    };
+
+    [Theory]
+    [MemberData(nameof(AggregatorPackages))]
+    public async Task AggregatorPackage_ExposesConsumerDependenciesAndBundledAssets(AggregatorPackageCase package)
+    {
+        var repoRoot = FindRepoRoot();
+        var packagePath = await PackPackageAsync(repoRoot, package);
+
+        try
+        {
+            using var archive = ZipFile.OpenRead(packagePath);
+            var entryNames = archive.Entries.Select(entry => entry.FullName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var nuspec = ReadNuspec(archive, package.PackageId);
+
+            foreach (var targetFramework in TargetFrameworks)
+            {
+                var dependencies = GetDependencyIds(nuspec, targetFramework);
+
+                foreach (var requiredDependency in package.RequiredDependencies)
+                {
+                    Assert.Contains(requiredDependency, dependencies);
+                }
+
+                foreach (var requiredLibAsset in package.RequiredLibAssets)
+                {
+                    Assert.Contains($"lib/{targetFramework}/{requiredLibAsset}", entryNames);
+                }
+
+                foreach (var forbiddenLibAsset in package.ForbiddenLibAssets)
+                {
+                    Assert.DoesNotContain($"lib/{targetFramework}/{forbiddenLibAsset}", entryNames);
+                }
+            }
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(packagePath)!, recursive: true);
+        }
+    }
+
+    private static async Task<string> PackPackageAsync(string repoRoot, AggregatorPackageCase package)
+    {
+        var outputDirectory = Path.Combine(Path.GetTempPath(), "dapr-packaging-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputDirectory);
+
+        var projectPath = Path.Combine(repoRoot, package.ProjectPath);
+        var result = await RunDotnetAsync(
+            repoRoot,
+            "pack",
+            projectPath,
+            "--configuration",
+            "Debug",
+            "--output",
+            outputDirectory);
+
+        Assert.True(
+            result.ExitCode == 0,
+            $"dotnet pack failed for {package.PackageId}.{Environment.NewLine}STDOUT:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}STDERR:{Environment.NewLine}{result.StandardError}");
+
+        var packages = Directory.GetFiles(outputDirectory, $"{package.PackageId}.*.nupkg");
+        return Assert.Single(packages);
+    }
+
+    private static async Task<ProcessResult> RunDotnetAsync(string workingDirectory, params string[] arguments)
+    {
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        try
+        {
+            await process.WaitForExitAsync(cancellation.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"dotnet {string.Join(" ", arguments)} timed out.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            await standardOutput,
+            await standardError);
+    }
+
+    private static XDocument ReadNuspec(ZipArchive archive, string packageId)
+    {
+        var nuspecEntry = archive.GetEntry($"{packageId}.nuspec");
+        Assert.NotNull(nuspecEntry);
+
+        using var stream = nuspecEntry.Open();
+        return XDocument.Load(stream);
+    }
+
+    private static HashSet<string> GetDependencyIds(XDocument nuspec, string targetFramework)
+    {
+        XNamespace ns = nuspec.Root?.Name.Namespace ?? XNamespace.None;
+        var group = nuspec
+            .Descendants(ns + "group")
+            .SingleOrDefault(element => string.Equals(
+                (string?)element.Attribute("targetFramework"),
+                targetFramework,
+                StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(group);
+
+        return group
+            .Elements(ns + "dependency")
+            .Select(element => (string?)element.Attribute("id"))
+            .Where(id => id is not null)
+            .Select(id => id!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Directory.Packages.props")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "src")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "test")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate the repository root.");
+    }
+
+    public sealed record AggregatorPackageCase(
+        string PackageId,
+        string ProjectPath,
+        string[] RequiredDependencies,
+        string[] RequiredLibAssets,
+        string[] ForbiddenLibAssets)
+    {
+        public override string ToString() => PackageId;
+    }
+
+    private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
+}

--- a/test/Dapr.Packaging.Test/AggregatorPackageTests.cs
+++ b/test/Dapr.Packaging.Test/AggregatorPackageTests.cs
@@ -130,7 +130,7 @@ public sealed class AggregatorPackageTests
 
         foreach (var requiredProjectReference in package.RequiredProjectReferences)
         {
-            Assert.Contains(projectReferences, reference => Path.GetFileName(reference) == requiredProjectReference);
+            Assert.Contains(projectReferences, reference => GetProjectFileName(reference) == requiredProjectReference);
         }
 
         foreach (var requiredPackageReference in package.RequiredPackageReferences)
@@ -140,12 +140,12 @@ public sealed class AggregatorPackageTests
 
         foreach (var requiredBundledProject in package.RequiredBundledProjects)
         {
-            Assert.Contains(bundledProjectReferences, reference => Path.GetFileName(reference) == requiredBundledProject);
+            Assert.Contains(bundledProjectReferences, reference => GetProjectFileName(reference) == requiredBundledProject);
         }
 
         foreach (var requiredAnalyzerProject in package.RequiredAnalyzerProjects)
         {
-            Assert.Contains(projectPathMentions, reference => Path.GetFileName(reference) == requiredAnalyzerProject);
+            Assert.Contains(projectPathMentions, reference => GetProjectFileName(reference) == requiredAnalyzerProject);
         }
 
         AssertTargetsTfmSpecificPackageFiles(elements);
@@ -182,6 +182,12 @@ public sealed class AggregatorPackageTests
             .SelectMany(value => value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             .Where(value => value.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
             .ToArray();
+
+    private static string GetProjectFileName(string msbuildPath) =>
+        msbuildPath
+            .Replace('\\', '/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Last();
 
     private static void AssertTargetsTfmSpecificPackageFiles(IEnumerable<XElement> elements)
     {

--- a/test/Dapr.Packaging.Test/AssemblyInfo.cs
+++ b/test/Dapr.Packaging.Test/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Dapr.Packaging.Test/Dapr.Packaging.Test.csproj
+++ b/test/Dapr.Packaging.Test/Dapr.Packaging.Test.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks></TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.v3.extensibility.core" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>

--- a/test/Dapr.Packaging.Test/Dapr.Packaging.Test.csproj
+++ b/test/Dapr.Packaging.Test/Dapr.Packaging.Test.csproj
@@ -5,8 +5,6 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <TargetFramework>net10.0</TargetFramework>
-        <TargetFrameworks></TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# Description

After installing the `Dapr.SecretsManagement` package, the developer will be prompted to install the `Dapr.Common` package as well. This should be transitively referenced and not require the developer to have to explicitly install it separately. This patch fixes this.

Also adding testing with an aim to prevent regressions around this issue in the future with this and other packages in the solution.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
