### PR TITLE
Restoring 1.17 to CI testing

### DIFF
--- a/.github/tools/tag-selector/src/index.ts
+++ b/.github/tools/tag-selector/src/index.ts
@@ -23,10 +23,8 @@ async function run() {
             per_page: 100
         });
 
-        // Temporary: skip Dapr 1.17.x while that version is blocked in testing.
         const releaseTags = releases
             .filter((release) => !release.draft)
-            .filter((release) => !release.tag_name.includes("1.17."))
             .map((release) => ({
                 name: release.tag_name,
                 prerelease: release.prerelease,


### PR DESCRIPTION
# Description

Restoring 1.17 to CI testing in GitHub now that multi-arch is publishing again

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
