### PR TITLE
Propagate trace context for gRPC calls

### DIFF
--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -2301,6 +2301,8 @@ internal class DaprClientGrpc : DaprClient
             {
                 options.Headers.Add(this.apiTokenHeader.Value.Key, this.apiTokenHeader.Value.Value);
             }
+
+            DaprClientUtilities.AddTraceContextHeaders(options.Headers);
         }
 
         return options;

--- a/src/Dapr.Common/DaprClientUtilities.cs
+++ b/src/Dapr.Common/DaprClientUtilities.cs
@@ -7,6 +7,16 @@ namespace Dapr.Common;
 
 internal static class DaprClientUtilities
 {
+    private const byte TraceContextVersion = 0;
+    private const byte TraceIdFieldId = 0;
+    private const byte SpanIdFieldId = 1;
+    private const byte TraceOptionsFieldId = 2;
+
+    private const int TraceIdLength = 16;
+    private const int SpanIdLength = 8;
+    private const int GrpcTraceBinHeaderLength = 29;
+    private const string GrpcTraceBinHeader = "grpc-trace-bin";
+
     /// <summary>
     /// Provisions the gRPC call options used to provision the various Dapr clients.
     /// </summary>
@@ -65,7 +75,7 @@ internal static class DaprClientUtilities
             ? null
             : new KeyValuePair<string, string>("dapr-api-token", daprApiToken);
 
-    private static void AddTraceContextHeaders(Metadata headers)
+    internal static void AddTraceContextHeaders(Metadata headers)
     {
         var activity = Activity.Current;
         if (activity?.Id is null || activity.IdFormat != ActivityIdFormat.W3C)
@@ -79,6 +89,36 @@ internal static class DaprClientUtilities
         {
             headers.Add("tracestate", activity.TraceStateString);
         }
+
+        if (!headers.Any(header => string.Equals(header.Key, GrpcTraceBinHeader, StringComparison.OrdinalIgnoreCase)))
+        {
+            headers.Add(GrpcTraceBinHeader, CreateGrpcTraceBinHeader(activity));
+        }
+    }
+
+    private static byte[] CreateGrpcTraceBinHeader(Activity activity)
+    {
+        // grpc-trace-bin format:
+        // {version}{trace-id-field}{trace-id}{span-id-field}{span-id}{trace-options-field}{trace-options}
+        // See:
+        // https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md
+        var header = new byte[GrpcTraceBinHeaderLength];
+
+        var offset = 0;
+
+        header[offset++] = TraceContextVersion;
+
+        header[offset++] = TraceIdFieldId;
+        activity.TraceId.CopyTo(header.AsSpan(offset, TraceIdLength));
+        offset += TraceIdLength;
+
+        header[offset++] = SpanIdFieldId;
+        activity.SpanId.CopyTo(header.AsSpan(offset, SpanIdLength));
+        offset += SpanIdLength;
+
+        header[offset++] = TraceOptionsFieldId;
+        header[offset] = (byte)(activity.ActivityTraceFlags & ActivityTraceFlags.Recorded);
+
+        return header;
     }
 }
-

--- a/test/Dapr.Client.Test/PublishEventApiTest.cs
+++ b/test/Dapr.Client.Test/PublishEventApiTest.cs
@@ -11,9 +11,11 @@
 // limitations under the License.
 // ------------------------------------------------------------------------
 
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
+using Google.Protobuf.WellKnownTypes;
 using Grpc.Net.Client;
 
 namespace Dapr.Client.Test;
