### PR TITLE
Notating the packages for Dapr.Actors.Next as not-packable

### DIFF
--- a/src/Dapr.Actors.Next.Abstractions/Dapr.Actors.Next.Abstractions.csproj
+++ b/src/Dapr.Actors.Next.Abstractions/Dapr.Actors.Next.Abstractions.csproj
@@ -5,6 +5,7 @@
         <Title>Dapr Actors Next Abstractions</Title>
         <Description>Public contract surface for the Dapr Actors Next SDK.</Description>
         <DaprActorsNextEnableTrimAotAnalysis>true</DaprActorsNextEnableTrimAotAnalysis>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Dapr.Actors.Next.Core/Dapr.Actors.Next.Core.csproj
+++ b/src/Dapr.Actors.Next.Core/Dapr.Actors.Next.Core.csproj
@@ -5,6 +5,7 @@
         <Title>Dapr Actors Next Core</Title>
         <Description>Runtime implementation for the Dapr Actors Next SDK.</Description>
         <DaprActorsNextEnableTrimAotAnalysis>true</DaprActorsNextEnableTrimAotAnalysis>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Dapr.Actors.Next.Interpreted/Dapr.Actors.Next.Interpreted.csproj
+++ b/src/Dapr.Actors.Next.Interpreted/Dapr.Actors.Next.Interpreted.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Dapr.Actors.Next.Abstractions\Dapr.Actors.Next.Abstractions.csproj" />

--- a/src/Dapr.Actors.Next.SourceGenerators/Dapr.Actors.Next.SourceGenerators.csproj
+++ b/src/Dapr.Actors.Next.SourceGenerators/Dapr.Actors.Next.SourceGenerators.csproj
@@ -7,6 +7,7 @@
         <Nullable>enable</Nullable>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <IsRoslynComponent>true</IsRoslynComponent>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Dapr.Actors.Next.StateMachine/Dapr.Actors.Next.StateMachine.csproj
+++ b/src/Dapr.Actors.Next.StateMachine/Dapr.Actors.Next.StateMachine.csproj
@@ -4,6 +4,7 @@
         <PackageId>Dapr.Actors.Next.StateMachine</PackageId>
         <Title>Dapr Actors Next State Machine</Title>
         <Description>Compiled state-machine actor authoring model for the Dapr Actors Next SDK.</Description>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Dapr.Actors.Next.Streams/Dapr.Actors.Next.Streams.csproj
+++ b/src/Dapr.Actors.Next.Streams/Dapr.Actors.Next.Streams.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Dapr.Actors.Next.Abstractions\Dapr.Actors.Next.Abstractions.csproj" />

--- a/src/Dapr.Actors.Next.Testing/Dapr.Actors.Next.Testing.csproj
+++ b/src/Dapr.Actors.Next.Testing/Dapr.Actors.Next.Testing.csproj
@@ -4,6 +4,7 @@
         <PackageId>Dapr.Actors.Next.Testing</PackageId>
         <Title>Dapr Actors Next Testing</Title>
         <Description>Deterministic in-memory testing runtime for the Dapr Actors Next SDK.</Description>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Dapr.Actors.Next/Dapr.Actors.Next.csproj
+++ b/src/Dapr.Actors.Next/Dapr.Actors.Next.csproj
@@ -2,35 +2,126 @@
 
     <PropertyGroup>
         <Description>Provides the functionality necessary to develop Dapr Actors using .NET.</Description>