@@ -32,6 +34,35 @@ using Xunit;
 public class PublishEventApiTest
 {
     const string TestPubsubName = "testpubsubname";
+
+    [Fact]
+    public async Task PublishEventAsync_PropagatesGrpcTraceContextHeader()
+    {
+        Activity.Current = null;
+        using var activity = new Activity("test");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.Start();
+
+        var client = new MockClient();
+        CallOptions capturedCallOptions = default;
+
+        client.Mock
+            .Setup(m => m.PublishEventAsync(
+                It.IsAny<Autogen.Grpc.v1.PublishEventRequest>(),
+                It.IsAny<CallOptions>()))
+            .Callback<Autogen.Grpc.v1.PublishEventRequest, CallOptions>((_, options) =>
+                capturedCallOptions = options)
+            .Returns(client.Call<Empty>().SetResponse(new Empty()).Build());
+
+        await client.DaprClient.PublishEventAsync(
+            TestPubsubName,
+            "test",
+            TestContext.Current.CancellationToken);
+
+        var headers = capturedCallOptions.Headers;
+        headers.ShouldNotBeNull();
+        headers.First(header => header.Key == "grpc-trace-bin").ValueBytes.Length.ShouldBe(29);
+    }
 
     [Fact]
     public async Task PublishEventAsync_CanPublishTopicWithData()

--- a/test/Dapr.Common.Test/DaprClientUtilitiesTests.cs
+++ b/test/Dapr.Common.Test/DaprClientUtilitiesTests.cs
@@ -11,6 +11,7 @@
 // limitations under the License.
 //  ------------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -21,8 +22,12 @@ namespace Dapr.Common.Test;
 
 public sealed class DaprClientUtilitiesTests
 {
+    private const int TraceIdLength = 16;
+    private const int SpanIdLength = 8;
+    private const int GrpcTraceBinHeaderLength = 29;
+
     [Fact]
-    public void ConfigureGrpcCallOptions_ShouldIncludeW3CTraceContext_WhenActivityCurrentIsSet()
+    public void ConfigureGrpcCallOptions_ShouldIncludeTraceContext_WhenActivityCurrentIsSet()
     {
         var previous = Activity.Current;
         using var activity = new Activity("parent");
@@ -41,6 +46,8 @@ public sealed class DaprClientUtilitiesTests
             Assert.Equal(activity.Id, traceParent);
             Assert.True(TryGetHeader(options.Headers, "tracestate", out var traceState));
             Assert.Equal(activity.TraceStateString, traceState);
+            Assert.True(TryGetBinaryHeader(options.Headers, "grpc-trace-bin", out var grpcTraceBin));
+            AssertGrpcTraceBinHeader(activity, grpcTraceBin);
         }
         finally
         {
@@ -63,11 +70,57 @@ public sealed class DaprClientUtilitiesTests
 
             Assert.False(TryGetHeader(options.Headers, "traceparent", out _));
             Assert.False(TryGetHeader(options.Headers, "tracestate", out _));
+            Assert.False(TryGetBinaryHeader(options.Headers, "grpc-trace-bin", out _));
         }
         finally
         {
             Activity.Current = previous;
         }
+    }
+
+    [Fact]
+    public void AddTraceContextHeaders_ShouldNotDuplicateGrpcTraceBinHeader()
+    {
+        var previous = Activity.Current;
+        using var activity = new Activity("parent");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.Start();
+
+        var existingGrpcTraceBin = new byte[] { 1, 2, 3 };
+        var headers = new Metadata
+        {
+            { "grpc-trace-bin", existingGrpcTraceBin },
+        };
+
+        try
+        {
+            DaprClientUtilities.AddTraceContextHeaders(headers);
+
+            Assert.Equal(1, headers.Count(header => header.Key == "grpc-trace-bin"));
+            Assert.True(TryGetBinaryHeader(headers, "grpc-trace-bin", out var grpcTraceBin));
+            Assert.Equal(existingGrpcTraceBin, grpcTraceBin);
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+    }
+
+    private static void AssertGrpcTraceBinHeader(Activity activity, byte[] grpcTraceBin)
+    {
+        var expectedTraceId = new byte[TraceIdLength];
+        activity.TraceId.CopyTo(expectedTraceId);
+        var expectedSpanId = new byte[SpanIdLength];
+        activity.SpanId.CopyTo(expectedSpanId);
+
+        Assert.Equal(GrpcTraceBinHeaderLength, grpcTraceBin.Length);
+        Assert.Equal(0, grpcTraceBin[0]);
+        Assert.Equal(0, grpcTraceBin[1]);
+        Assert.True(grpcTraceBin.AsSpan(2, TraceIdLength).SequenceEqual(expectedTraceId));
+        Assert.Equal(1, grpcTraceBin[18]);
+        Assert.True(grpcTraceBin.AsSpan(19, SpanIdLength).SequenceEqual(expectedSpanId));
+        Assert.Equal(2, grpcTraceBin[27]);
+        Assert.Equal((byte)(activity.ActivityTraceFlags & ActivityTraceFlags.Recorded), grpcTraceBin[28]);
     }
 
     private static bool TryGetHeader(Metadata metadata, string key, out string value)
@@ -80,6 +133,19 @@ public sealed class DaprClientUtilitiesTests
         }
 
         value = entry.Value;
+        return true;
+    }
+
+    private static bool TryGetBinaryHeader(Metadata metadata, string key, out byte[] value)
+    {
+        value = [];
+        var entry = metadata.FirstOrDefault(item => item.Key == key);
+        if (entry is null)
+        {
+            return false;
+        }
+
+        value = entry.ValueBytes;
         return true;
     }
 }


### PR DESCRIPTION
## Description

Propagates trace context on  gRPC calls so Dapr sidecar spans can preserve the expected parent-child relationship with the application operation that initiated the call.

This adds `grpc-trace-bin` metadata from the current .NET activity when available, and includes tests for the shared gRPC call options path and `DaprClient` publish flow.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1857

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