+        <NoWarn>$(NoWarn);NU5128</NoWarn>
+        <TargetsForTfmSpecificContentInPackage>
+            $(TargetsForTfmSpecificContentInPackage);
+            _BuildDaprActorsNextChildrenForCurrentTFM;
+            _CollectDaprActorsNextChildOutputsForCurrentTFM;
+            _AddDaprActorsNextAnalyzerOnce
+        </TargetsForTfmSpecificContentInPackage>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Dapr.Actors.Next.Abstractions\Dapr.Actors.Next.Abstractions.csproj" />
-        <ProjectReference Include="..\Dapr.Actors.Next.Core\Dapr.Actors.Next.Core.csproj" />
-        <ProjectReference Include="..\Dapr.Actors.Next.StateMachine\Dapr.Actors.Next.StateMachine.csproj" />
-        <ProjectReference Include="..\Dapr.Actors.Next.Streams\Dapr.Actors.Next.Streams.csproj" />
-        <ProjectReference Include="..\Dapr.Actors.Next.Interpreted\Dapr.Actors.Next.Interpreted.csproj" />
-        <ProjectReference Include="..\Dapr.Actors.Next.Testing\Dapr.Actors.Next.Testing.csproj" />
-        <ProjectReference Include="..\Dapr.Actors.Next.SourceGenerators\Dapr.Actors.Next.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="none" />
-        <ProjectReference Include="..\Dapr.Actors.Next.Analyzers\Dapr.Actors.Next.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="none" />
+        <ProjectReference Include="..\Dapr.Common\Dapr.Common.csproj" />
+        <ProjectReference Include="..\Dapr.Messaging\Dapr.Messaging.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <_DaprActorsNextChildLib Include="..\Dapr.Actors.Next.Abstractions\Dapr.Actors.Next.Abstractions.csproj" />
+        <_DaprActorsNextChildLib Include="..\Dapr.Actors.Next.Core\Dapr.Actors.Next.Core.csproj" />
+        <_DaprActorsNextChildLib Include="..\Dapr.Actors.Next.StateMachine\Dapr.Actors.Next.StateMachine.csproj" />
+        <_DaprActorsNextChildLib Include="..\Dapr.Actors.Next.Streams\Dapr.Actors.Next.Streams.csproj" />
+        <_DaprActorsNextChildLib Include="..\Dapr.Actors.Next.Interpreted\Dapr.Actors.Next.Interpreted.csproj" />
+        <_DaprActorsNextChildLib Include="..\Dapr.Actors.Next.Testing\Dapr.Actors.Next.Testing.csproj" />
+
+        <ProjectReference Include="@(_DaprActorsNextChildLib)"
+                          PrivateAssets="all"
+                          ReferenceOutputAssembly="true" />
+
+        <ProjectReference Include="..\Dapr.Actors.Next.SourceGenerators\Dapr.Actors.Next.SourceGenerators.csproj"
+                          PrivateAssets="all"
+                          ReferenceOutputAssembly="false"
+                          SetTargetFramework="TargetFramework=netstandard2.0" />
+        <ProjectReference Include="..\Dapr.Actors.Next.Analyzers\Dapr.Actors.Next.Analyzers.csproj"
+                          PrivateAssets="all"
+                          ReferenceOutputAssembly="false"
+                          SetTargetFramework="TargetFramework=netstandard2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Grpc.Net.ClientFactory" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
     </ItemGroup>
 
     <ItemGroup>
         <None Include="buildTransitive\Dapr.Actors.Next.props" Pack="true" PackagePath="buildTransitive\Dapr.Actors.Next.props" />
     </ItemGroup>
 
-    <Target Name="IncludeDaprActorsNextAnalyzerAssets"
-            BeforeTargets="_GetPackageFiles">
-        <MSBuild Projects="../Dapr.Actors.Next.SourceGenerators/Dapr.Actors.Next.SourceGenerators.csproj;../Dapr.Actors.Next.Analyzers/Dapr.Actors.Next.Analyzers.csproj"
+    <Target Name="_BuildDaprActorsNextChildrenForCurrentTFM">
+        <MSBuild Projects="@(_DaprActorsNextChildLib)"
+                 Targets="Build"
+                 Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)"
+                 BuildInParallel="true" />
+    </Target>
+
+    <Target Name="_CollectDaprActorsNextChildOutputsForCurrentTFM"
+            DependsOnTargets="_BuildDaprActorsNextChildrenForCurrentTFM">
+        <MSBuild Projects="@(_DaprActorsNextChildLib)"
+                 Targets="GetTargetPath"
+                 Properties="TargetFramework=$(TargetFramework);Configuration=$(Configuration)">
+            <Output TaskParameter="TargetOutputs" ItemName="_DaprActorsNextBuiltChildOutputs" />
+        </MSBuild>
+
+        <PropertyGroup>
+            <_DaprActorsNextEffectiveTfmFolder>$(NuGetTargetFrameworkFolderName)</_DaprActorsNextEffectiveTfmFolder>
+            <_DaprActorsNextEffectiveTfmFolder Condition="'$(_DaprActorsNextEffectiveTfmFolder)' == ''">$(TargetFramework)</_DaprActorsNextEffectiveTfmFolder>
+        </PropertyGroup>
+
+        <ItemGroup>
+            <_DaprActorsNextChildDll Include="@(_DaprActorsNextBuiltChildOutputs)"
+                                     Condition="'%(_DaprActorsNextBuiltChildOutputs.Extension)' == '.dll'" />
+            <_DaprActorsNextChildXml Include="%(_DaprActorsNextChildDll.RootDir)%(_DaprActorsNextChildDll.Directory)%(_DaprActorsNextChildDll.Filename).xml"
+                                     Condition="Exists('%(_DaprActorsNextChildDll.RootDir)%(_DaprActorsNextChildDll.Directory)%(_DaprActorsNextChildDll.Filename).xml')" />
+            <_DaprActorsNextChildPdb Include="%(_DaprActorsNextChildDll.RootDir)%(_DaprActorsNextChildDll.Directory)%(_DaprActorsNextChildDll.Filename).pdb"
+                                     Condition="Exists('%(_DaprActorsNextChildDll.RootDir)%(_DaprActorsNextChildDll.Directory)%(_DaprActorsNextChildDll.Filename).pdb')" />
+
+            <TfmSpecificPackageFile Include="@(_DaprActorsNextChildDll)">
+                <TargetFramework>$(TargetFramework)</TargetFramework>
+                <PackagePath>lib/$(_DaprActorsNextEffectiveTfmFolder)/%(_DaprActorsNextChildDll.Filename)%(_DaprActorsNextChildDll.Extension)</PackagePath>
+            </TfmSpecificPackageFile>
+            <TfmSpecificPackageFile Include="@(_DaprActorsNextChildXml)">
+                <TargetFramework>$(TargetFramework)</TargetFramework>
+                <PackagePath>lib/$(_DaprActorsNextEffectiveTfmFolder)/%(_DaprActorsNextChildXml.Filename).xml</PackagePath>
+            </TfmSpecificPackageFile>
+            <TfmSpecificPackageFile Include="@(_DaprActorsNextChildPdb)">
+                <TargetFramework>$(TargetFramework)</TargetFramework>
+                <PackagePath>lib/$(_DaprActorsNextEffectiveTfmFolder)/%(_DaprActorsNextChildPdb.Filename).pdb</PackagePath>
+            </TfmSpecificPackageFile>
+        </ItemGroup>
+    </Target>
+
+    <ItemGroup>
+        <_DaprActorsNextAnalyzerProject Include="..\Dapr.Actors.Next.SourceGenerators\Dapr.Actors.Next.SourceGenerators.csproj" />
+        <_DaprActorsNextAnalyzerProject Include="..\Dapr.Actors.Next.Analyzers\Dapr.Actors.Next.Analyzers.csproj" />
+    </ItemGroup>
+
+    <Target Name="_AddDaprActorsNextAnalyzerOnce">
+        <PropertyGroup>
+            <_DaprActorsNextIsFirstTfm Condition="'$(TargetFramework)' == 'net8.0'">true</_DaprActorsNextIsFirstTfm>
+        </PropertyGroup>
+
+        <MSBuild Condition="'$(_DaprActorsNextIsFirstTfm)' == 'true'"
+                 Projects="@(_DaprActorsNextAnalyzerProject)"
+                 Targets="Build"
+                 Properties="Configuration=$(Configuration);TargetFramework=netstandard2.0" />
+
+        <MSBuild Condition="'$(_DaprActorsNextIsFirstTfm)' == 'true'"
+                 Projects="@(_DaprActorsNextAnalyzerProject)"
                  Targets="GetTargetPath"
                  Properties="Configuration=$(Configuration);TargetFramework=netstandard2.0">
-            <Output TaskParameter="TargetOutputs" ItemName="_DaprActorsNextAnalyzerAsset" />
+            <Output TaskParameter="TargetOutputs" ItemName="_DaprActorsNextAnalyzerOutput" />
         </MSBuild>
-        <ItemGroup>
-            <None Include="@(_DaprActorsNextAnalyzerAsset)"
-                  Pack="true"
-                  PackagePath="analyzers/dotnet/cs"
-                  Visible="false" />
+
+        <ItemGroup Condition="'$(_DaprActorsNextIsFirstTfm)' == 'true'">
+            <TfmSpecificPackageFile Include="@(_DaprActorsNextAnalyzerOutput)">
+                <TargetFramework>$(TargetFramework)</TargetFramework>
+                <PackagePath>analyzers/dotnet/cs/%(_DaprActorsNextAnalyzerOutput.Filename)%(_DaprActorsNextAnalyzerOutput.Extension)</PackagePath>
+            </TfmSpecificPackageFile>
         </ItemGroup>
     </Target>
 

--- a/src/Dapr.Actors.Next/Dapr.Actors.Next.csproj
+++ b/src/Dapr.Actors.Next/Dapr.Actors.Next.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Description>Meta package for Dapr Actors Next runtime, satellites, source generators, analyzers, and transitive build assets.</Description>
+        <Description>Provides the functionality necessary to develop Dapr Actors using .NET.</Description>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Dapr.Actors.Next.MetaConsumerSmoke.Test/Dapr.Actors.Next.MetaConsumerSmoke.Test.csproj
+++ b/test/Dapr.Actors.Next.MetaConsumerSmoke.Test/Dapr.Actors.Next.MetaConsumerSmoke.Test.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Dapr.Actors.Next\Dapr.Actors.Next.csproj" />
+        <ProjectReference Include="..\..\src\Dapr.Actors.Next.Abstractions\Dapr.Actors.Next.Abstractions.csproj" />
         <ProjectReference Include="..\..\src\Dapr.Testcontainers.Xunit\Dapr.Testcontainers.Xunit.csproj" />
 
     </ItemGroup>


### PR DESCRIPTION
# Description

Marking the various component projects of Dapr.Actors.Next as not-packable as they are not intended to be installed independently of the `Dapr.Actors.Next` package.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
