### PR TITLE
Fixing workflow tracing + adding observability integration testing

### DIFF
--- a/src/Dapr.Common/DaprClientUtilities.cs
+++ b/src/Dapr.Common/DaprClientUtilities.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http.Headers;
+using System.Diagnostics;
 using System.Reflection;
 using Grpc.Core;
 
@@ -35,6 +36,8 @@ internal static class DaprClientUtilities
             }
         }
 
+        AddTraceContextHeaders(callOptions.Headers);
+
         return callOptions;
     }
     
@@ -61,5 +64,21 @@ internal static class DaprClientUtilities
         string.IsNullOrWhiteSpace(daprApiToken)
             ? null
             : new KeyValuePair<string, string>("dapr-api-token", daprApiToken);
+
+    private static void AddTraceContextHeaders(Metadata headers)
+    {
+        var activity = Activity.Current;
+        if (activity?.Id is null || activity.IdFormat != ActivityIdFormat.W3C)
+        {
+            return;
+        }
+
+        headers.Add("traceparent", activity.Id);
+
+        if (!string.IsNullOrWhiteSpace(activity.TraceStateString))
+        {
+            headers.Add("tracestate", activity.TraceStateString);
+        }
+    }
 }
 

--- a/src/Dapr.Testcontainers/Harnesses/WorkflowHarness.cs
+++ b/src/Dapr.Testcontainers/Harnesses/WorkflowHarness.cs
@@ -12,10 +12,12 @@
 //  ------------------------------------------------------------------------
 
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Dapr.Testcontainers.Common.Options;
 using Dapr.Testcontainers.Containers;
+using Dapr.Testcontainers.Telemetry;
 
 namespace Dapr.Testcontainers.Harnesses;
 
@@ -26,6 +28,7 @@ public sealed class WorkflowHarness : BaseHarness
 {
     private readonly RedisContainer _redis;
     private readonly bool _isSelfHostedRedis;
+    private DaprTelemetryCollector? _telemetryCollector;
     
     /// <summary>
     /// Provides an implementation harness for Dapr's Workflow building block.
@@ -40,6 +43,29 @@ public sealed class WorkflowHarness : BaseHarness
         _isSelfHostedRedis = environment?.RedisContainer is null;
     }
 
+    /// <summary>
+    /// Gets the telemetry collector when telemetry capture has been enabled for this harness.
+    /// </summary>
+    public DaprTelemetryCollector? TelemetryCollector => _telemetryCollector;
+
+    /// <summary>
+    /// Enables Dapr runtime trace export capture for this workflow harness.
+    /// When <paramref name="captureWorkflowActivitySource"/> is true, completed
+    /// <c>Dapr.Workflow</c> in-process activities are captured from the test application.
+    /// </summary>
+    /// <param name="captureWorkflowActivitySource">Whether to capture .NET activities emitted by the workflow SDK.</param>
+    /// <returns>This workflow harness.</returns>
+    public WorkflowHarness EnableTelemetryCapture(bool captureWorkflowActivitySource = true)
+    {
+        _telemetryCollector ??= new DaprTelemetryCollector();
+        if (captureWorkflowActivitySource)
+        {
+            _telemetryCollector.CaptureActivitySource("Dapr.Workflow");
+        }
+
+        return this;
+    }
+
     /// <inheritdoc />
 	protected override async Task OnInitializeAsync(CancellationToken cancellationToken)
 	{
@@ -51,6 +77,13 @@ public sealed class WorkflowHarness : BaseHarness
         
         // Emit component YAMLs pointing to Redis
         RedisContainer.Yaml.WriteStateStoreYamlToFolder(ComponentsDirectory, redisHost: $"{_redis.NetworkAlias}:{RedisContainer.ContainerPort}");
+
+        if (_telemetryCollector is not null)
+        {
+            await _telemetryCollector.StartAsync(cancellationToken);
+            WriteWorkflowTracingConfigYaml(ComponentsDirectory, _telemetryCollector.ZipkinEndpointAddressForDapr);
+            DaprConfigFilePath = "/components/workflow-tracing-config.yaml";
+        }
         
         // Set the service ports
         this.DaprPlacementExternalPort = Environment.PlacementExternalPort;
@@ -58,10 +91,32 @@ public sealed class WorkflowHarness : BaseHarness
         this.DaprSchedulerExternalPort = Environment.SchedulerExternalPort;
         this.DaprSchedulerAlias = Environment.SchedulerAlias;
     }
+
+    private static void WriteWorkflowTracingConfigYaml(string componentsDirectory, string zipkinEndpointAddress)
+    {
+        var yaml = $$"""
+            apiVersion: dapr.io/v1alpha1
+            kind: Configuration
+            metadata:
+              name: workflowTracing
+            spec:
+              tracing:
+                samplingRate: "1"
+                zipkin:
+                  endpointAddress: "{{zipkinEndpointAddress}}"
+            """;
+        Directory.CreateDirectory(componentsDirectory);
+        File.WriteAllText(Path.Combine(componentsDirectory, "workflow-tracing-config.yaml"), yaml);
+    }
     
     /// <inheritdoc />
 	protected override async ValueTask OnDisposeAsync()
     {
+        if (_telemetryCollector is not null)
+        {
+            await _telemetryCollector.DisposeAsync();
+        }
+
         if (_isSelfHostedRedis)
         {
             await _redis.DisposeAsync();

--- a/src/Dapr.Testcontainers/Telemetry/CapturedActivity.cs
+++ b/src/Dapr.Testcontainers/Telemetry/CapturedActivity.cs
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------------------
+// Copyright 2026 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  ------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Dapr.Testcontainers.Telemetry;
+
+/// <summary>
+/// Captured in-process .NET activity emitted by a configured <see cref="ActivitySource"/>.
+/// </summary>
+public sealed record CapturedActivity(
+    string SourceName,
+    string DisplayName,
+    string TraceId,
+    string SpanId,
+    string ParentSpanId,
+    string? ParentId,
+    ActivityKind Kind,
+    ActivityStatusCode Status,
+    DateTime StartTimeUtc,
+    TimeSpan Duration,
+    IReadOnlyDictionary<string, object?> Tags);

--- a/src/Dapr.Testcontainers/Telemetry/DaprTelemetryCollector.cs
+++ b/src/Dapr.Testcontainers/Telemetry/DaprTelemetryCollector.cs
@@ -1,0 +1,241 @@
+// ------------------------------------------------------------------------
+// Copyright 2026 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  ------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapr.Testcontainers.Common;
+using Dapr.Testcontainers.Containers.Dapr;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Dapr.Testcontainers.Telemetry;
+
+/// <summary>
+/// In-process telemetry collector for Dapr integration tests.
+/// Captures Zipkin v2 spans exported by daprd and optionally captures .NET
+/// <see cref="ActivitySource"/> spans from the test application process.
+/// </summary>
+public sealed class DaprTelemetryCollector : IAsyncDisposable
+{
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+    private readonly ConcurrentQueue<ZipkinSpan> _zipkinSpans = new();
+    private readonly ConcurrentQueue<CapturedActivity> _activities = new();
+    private readonly int _port;
+    private WebApplication? _app;
+    private ActivityListener? _activityListener;
+
+    /// <summary>
+    /// Initializes a new telemetry collector on a random available host port.
+    /// </summary>
+    public DaprTelemetryCollector() : this(PortUtilities.GetAvailablePort())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new telemetry collector on the specified host port.
+    /// </summary>
+    public DaprTelemetryCollector(int port)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(port, 0, nameof(port));
+        _port = port;
+    }
+
+    /// <summary>
+    /// Host port used by the collector.
+    /// </summary>
+    public int Port => _port;
+
+    /// <summary>
+    /// Zipkin endpoint address reachable from a daprd container.
+    /// </summary>
+    public string ZipkinEndpointAddressForDapr =>
+        $"http://{DaprdContainer.ContainerHostAlias}:{_port}/api/v2/spans";
+
+    /// <summary>
+    /// Captured Zipkin spans exported by daprd.
+    /// </summary>
+    public IReadOnlyList<ZipkinSpan> ZipkinSpans => _zipkinSpans.ToArray();
+
+    /// <summary>
+    /// Captured .NET activities from configured activity sources.
+    /// </summary>
+    public IReadOnlyList<CapturedActivity> Activities => _activities.ToArray();
+
+    /// <summary>
+    /// Starts the Zipkin-compatible HTTP collector.
+    /// </summary>
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_app is not null)
+        {
+            return;
+        }
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = [] });
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls($"http://0.0.0.0:{_port}");
+
+        var app = builder.Build();
+        app.MapPost("/api/v2/spans", async (HttpRequest request) =>
+        {
+            var spans = await JsonSerializer.DeserializeAsync<List<ZipkinSpan>>(
+                request.Body,
+                JsonSerializerOptions,
+                request.HttpContext.RequestAborted);
+
+            if (spans is not null)
+            {
+                foreach (var span in spans)
+                {
+                    _zipkinSpans.Enqueue(span);
+                }
+            }
+
+            return Results.Accepted();
+        });
+
+        await app.StartAsync(cancellationToken);
+        _app = app;
+    }
+
+    /// <summary>
+    /// Captures completed activities from the named source.
+    /// </summary>
+    public void CaptureActivitySource(string sourceName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceName);
+
+        if (_activityListener is null)
+        {
+            _activityListener = new ActivityListener
+            {
+                ShouldListenTo = source => string.Equals(source.Name, sourceName, StringComparison.Ordinal),
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = CaptureActivity
+            };
+            ActivitySource.AddActivityListener(_activityListener);
+            return;
+        }
+
+        var existingListener = _activityListener;
+        _activityListener = new ActivityListener
+        {
+            ShouldListenTo = source =>
+                existingListener.ShouldListenTo?.Invoke(source) == true ||
+                string.Equals(source.Name, sourceName, StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = CaptureActivity
+        };
+        ActivitySource.AddActivityListener(_activityListener);
+        existingListener.Dispose();
+    }
+
+    /// <summary>
+    /// Waits until a captured Zipkin span matches the predicate.
+    /// </summary>
+    public Task<ZipkinSpan> WaitForZipkinSpanAsync(
+        Func<ZipkinSpan, bool> predicate,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default) =>
+        WaitForAsync(
+            () => _zipkinSpans.FirstOrDefault(predicate),
+            timeout,
+            cancellationToken,
+            () => $"Captured Zipkin spans: {_zipkinSpans.Count}; spans: {string.Join(", ", _zipkinSpans.Select(span => $"{span.TraceId}/{span.Name}/{span.Kind}").Take(10))}");
+
+    /// <summary>
+    /// Waits until a captured .NET activity matches the predicate.
+    /// </summary>
+    public Task<CapturedActivity> WaitForActivityAsync(
+        Func<CapturedActivity, bool> predicate,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default) =>
+        WaitForAsync(
+            () => _activities.FirstOrDefault(predicate),
+            timeout,
+            cancellationToken,
+            () => $"Captured activities: {_activities.Count}; activities: {string.Join(", ", _activities.Select(activity => $"{activity.SourceName}/{activity.DisplayName}/{activity.TraceId}").Take(10))}");
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        _activityListener?.Dispose();
+
+        if (_app is not null)
+        {
+            await _app.DisposeAsync();
+        }
+    }
+
+    private void CaptureActivity(Activity activity)
+    {
+        _activities.Enqueue(new CapturedActivity(
+            activity.Source.Name,
+            activity.DisplayName,
+            activity.TraceId.ToHexString(),
+            activity.SpanId.ToHexString(),
+            activity.ParentSpanId.ToHexString(),
+            activity.ParentId,
+            activity.Kind,
+            activity.Status,
+            activity.StartTimeUtc,
+            activity.Duration,
+            activity.Tags.ToDictionary(tag => tag.Key, tag => (object?)tag.Value)));
+    }
+
+    private static async Task<T> WaitForAsync<T>(
+        Func<T?> probe,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        Func<string>? diagnostics = null)
+        where T : class
+    {
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        while (!linkedCts.IsCancellationRequested)
+        {
+            var result = probe();
+            if (result is not null)
+            {
+                return result;
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100), linkedCts.Token);
+            }
+            catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var diagnosticText = diagnostics?.Invoke();
+        throw new TimeoutException(
+            string.IsNullOrWhiteSpace(diagnosticText)
+                ? $"Telemetry condition was not satisfied within {timeout}."
+                : $"Telemetry condition was not satisfied within {timeout}. {diagnosticText}");
+    }
+}

--- a/src/Dapr.Testcontainers/Telemetry/ZipkinEndpoint.cs
+++ b/src/Dapr.Testcontainers/Telemetry/ZipkinEndpoint.cs
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------------------
+// Copyright 2026 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  ------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace Dapr.Testcontainers.Telemetry;
+
+/// <summary>
+/// Endpoint metadata attached to a Zipkin span.
+/// </summary>
+public sealed class ZipkinEndpoint
+{
+    /// <summary>
+    /// Service name reported by the emitter.
+    /// </summary>
+    [JsonPropertyName("serviceName")]
+    public string? ServiceName { get; init; }
+
+    /// <summary>
+    /// IPv4 address reported by the emitter.
+    /// </summary>
+    [JsonPropertyName("ipv4")]
+    public string? Ipv4 { get; init; }
+
+    /// <summary>
+    /// IPv6 address reported by the emitter.
+    /// </summary>
+    [JsonPropertyName("ipv6")]
+    public string? Ipv6 { get; init; }
+
+    /// <summary>
+    /// Port reported by the emitter.
+    /// </summary>
+    [JsonPropertyName("port")]
+    public int? Port { get; init; }
+}

--- a/src/Dapr.Testcontainers/Telemetry/ZipkinSpan.cs
+++ b/src/Dapr.Testcontainers/Telemetry/ZipkinSpan.cs
@@ -1,0 +1,83 @@
+// ------------------------------------------------------------------------
+// Copyright 2026 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  ------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Dapr.Testcontainers.Telemetry;
+
+/// <summary>
+/// Zipkin v2 span captured from Dapr runtime trace export.
+/// </summary>
+public sealed class ZipkinSpan
+{
+    /// <summary>
+    /// Trace identifier.
+    /// </summary>
+    [JsonPropertyName("traceId")]
+    public string TraceId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Span identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Parent span identifier, if any.
+    /// </summary>
+    [JsonPropertyName("parentId")]
+    public string? ParentId { get; init; }
+
+    /// <summary>
+    /// Span name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Span kind.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public string? Kind { get; init; }
+
+    /// <summary>
+    /// Start timestamp in microseconds since Unix epoch.
+    /// </summary>
+    [JsonPropertyName("timestamp")]
+    public long? Timestamp { get; init; }
+
+    /// <summary>
+    /// Duration in microseconds.
+    /// </summary>
+    [JsonPropertyName("duration")]
+    public long? Duration { get; init; }
+
+    /// <summary>
+    /// Local endpoint metadata.
+    /// </summary>
+    [JsonPropertyName("localEndpoint")]
+    public ZipkinEndpoint? LocalEndpoint { get; init; }
+
+    /// <summary>
+    /// Remote endpoint metadata.
+    /// </summary>
+    [JsonPropertyName("remoteEndpoint")]
+    public ZipkinEndpoint? RemoteEndpoint { get; init; }
+
+    /// <summary>
+    /// Span tags.
+    /// </summary>
+    [JsonPropertyName("tags")]
+    public IReadOnlyDictionary<string, string>? Tags { get; init; }
+}

--- a/src/Dapr.Workflow/Client/WorkflowGrpcClient.cs
+++ b/src/Dapr.Workflow/Client/WorkflowGrpcClient.cs
@@ -13,6 +13,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,7 +44,8 @@ internal sealed class WorkflowGrpcClient(
         {
             InstanceId = instanceId,
             Name = workflowName,
-            Input = SerializeToJson(input)
+            Input = SerializeToJson(input),
+            ParentTraceContext = CreateParentTraceContext()
         };
         
         // Add the scheduled start time if specified
@@ -331,6 +333,21 @@ internal sealed class WorkflowGrpcClient(
     }
 
     private string SerializeToJson(object? obj) => obj == null ? string.Empty : serializer.Serialize(obj);
+
+    private static grpc.TraceContext? CreateParentTraceContext()
+    {
+        var activity = Activity.Current;
+        if (activity?.Id is null || activity.IdFormat != ActivityIdFormat.W3C)
+        {
+            return null;
+        }
+
+        return new grpc.TraceContext
+        {
+            TraceParent = activity.Id,
+            TraceState = string.IsNullOrEmpty(activity.TraceStateString) ? null : activity.TraceStateString
+        };
+    }
 
     private CallOptions CreateCallOptions(CancellationToken cancellationToken) =>
         DaprClientUtilities.ConfigureGrpcCallOptions(typeof(DaprWorkflowClient).Assembly, daprApiToken, cancellationToken);

--- a/test/Dapr.Common.Test/DaprClientUtilitiesTests.cs
+++ b/test/Dapr.Common.Test/DaprClientUtilitiesTests.cs
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------------------
+// Copyright 2026 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  ------------------------------------------------------------------------
+
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Grpc.Core;
+using Xunit;
+
+namespace Dapr.Common.Test;
+
+public sealed class DaprClientUtilitiesTests
+{
+    [Fact]
+    public void ConfigureGrpcCallOptions_ShouldIncludeW3CTraceContext_WhenActivityCurrentIsSet()
+    {
+        var previous = Activity.Current;
+        using var activity = new Activity("parent");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.TraceStateString = "vendor=value";
+        activity.Start();
+
+        try
+        {
+            var options = DaprClientUtilities.ConfigureGrpcCallOptions(
+                typeof(DaprClientUtilitiesTests).Assembly,
+                daprApiToken: null,
+                CancellationToken.None);
+
+            Assert.True(TryGetHeader(options.Headers, "traceparent", out var traceParent));
+            Assert.Equal(activity.Id, traceParent);
+            Assert.True(TryGetHeader(options.Headers, "tracestate", out var traceState));
+            Assert.Equal(activity.TraceStateString, traceState);
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+    }
+
+    [Fact]
+    public void ConfigureGrpcCallOptions_ShouldNotIncludeTraceContext_WhenActivityCurrentIsNull()
+    {
+        var previous = Activity.Current;
+        Activity.Current = null;
+
+        try
+        {
+            var options = DaprClientUtilities.ConfigureGrpcCallOptions(
+                typeof(DaprClientUtilitiesTests).Assembly,
+                daprApiToken: null,
+                CancellationToken.None);
+
+            Assert.False(TryGetHeader(options.Headers, "traceparent", out _));
+            Assert.False(TryGetHeader(options.Headers, "tracestate", out _));
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+    }
+
+    private static bool TryGetHeader(Metadata metadata, string key, out string value)
+    {
+        value = string.Empty;
+        var entry = metadata.FirstOrDefault(item => item.Key == key);
+        if (entry is null)
+        {
+            return false;
+        }
+
+        value = entry.Value;
+        return true;
+    }
+}

--- a/test/Dapr.IntegrationTest.Workflow/Versioning/Patches/WorkflowPatchTestExtensions.cs
+++ b/test/Dapr.IntegrationTest.Workflow/Versioning/Patches/WorkflowPatchTestExtensions.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Dapr.Workflow;
 
 namespace Dapr.IntegrationTest.Workflow.Versioning.Patches;

--- a/test/Dapr.IntegrationTest.Workflow/WorkflowObservabilityTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/WorkflowObservabilityTests.cs
@@ -103,11 +103,13 @@ public sealed class WorkflowObservabilityTests
         Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
         Assert.Equal(3, result.ReadOutputAs<int>());
 
-        var traceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(RetryObservedActivity), expectedCount: 3);
+        var runtimeSpans = await WaitForRuntimeActivitySpansAsync(run.Harness, nameof(RetryObservedActivity), expectedCount: 3);
         var activities = await WaitForSdkActivitiesAsync(run.Harness, nameof(RetryObservedActivity), expectedCount: 3);
 
         Assert.Equal(3, activities.Count);
-        Assert.All(activities, activity => Assert.Contains(activity.TraceId, traceIds));
+        Assert.All(activities, activity => Assert.Contains(
+            runtimeSpans,
+            span => IsChildOfRuntimeSpan(activity, span)));
     }
 
     [MinimumDaprRuntimeFact("1.17")]
@@ -131,11 +133,13 @@ public sealed class WorkflowObservabilityTests
         Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
         Assert.Equal(12, result.ReadOutputAs<int>());
 
-        var traceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(FanOutObservedActivity), expectedCount: 3);
+        var runtimeSpans = await WaitForRuntimeActivitySpansAsync(run.Harness, nameof(FanOutObservedActivity), expectedCount: 3);
         var activities = await WaitForSdkActivitiesAsync(run.Harness, nameof(FanOutObservedActivity), expectedCount: 3);
 
         Assert.Equal(3, activities.Count);
-        Assert.All(activities, activity => Assert.Contains(activity.TraceId, traceIds));
+        Assert.All(activities, activity => Assert.Contains(
+            runtimeSpans,
+            span => IsChildOfRuntimeSpan(activity, span)));
     }
 
     [MinimumDaprRuntimeFact("1.17")]
@@ -511,13 +515,17 @@ public sealed class WorkflowObservabilityTests
         Assert.Equal(WorkflowRuntimeStatus.Completed, rerunResult.RuntimeStatus);
         Assert.Equal(8, rerunResult.ReadOutputAs<int>());
 
-        var firstTraceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(RerunFirstObservedActivity), expectedCount: 2);
+        var firstRuntimeSpans = await WaitForRuntimeActivitySpansAsync(run.Harness, nameof(RerunFirstObservedActivity), expectedCount: 2);
         var firstActivities = await WaitForSdkActivitiesAsync(run.Harness, nameof(RerunFirstObservedActivity), expectedCount: 2);
-        Assert.All(firstActivities, activity => Assert.Contains(activity.TraceId, firstTraceIds));
+        Assert.All(firstActivities, activity => Assert.Contains(
+            firstRuntimeSpans,
+            span => IsChildOfRuntimeSpan(activity, span)));
 
-        var secondTraceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(RerunSecondObservedActivity), expectedCount: 2);
+        var secondRuntimeSpans = await WaitForRuntimeActivitySpansAsync(run.Harness, nameof(RerunSecondObservedActivity), expectedCount: 2);
         var secondActivities = await WaitForSdkActivitiesAsync(run.Harness, nameof(RerunSecondObservedActivity), expectedCount: 2);
-        Assert.All(secondActivities, activity => Assert.Contains(activity.TraceId, secondTraceIds));
+        Assert.All(secondActivities, activity => Assert.Contains(
+            secondRuntimeSpans,
+            span => IsChildOfRuntimeSpan(activity, span)));
     }
 
     [MinimumDaprRuntimeFact("1.18")]
@@ -601,11 +609,13 @@ public sealed class WorkflowObservabilityTests
         Assert.NotNull(output);
         Assert.Equal([10, 20, 30], output);
 
-        var traceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(ParallelChildObservedActivity), expectedCount: 3);
+        var runtimeSpans = await WaitForRuntimeActivitySpansAsync(run.Harness, nameof(ParallelChildObservedActivity), expectedCount: 3);
         var activities = await WaitForSdkActivitiesAsync(run.Harness, nameof(ParallelChildObservedActivity), expectedCount: 3);
 
         Assert.Equal(3, activities.Count);
-        Assert.All(activities, activity => Assert.Contains(activity.TraceId, traceIds));
+        Assert.All(activities, activity => Assert.Contains(
+            runtimeSpans,
+            span => IsChildOfRuntimeSpan(activity, span)));
     }
 
     [MinimumDaprRuntimeFact("1.17")]
@@ -719,15 +729,21 @@ public sealed class WorkflowObservabilityTests
 
     private static async Task AssertRuntimeAndSdkActivityTraceAsync(WorkflowHarness harness, string activityName)
     {
-        var traceId = await GetRuntimeActivityTraceIdAsync(harness, activityName);
-        var activities = await WaitForSdkActivitiesAsync(harness, activityName, traceId, expectedCount: 1);
+        var runtimeSpan = await GetRuntimeActivitySpanAsync(harness, activityName);
+        var activities = await WaitForSdkActivitiesAsync(harness, activityName, runtimeSpan.TraceId, expectedCount: 1);
 
         var activity = Assert.Single(activities);
         Assert.False(string.IsNullOrWhiteSpace(activity.ParentId));
         Assert.False(string.IsNullOrWhiteSpace(activity.SpanId));
+        Assert.True(
+            IsChildOfRuntimeSpan(activity, runtimeSpan),
+            $"Expected SDK activity '{activity.DisplayName}' span '{activity.SpanId}' to be a child of runtime span '{runtimeSpan.Id}' on trace '{runtimeSpan.TraceId}'.");
     }
 
-    private static async Task<string> GetRuntimeActivityTraceIdAsync(WorkflowHarness harness, string activityName)
+    private static async Task<string> GetRuntimeActivityTraceIdAsync(WorkflowHarness harness, string activityName) =>
+        (await GetRuntimeActivitySpanAsync(harness, activityName)).TraceId;
+
+    private static async Task<ZipkinSpan> GetRuntimeActivitySpanAsync(WorkflowHarness harness, string activityName)
     {
         var collector = GetCollector(harness);
         var runtimeActivitySpan = await collector.WaitForZipkinSpanAsync(
@@ -737,10 +753,10 @@ public sealed class WorkflowObservabilityTests
 
         Assert.False(string.IsNullOrWhiteSpace(runtimeActivitySpan.Id));
         Assert.False(string.IsNullOrWhiteSpace(runtimeActivitySpan.TraceId));
-        return runtimeActivitySpan.TraceId;
+        return runtimeActivitySpan;
     }
 
-    private static async Task<IReadOnlySet<string>> WaitForRuntimeActivityTraceIdsAsync(
+    private static async Task<IReadOnlyList<ZipkinSpan>> WaitForRuntimeActivitySpansAsync(
         WorkflowHarness harness,
         string activityName,
         int expectedCount)
@@ -751,16 +767,15 @@ public sealed class WorkflowObservabilityTests
 
         while (DateTimeOffset.UtcNow < deadline)
         {
-            var traceIds = collector.ZipkinSpans
+            var spans = collector.ZipkinSpans
                 .Where(span => string.Equals(span.Name, runtimeName, StringComparison.OrdinalIgnoreCase))
-                .Select(span => span.TraceId)
-                .Where(traceId => !string.IsNullOrWhiteSpace(traceId))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                .Where(span => !string.IsNullOrWhiteSpace(span.Id))
+                .Where(span => !string.IsNullOrWhiteSpace(span.TraceId))
+                .ToList();
 
-            if (traceIds.Count >= expectedCount)
+            if (spans.Count >= expectedCount)
             {
-                return traceIds;
+                return spans;
             }
 
             await Task.Delay(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
@@ -771,6 +786,10 @@ public sealed class WorkflowObservabilityTests
             $"but captured {collector.ZipkinSpans.Count} Zipkin span(s).");
         throw new UnreachableException();
     }
+
+    private static bool IsChildOfRuntimeSpan(CapturedActivity activity, ZipkinSpan runtimeSpan) =>
+        string.Equals(activity.TraceId, runtimeSpan.TraceId, StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(activity.ParentSpanId, runtimeSpan.Id, StringComparison.OrdinalIgnoreCase);
 
     private static async Task<IReadOnlyList<CapturedActivity>> WaitForSdkActivitiesAsync(
         WorkflowHarness harness,

--- a/test/Dapr.IntegrationTest.Workflow/WorkflowObservabilityTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/WorkflowObservabilityTests.cs
@@ -234,6 +234,72 @@ public sealed class WorkflowObservabilityTests
     }
 
     [MinimumDaprRuntimeFact("1.17")]
+    public async Task WorkflowFailureAfterActivityFailure_ShouldPreserveFailedActivityTraceAndHistory()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<WorkflowFailureAfterActivityFailureObservedWorkflow>();
+                opt.RegisterActivity<WorkflowFailureObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(WorkflowFailureAfterActivityFailureObservedWorkflow), instanceId);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Failed, result.RuntimeStatus);
+
+        var history = await client.GetInstanceHistoryAsync(instanceId, TestContext.Current.CancellationToken);
+        Assert.Contains(history, e => e.EventType == WorkflowHistoryEventType.TaskFailed);
+
+        var traceId = await GetRuntimeActivityTraceIdAsync(run.Harness, nameof(WorkflowFailureObservedActivity));
+        var activity = Assert.Single(await WaitForSdkActivitiesAsync(
+            run.Harness,
+            nameof(WorkflowFailureObservedActivity),
+            traceId,
+            expectedCount: 1));
+
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task CaughtActivityFailureCompensation_ShouldTraceFailedAndCompensatingActivities()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<CaughtFailureCompensationObservedWorkflow>();
+                opt.RegisterActivity<CompensatedFailingObservedActivity>();
+                opt.RegisterActivity<CompensationObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(CaughtFailureCompensationObservedWorkflow), instanceId, 7);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal("compensated-7", result.ReadOutputAs<string>());
+
+        var failureTraceId = await GetRuntimeActivityTraceIdAsync(run.Harness, nameof(CompensatedFailingObservedActivity));
+        var failedActivity = Assert.Single(await WaitForSdkActivitiesAsync(
+            run.Harness,
+            nameof(CompensatedFailingObservedActivity),
+            failureTraceId,
+            expectedCount: 1));
+        Assert.Equal(ActivityStatusCode.Error, failedActivity.Status);
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(CompensationObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
     public async Task ContinueAsNew_ShouldPreserveActivityTracingAfterContinuation()
     {
         var run = await StartWorkflowTestAsync(
@@ -302,6 +368,33 @@ public sealed class WorkflowObservabilityTests
         Assert.Equal(20, result.ReadOutputAs<int>());
 
         await AssertRuntimeAndSdkActivityTraceAsync(harness2, nameof(MultiAppChildObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task SubworkflowWithParentAndChildActivities_ShouldTraceBothWorkflowLevels()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<ParentChildActivitiesObservedParentWorkflow>();
+                opt.RegisterWorkflow<ParentChildActivitiesObservedChildWorkflow>();
+                opt.RegisterActivity<ParentLevelObservedActivity>();
+                opt.RegisterActivity<ChildLevelObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(ParentChildActivitiesObservedParentWorkflow), instanceId, 5);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(36, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(ParentLevelObservedActivity));
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(ChildLevelObservedActivity));
     }
 
     [MinimumDaprRuntimeFact("1.17")]
@@ -893,6 +986,49 @@ public sealed class WorkflowObservabilityTests
             throw new InvalidOperationException("Observed failure");
     }
 
+    private sealed class WorkflowFailureAfterActivityFailureObservedWorkflow : Workflow<string?, string>
+    {
+        public override async Task<string> RunAsync(WorkflowContext context, string? input)
+        {
+            await context.CallActivityAsync<string>(nameof(WorkflowFailureObservedActivity), string.Empty);
+            return "unreachable";
+        }
+    }
+
+    private sealed class WorkflowFailureObservedActivity : WorkflowActivity<string?, string>
+    {
+        public override Task<string> RunAsync(WorkflowActivityContext context, string? input) =>
+            throw new InvalidOperationException("Observed workflow failure");
+    }
+
+    private sealed class CaughtFailureCompensationObservedWorkflow : Workflow<int, string>
+    {
+        public override async Task<string> RunAsync(WorkflowContext context, int input)
+        {
+            try
+            {
+                await context.CallActivityAsync<string>(nameof(CompensatedFailingObservedActivity), input);
+                return "unreachable";
+            }
+            catch (WorkflowTaskFailedException)
+            {
+                return await context.CallActivityAsync<string>(nameof(CompensationObservedActivity), input);
+            }
+        }
+    }
+
+    private sealed class CompensatedFailingObservedActivity : WorkflowActivity<int, string>
+    {
+        public override Task<string> RunAsync(WorkflowActivityContext context, int input) =>
+            throw new InvalidOperationException("Observed compensated failure");
+    }
+
+    private sealed class CompensationObservedActivity : WorkflowActivity<int, string>
+    {
+        public override Task<string> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult($"compensated-{input}");
+    }
+
     private sealed class ContinueAsNewObservedWorkflow : Workflow<int, int>
     {
         public override async Task<int> RunAsync(WorkflowContext context, int input)
@@ -938,6 +1074,38 @@ public sealed class WorkflowObservabilityTests
     {
         public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
             Task.FromResult(input * 5);
+    }
+
+    private sealed class ParentChildActivitiesObservedParentWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            var parentValue = await context.CallActivityAsync<int>(nameof(ParentLevelObservedActivity), input);
+            var childValue = await context.CallChildWorkflowAsync<int>(
+                nameof(ParentChildActivitiesObservedChildWorkflow),
+                parentValue,
+                new ChildWorkflowTaskOptions(InstanceId: $"{context.InstanceId}-child"));
+
+            return parentValue + childValue;
+        }
+    }
+
+    private sealed class ParentChildActivitiesObservedChildWorkflow : Workflow<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, int input) =>
+            context.CallActivityAsync<int>(nameof(ChildLevelObservedActivity), input);
+    }
+
+    private sealed class ParentLevelObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input + 7);
+    }
+
+    private sealed class ChildLevelObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 2);
     }
 
     private sealed class DownstreamObservedWorkflow : Workflow<int, int>

--- a/test/Dapr.IntegrationTest.Workflow/WorkflowObservabilityTests.cs
+++ b/test/Dapr.IntegrationTest.Workflow/WorkflowObservabilityTests.cs
@@ -1,0 +1,1110 @@
+// ------------------------------------------------------------------------
+// Copyright 2026 The Dapr Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//  ------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Dapr.Testcontainers.Common;
+using Dapr.Testcontainers.Common.Options;
+using Dapr.Testcontainers.Common.Testing;
+using Dapr.Testcontainers.Harnesses;
+using Dapr.Testcontainers.Telemetry;
+using Dapr.Testcontainers.Xunit.Attributes;
+using Dapr.Workflow;
+using Dapr.Workflow.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dapr.IntegrationTest.Workflow;
+
+public sealed class WorkflowObservabilityTests
+{
+    private static readonly TimeSpan TelemetryTimeout = TimeSpan.FromSeconds(30);
+    private const string DownstreamActivitySourceName = "Dapr.Workflow.Observability.Downstream";
+    private static readonly ActivitySource DownstreamActivitySource = new(DownstreamActivitySourceName);
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task SimpleActivity_ShouldConnectRuntimeAndSdkActivitySpans()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<SimpleObservedWorkflow>();
+                opt.RegisterActivity<SimpleObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(SimpleObservedWorkflow), instanceId, 8);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(16, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(SimpleObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task ChildWorkflow_ShouldPreserveActivityTraceInChildExecution()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<ObservedParentWorkflow>();
+                opt.RegisterWorkflow<ObservedChildWorkflow>();
+                opt.RegisterActivity<ChildObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(ObservedParentWorkflow), instanceId, 5);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(15, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(ChildObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task ActivityRetry_ShouldCaptureEachAttemptInSameWorkflowTrace()
+    {
+        RetryObservedActivity.Reset();
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<RetryObservedWorkflow>();
+                opt.RegisterActivity<RetryObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(RetryObservedWorkflow), instanceId);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(3, result.ReadOutputAs<int>());
+
+        var traceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(RetryObservedActivity), expectedCount: 3);
+        var activities = await WaitForSdkActivitiesAsync(run.Harness, nameof(RetryObservedActivity), expectedCount: 3);
+
+        Assert.Equal(3, activities.Count);
+        Assert.All(activities, activity => Assert.Contains(activity.TraceId, traceIds));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task FanOutFanIn_ShouldKeepParallelActivitySpansOnOneTrace()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<FanOutObservedWorkflow>();
+                opt.RegisterActivity<FanOutObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(FanOutObservedWorkflow), instanceId, 3);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(12, result.ReadOutputAs<int>());
+
+        var traceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(FanOutObservedActivity), expectedCount: 3);
+        var activities = await WaitForSdkActivitiesAsync(run.Harness, nameof(FanOutObservedActivity), expectedCount: 3);
+
+        Assert.Equal(3, activities.Count);
+        Assert.All(activities, activity => Assert.Contains(activity.TraceId, traceIds));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task TimerAndExternalEvent_ShouldPreserveTraceUntilActivityExecution()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<TimerEventObservedWorkflow>();
+                opt.RegisterActivity<TimerEventObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(TimerEventObservedWorkflow), instanceId);
+        await Task.Delay(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        await client.RaiseEventAsync(instanceId, "Approval", "approved", TestContext.Current.CancellationToken);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal("approved-observed", result.ReadOutputAs<string>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(TimerEventObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task MultiAppActivity_ShouldPreserveTraceAcrossRemoteActivityHost()
+    {
+        var guid = Guid.NewGuid().ToString("N");
+        var app1Id = $"workflow-observe-source-{guid}";
+        var app2Id = $"workflow-observe-target-{guid}";
+
+        var options1 = new DaprRuntimeOptions().WithAppId(app1Id);
+        var options2 = new DaprRuntimeOptions().WithAppId(app2Id);
+
+        await using var environment = await DaprTestEnvironment.CreateWithPooledNetworkAsync(
+            needsActorState: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+        await environment.StartAsync(TestContext.Current.CancellationToken);
+
+        var harness1 = CreateWorkflowHarness("workflow-observability-multiapp-1", environment, options1)
+            .EnableTelemetryCapture();
+        var harness2 = CreateWorkflowHarness("workflow-observability-multiapp-2", environment, options2)
+            .EnableTelemetryCapture();
+
+        await using var app1 = await StartAppAsync(
+            harness1,
+            opt => opt.RegisterWorkflow<MultiAppObservedWorkflow>());
+        await using var app2 = await StartAppAsync(
+            harness2,
+            opt => opt.RegisterActivity<RemoteObservedActivity>());
+
+        var client = GetWorkflowClient(app1);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(
+            nameof(MultiAppObservedWorkflow),
+            instanceId,
+            new MultiAppObservedInput(app2Id, 9));
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(27, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(harness2, nameof(RemoteObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task ActivityFailure_ShouldMarkSdkActivitySpanAsError()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<FailingObservedWorkflow>();
+                opt.RegisterActivity<FailingObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(FailingObservedWorkflow), instanceId);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Failed, result.RuntimeStatus);
+
+        var traceId = await GetRuntimeActivityTraceIdAsync(run.Harness, nameof(FailingObservedActivity));
+        var activities = await WaitForSdkActivitiesAsync(run.Harness, nameof(FailingObservedActivity), traceId, expectedCount: 1);
+        var activity = Assert.Single(activities);
+
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task ContinueAsNew_ShouldPreserveActivityTracingAfterContinuation()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<ContinueAsNewObservedWorkflow>();
+                opt.RegisterActivity<ContinueAsNewObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(ContinueAsNewObservedWorkflow), instanceId, 0);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(2, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(ContinueAsNewObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task MultiAppChildWorkflow_ShouldPreserveTraceAcrossRemoteChildWorkflowHost()
+    {
+        var guid = Guid.NewGuid().ToString("N");
+        var app1Id = $"workflow-observe-child-source-{guid}";
+        var app2Id = $"workflow-observe-child-target-{guid}";
+
+        var options1 = new DaprRuntimeOptions().WithAppId(app1Id);
+        var options2 = new DaprRuntimeOptions().WithAppId(app2Id);
+
+        await using var environment = await DaprTestEnvironment.CreateWithPooledNetworkAsync(
+            needsActorState: true,
+            cancellationToken: TestContext.Current.CancellationToken);
+        await environment.StartAsync(TestContext.Current.CancellationToken);
+
+        var harness1 = CreateWorkflowHarness("workflow-observability-child-multiapp-1", environment, options1)
+            .EnableTelemetryCapture();
+        var harness2 = CreateWorkflowHarness("workflow-observability-child-multiapp-2", environment, options2)
+            .EnableTelemetryCapture();
+
+        await using var app1 = await StartAppAsync(
+            harness1,
+            opt => opt.RegisterWorkflow<MultiAppChildObservedParentWorkflow>());
+        await using var app2 = await StartAppAsync(
+            harness2,
+            opt =>
+            {
+                opt.RegisterWorkflow<MultiAppChildObservedTargetWorkflow>();
+                opt.RegisterActivity<MultiAppChildObservedActivity>();
+            });
+
+        var client = GetWorkflowClient(app1);
+        var parentInstanceId = NewInstanceId();
+        var childInstanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(
+            nameof(MultiAppChildObservedParentWorkflow),
+            parentInstanceId,
+            new MultiAppChildObservedInput(app2Id, childInstanceId, 4));
+        var result = await client.WaitForWorkflowCompletionAsync(parentInstanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(20, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(harness2, nameof(MultiAppChildObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task DownstreamActivitySource_ShouldBeParentedUnderWorkflowActivitySpan()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<DownstreamObservedWorkflow>();
+                opt.RegisterActivity<DownstreamObservedActivity>();
+            },
+            TestContext.Current.CancellationToken,
+            configureTelemetry: collector => collector.CaptureActivitySource(DownstreamActivitySourceName));
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(DownstreamObservedWorkflow), instanceId, 6);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(7, result.ReadOutputAs<int>());
+
+        var traceId = await GetRuntimeActivityTraceIdAsync(run.Harness, nameof(DownstreamObservedActivity));
+        var workflowActivity = Assert.Single(await WaitForSdkActivitiesAsync(
+            run.Harness,
+            nameof(DownstreamObservedActivity),
+            traceId,
+            expectedCount: 1));
+
+        var downstream = await GetCollector(run.Harness).WaitForActivityAsync(
+            activity =>
+                activity.SourceName == DownstreamActivitySourceName &&
+                activity.DisplayName == "DownstreamOperation" &&
+                activity.TraceId == workflowActivity.TraceId &&
+                activity.ParentSpanId == workflowActivity.SpanId,
+            TelemetryTimeout,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(workflowActivity.TraceId, downstream.TraceId);
+        Assert.Equal(workflowActivity.SpanId, downstream.ParentSpanId);
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task SuspendResume_ShouldPreserveTraceAfterWorkflowResumes()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<SuspendResumeObservedWorkflow>();
+                opt.RegisterActivity<SuspendResumeObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(SuspendResumeObservedWorkflow), instanceId);
+        await client.WaitForWorkflowStartAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        await client.SuspendWorkflowAsync(instanceId, "observability-test", TestContext.Current.CancellationToken);
+        var suspended = await WaitForWorkflowStatusAsync(client, instanceId, WorkflowRuntimeStatus.Suspended);
+        Assert.Equal(WorkflowRuntimeStatus.Suspended, suspended.RuntimeStatus);
+
+        await client.ResumeWorkflowAsync(instanceId, "observability-test", TestContext.Current.CancellationToken);
+        await client.RaiseEventAsync(instanceId, "Continue", 11, TestContext.Current.CancellationToken);
+
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(22, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(SuspendResumeObservedActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task RerunWorkflow_ShouldCaptureActivityTracingForRerunInstance()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<RerunObservedWorkflow>();
+                opt.RegisterActivity<RerunFirstObservedActivity>();
+                opt.RegisterActivity<RerunSecondObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var sourceInstanceId = NewInstanceId();
+        var rerunInstanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(RerunObservedWorkflow), sourceInstanceId, 3);
+        var sourceResult = await client.WaitForWorkflowCompletionAsync(sourceInstanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, sourceResult.RuntimeStatus);
+        Assert.Equal(8, sourceResult.ReadOutputAs<int>());
+
+        var history = await client.GetInstanceHistoryAsync(sourceInstanceId, TestContext.Current.CancellationToken);
+        var firstActivityScheduledEventId = history
+            .First(e => e is { EventType: WorkflowHistoryEventType.TaskScheduled, EventId: >= 0 })
+            .EventId;
+
+        var actualRerunInstanceId = await client.RerunWorkflowFromEventAsync(
+            sourceInstanceId,
+            (uint)firstActivityScheduledEventId,
+            new RerunWorkflowFromEventOptions { NewInstanceId = rerunInstanceId },
+            TestContext.Current.CancellationToken);
+        var rerunResult = await client.WaitForWorkflowCompletionAsync(actualRerunInstanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(rerunInstanceId, actualRerunInstanceId);
+        Assert.Equal(WorkflowRuntimeStatus.Completed, rerunResult.RuntimeStatus);
+        Assert.Equal(8, rerunResult.ReadOutputAs<int>());
+
+        var firstTraceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(RerunFirstObservedActivity), expectedCount: 2);
+        var firstActivities = await WaitForSdkActivitiesAsync(run.Harness, nameof(RerunFirstObservedActivity), expectedCount: 2);
+        Assert.All(firstActivities, activity => Assert.Contains(activity.TraceId, firstTraceIds));
+
+        var secondTraceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(RerunSecondObservedActivity), expectedCount: 2);
+        var secondActivities = await WaitForSdkActivitiesAsync(run.Harness, nameof(RerunSecondObservedActivity), expectedCount: 2);
+        Assert.All(secondActivities, activity => Assert.Contains(activity.TraceId, secondTraceIds));
+    }
+
+    [MinimumDaprRuntimeFact("1.18")]
+    public async Task HistoryPropagationOwnHistory_ShouldPreserveActivityTracingAcrossPropagatedChildWorkflow()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<OwnHistoryObservedParentWorkflow>();
+                opt.RegisterWorkflow<HistoryObservedReceiverWorkflow>();
+                opt.RegisterActivity<HistoryObservedParentActivity>();
+                opt.RegisterActivity<HistoryObservedChildActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(OwnHistoryObservedParentWorkflow), instanceId, 4);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(14, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(HistoryObservedParentActivity));
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(HistoryObservedChildActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.18")]
+    public async Task HistoryPropagationLineage_ShouldPreserveActivityTracingAcrossWorkflowLineage()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<LineageObservedParentWorkflow>();
+                opt.RegisterWorkflow<LineageObservedMiddleWorkflow>();
+                opt.RegisterWorkflow<HistoryObservedReceiverWorkflow>();
+                opt.RegisterActivity<HistoryObservedParentActivity>();
+                opt.RegisterActivity<HistoryObservedMiddleActivity>();
+                opt.RegisterActivity<HistoryObservedChildActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(LineageObservedParentWorkflow), instanceId, 2);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        Assert.Equal(14, result.ReadOutputAs<int>());
+
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(HistoryObservedParentActivity));
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(HistoryObservedMiddleActivity));
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(HistoryObservedChildActivity));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task ParallelChildWorkflows_ShouldCaptureEachChildActivityTrace()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<ParallelChildObservedParentWorkflow>();
+                opt.RegisterWorkflow<ParallelChildObservedChildWorkflow>();
+                opt.RegisterActivity<ParallelChildObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(ParallelChildObservedParentWorkflow), instanceId, 3);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Completed, result.RuntimeStatus);
+        var output = result.ReadOutputAs<int[]>();
+        Assert.NotNull(output);
+        Assert.Equal([10, 20, 30], output);
+
+        var traceIds = await WaitForRuntimeActivityTraceIdsAsync(run.Harness, nameof(ParallelChildObservedActivity), expectedCount: 3);
+        var activities = await WaitForSdkActivitiesAsync(run.Harness, nameof(ParallelChildObservedActivity), expectedCount: 3);
+
+        Assert.Equal(3, activities.Count);
+        Assert.All(activities, activity => Assert.Contains(activity.TraceId, traceIds));
+    }
+
+    [MinimumDaprRuntimeFact("1.17")]
+    public async Task TerminateWorkflow_ShouldPreserveTracingForWorkCompletedBeforeTermination()
+    {
+        var run = await StartWorkflowTestAsync(
+            opt =>
+            {
+                opt.RegisterWorkflow<TerminateObservedWorkflow>();
+                opt.RegisterActivity<TerminateObservedActivity>();
+            },
+            TestContext.Current.CancellationToken);
+        await using var _ = run;
+
+        var client = GetWorkflowClient(run.App);
+        var instanceId = NewInstanceId();
+
+        await client.ScheduleNewWorkflowAsync(nameof(TerminateObservedWorkflow), instanceId, 5);
+        await WaitForSdkActivitiesAsync(run.Harness, nameof(TerminateObservedActivity), expectedCount: 1);
+
+        await client.TerminateWorkflowAsync(instanceId, "terminated", TestContext.Current.CancellationToken);
+        var result = await client.WaitForWorkflowCompletionAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+
+        Assert.Equal(WorkflowRuntimeStatus.Terminated, result.RuntimeStatus);
+
+        var history = await client.GetInstanceHistoryAsync(instanceId, TestContext.Current.CancellationToken);
+        Assert.Contains(history, e => e.EventType == WorkflowHistoryEventType.ExecutionTerminated);
+        await AssertRuntimeAndSdkActivityTraceAsync(run.Harness, nameof(TerminateObservedActivity));
+    }
+
+    private static async Task<WorkflowObservabilityRun> StartWorkflowTestAsync(
+        Action<WorkflowRuntimeOptions> configureRuntime,
+        CancellationToken cancellationToken,
+        Action<DaprTelemetryCollector>? configureTelemetry = null)
+    {
+        var environment = await DaprTestEnvironment.CreateWithPooledNetworkAsync(
+            needsActorState: true,
+            cancellationToken: cancellationToken);
+        await environment.StartAsync(cancellationToken);
+
+        var harness = CreateWorkflowHarness("workflow-observability", environment)
+            .EnableTelemetryCapture();
+        configureTelemetry?.Invoke(GetCollector(harness));
+        var app = await StartAppAsync(harness, configureRuntime);
+
+        return new WorkflowObservabilityRun(environment, harness, app);
+    }
+
+    private static WorkflowHarness CreateWorkflowHarness(
+        string directoryPrefix,
+        DaprTestEnvironment environment,
+        DaprRuntimeOptions? options = null)
+    {
+        var builder = new DaprHarnessBuilder(TestDirectoryManager.CreateTestDirectory(directoryPrefix))
+            .WithEnvironment(environment);
+        if (options is not null)
+        {
+            builder.WithOptions(options);
+        }
+
+        return builder.BuildWorkflow();
+    }
+
+    private static Task<DaprTestApplication> StartAppAsync(
+        WorkflowHarness harness,
+        Action<WorkflowRuntimeOptions> configureRuntime) =>
+        DaprHarnessBuilder.ForHarness(harness)
+            .ConfigureServices(builder =>
+            {
+                builder.Services.AddDaprWorkflowBuilder(
+                    configureRuntime,
+                    configureClient: (sp, clientBuilder) =>
+                    {
+                        var config = sp.GetRequiredService<IConfiguration>();
+                        var grpcEndpoint = config["DAPR_GRPC_ENDPOINT"];
+                        if (!string.IsNullOrWhiteSpace(grpcEndpoint))
+                        {
+                            clientBuilder.UseGrpcEndpoint(grpcEndpoint);
+                        }
+                    });
+            })
+            .BuildAndStartAsync();
+
+    private static DaprWorkflowClient GetWorkflowClient(DaprTestApplication app)
+    {
+        var scope = app.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<DaprWorkflowClient>();
+    }
+
+    private static async Task<WorkflowState> WaitForWorkflowStatusAsync(
+        DaprWorkflowClient client,
+        string instanceId,
+        WorkflowRuntimeStatus status)
+    {
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var state = await client.GetWorkflowStateAsync(instanceId, cancellation: TestContext.Current.CancellationToken);
+            if (state?.RuntimeStatus == status)
+            {
+                return state;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        }
+
+        Assert.Fail($"Expected workflow '{instanceId}' to reach status '{status}' within 30 seconds.");
+        throw new UnreachableException();
+    }
+
+    private static async Task AssertRuntimeAndSdkActivityTraceAsync(WorkflowHarness harness, string activityName)
+    {
+        var traceId = await GetRuntimeActivityTraceIdAsync(harness, activityName);
+        var activities = await WaitForSdkActivitiesAsync(harness, activityName, traceId, expectedCount: 1);
+
+        var activity = Assert.Single(activities);
+        Assert.False(string.IsNullOrWhiteSpace(activity.ParentId));
+        Assert.False(string.IsNullOrWhiteSpace(activity.SpanId));
+    }
+
+    private static async Task<string> GetRuntimeActivityTraceIdAsync(WorkflowHarness harness, string activityName)
+    {
+        var collector = GetCollector(harness);
+        var runtimeActivitySpan = await collector.WaitForZipkinSpanAsync(
+            span => string.Equals(span.Name, RuntimeActivitySpanName(activityName), StringComparison.OrdinalIgnoreCase),
+            TelemetryTimeout,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(string.IsNullOrWhiteSpace(runtimeActivitySpan.Id));
+        Assert.False(string.IsNullOrWhiteSpace(runtimeActivitySpan.TraceId));
+        return runtimeActivitySpan.TraceId;
+    }
+
+    private static async Task<IReadOnlySet<string>> WaitForRuntimeActivityTraceIdsAsync(
+        WorkflowHarness harness,
+        string activityName,
+        int expectedCount)
+    {
+        var collector = GetCollector(harness);
+        var runtimeName = RuntimeActivitySpanName(activityName);
+        var deadline = DateTimeOffset.UtcNow + TelemetryTimeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var traceIds = collector.ZipkinSpans
+                .Where(span => string.Equals(span.Name, runtimeName, StringComparison.OrdinalIgnoreCase))
+                .Select(span => span.TraceId)
+                .Where(traceId => !string.IsNullOrWhiteSpace(traceId))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            if (traceIds.Count >= expectedCount)
+            {
+                return traceIds;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        }
+
+        Assert.Fail(
+            $"Expected {expectedCount} runtime activity trace(s) named '{runtimeName}', " +
+            $"but captured {collector.ZipkinSpans.Count} Zipkin span(s).");
+        throw new UnreachableException();
+    }
+
+    private static async Task<IReadOnlyList<CapturedActivity>> WaitForSdkActivitiesAsync(
+        WorkflowHarness harness,
+        string activityName,
+        string traceId,
+        int expectedCount)
+    {
+        var collector = GetCollector(harness);
+        var displayName = $"WorkflowActivity {activityName}";
+        var deadline = DateTimeOffset.UtcNow + TelemetryTimeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var matches = collector.Activities
+                .Where(activity =>
+                    activity.SourceName == "Dapr.Workflow" &&
+                    activity.DisplayName == displayName &&
+                    string.Equals(activity.TraceId, traceId, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (matches.Count >= expectedCount)
+            {
+                return matches;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        }
+
+        Assert.Fail(
+            $"Expected {expectedCount} SDK activity span(s) named '{displayName}' on trace '{traceId}', " +
+            $"but captured {collector.Activities.Count} activity span(s).");
+        throw new UnreachableException();
+    }
+
+    private static async Task<IReadOnlyList<CapturedActivity>> WaitForSdkActivitiesAsync(
+        WorkflowHarness harness,
+        string activityName,
+        int expectedCount)
+    {
+        var collector = GetCollector(harness);
+        var displayName = $"WorkflowActivity {activityName}";
+        var deadline = DateTimeOffset.UtcNow + TelemetryTimeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var matches = collector.Activities
+                .Where(activity =>
+                    activity.SourceName == "Dapr.Workflow" &&
+                    activity.DisplayName == displayName)
+                .ToList();
+
+            if (matches.Count >= expectedCount)
+            {
+                return matches;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken);
+        }
+
+        Assert.Fail(
+            $"Expected {expectedCount} SDK activity span(s) named '{displayName}', " +
+            $"but captured {collector.Activities.Count} activity span(s).");
+        throw new UnreachableException();
+    }
+
+    private static DaprTelemetryCollector GetCollector(WorkflowHarness harness) =>
+        harness.TelemetryCollector ?? throw new InvalidOperationException("Telemetry capture was not enabled.");
+
+    private static string RuntimeActivitySpanName(string activityName) =>
+        $"activity||{activityName.ToLowerInvariant()}";
+
+    private static string NewInstanceId() => $"observability-{Guid.NewGuid():N}";
+
+    private sealed class WorkflowObservabilityRun(
+        DaprTestEnvironment environment,
+        WorkflowHarness harness,
+        DaprTestApplication app) : IAsyncDisposable
+    {
+        public WorkflowHarness Harness => harness;
+
+        public DaprTestApplication App => app;
+
+        public async ValueTask DisposeAsync()
+        {
+            await app.DisposeAsync();
+            await environment.DisposeAsync();
+        }
+    }
+
+    private sealed class SimpleObservedWorkflow : Workflow<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, int input) =>
+            context.CallActivityAsync<int>(nameof(SimpleObservedActivity), input);
+    }
+
+    private sealed class SimpleObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 2);
+    }
+
+    private sealed class ObservedParentWorkflow : Workflow<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, int input) =>
+            context.CallChildWorkflowAsync<int>(nameof(ObservedChildWorkflow), input);
+    }
+
+    private sealed class ObservedChildWorkflow : Workflow<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, int input) =>
+            context.CallActivityAsync<int>(nameof(ChildObservedActivity), input);
+    }
+
+    private sealed class ChildObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 3);
+    }
+
+    private sealed class RetryObservedWorkflow : Workflow<object?, int>
+    {
+        private static readonly WorkflowTaskOptions RetryOptions = new()
+        {
+            RetryPolicy = new WorkflowRetryPolicy(
+                maxNumberOfAttempts: 3,
+                firstRetryInterval: TimeSpan.FromSeconds(1),
+                backoffCoefficient: 1),
+        };
+
+        public override Task<int> RunAsync(WorkflowContext context, object? input) =>
+            context.CallActivityAsync<int>(nameof(RetryObservedActivity), string.Empty, RetryOptions);
+    }
+
+    private sealed class RetryObservedActivity : WorkflowActivity<string?, int>
+    {
+        private static readonly ConcurrentDictionary<string, int> Attempts = new(StringComparer.Ordinal);
+
+        public static void Reset() => Attempts.Clear();
+
+        public override Task<int> RunAsync(WorkflowActivityContext context, string? input)
+        {
+            var attempt = Attempts.AddOrUpdate(context.InstanceId, _ => 1, (_, current) => current + 1);
+            return attempt < 3
+                ? throw new InvalidOperationException("Observed retry")
+                : Task.FromResult(attempt);
+        }
+    }
+
+    private sealed class FanOutObservedWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            var tasks = Enumerable.Range(1, input)
+                .Select(value => context.CallActivityAsync<int>(nameof(FanOutObservedActivity), value))
+                .ToArray();
+
+            var results = await Task.WhenAll(tasks);
+            return results.Sum();
+        }
+    }
+
+    private sealed class FanOutObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 2);
+    }
+
+    private sealed class TimerEventObservedWorkflow : Workflow<object?, string>
+    {
+        public override async Task<string> RunAsync(WorkflowContext context, object? input)
+        {
+            await context.CreateTimer(TimeSpan.FromSeconds(1));
+            var approval = await context.WaitForExternalEventAsync<string>("Approval");
+            return await context.CallActivityAsync<string>(nameof(TimerEventObservedActivity), approval);
+        }
+    }
+
+    private sealed class TimerEventObservedActivity : WorkflowActivity<string, string>
+    {
+        public override Task<string> RunAsync(WorkflowActivityContext context, string input) =>
+            Task.FromResult($"{input}-observed");
+    }
+
+    private sealed record MultiAppObservedInput(string TargetAppId, int Value);
+
+    private sealed class MultiAppObservedWorkflow : Workflow<MultiAppObservedInput, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, MultiAppObservedInput input) =>
+            context.CallActivityAsync<int>(
+                nameof(RemoteObservedActivity),
+                input.Value,
+                new WorkflowTaskOptions(TargetAppId: input.TargetAppId));
+    }
+
+    private sealed class RemoteObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 3);
+    }
+
+    private sealed class FailingObservedWorkflow : Workflow<string?, string>
+    {
+        public override async Task<string> RunAsync(WorkflowContext context, string? input)
+        {
+            await context.CallActivityAsync<string>(nameof(FailingObservedActivity), string.Empty);
+            return "unreachable";
+        }
+    }
+
+    private sealed class FailingObservedActivity : WorkflowActivity<string?, string>
+    {
+        public override Task<string> RunAsync(WorkflowActivityContext context, string? input) =>
+            throw new InvalidOperationException("Observed failure");
+    }
+
+    private sealed class ContinueAsNewObservedWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            if (input == 0)
+            {
+                context.ContinueAsNew(1);
+                return -1;
+            }
+
+            return await context.CallActivityAsync<int>(nameof(ContinueAsNewObservedActivity), input);
+        }
+    }
+
+    private sealed class ContinueAsNewObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input + 1);
+    }
+
+    private sealed record MultiAppChildObservedInput(string TargetAppId, string ChildInstanceId, int Value);
+
+    private sealed class MultiAppChildObservedParentWorkflow : Workflow<MultiAppChildObservedInput, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, MultiAppChildObservedInput input) =>
+            context.CallChildWorkflowAsync<int>(
+                nameof(MultiAppChildObservedTargetWorkflow),
+                input.Value,
+                new ChildWorkflowTaskOptions
+                {
+                    InstanceId = input.ChildInstanceId,
+                    TargetAppId = input.TargetAppId
+                });
+    }
+
+    private sealed class MultiAppChildObservedTargetWorkflow : Workflow<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, int input) =>
+            context.CallActivityAsync<int>(nameof(MultiAppChildObservedActivity), input);
+    }
+
+    private sealed class MultiAppChildObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 5);
+    }
+
+    private sealed class DownstreamObservedWorkflow : Workflow<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, int input) =>
+            context.CallActivityAsync<int>(nameof(DownstreamObservedActivity), input);
+    }
+
+    private sealed class DownstreamObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input)
+        {
+            using var activity = DownstreamActivitySource.StartActivity("DownstreamOperation");
+            activity?.SetTag("workflow.instance_id", context.InstanceId);
+            return Task.FromResult(input + 1);
+        }
+    }
+
+    private sealed class SuspendResumeObservedWorkflow : Workflow<object?, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, object? input)
+        {
+            var value = await context.WaitForExternalEventAsync<int>("Continue");
+            return await context.CallActivityAsync<int>(nameof(SuspendResumeObservedActivity), value);
+        }
+    }
+
+    private sealed class SuspendResumeObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 2);
+    }
+
+    private sealed class RerunObservedWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            var first = await context.CallActivityAsync<int>(nameof(RerunFirstObservedActivity), input);
+            return await context.CallActivityAsync<int>(nameof(RerunSecondObservedActivity), first);
+        }
+    }
+
+    private sealed class RerunFirstObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input + 1);
+    }
+
+    private sealed class RerunSecondObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 2);
+    }
+
+    private sealed class OwnHistoryObservedParentWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            var parentValue = await context.CallActivityAsync<int>(nameof(HistoryObservedParentActivity), input);
+            var childOptions = new ChildWorkflowTaskOptions(InstanceId: $"{context.InstanceId}-child")
+                .WithHistoryPropagation(HistoryPropagationScope.OwnHistory);
+
+            return await context.CallChildWorkflowAsync<int>(
+                nameof(HistoryObservedReceiverWorkflow),
+                parentValue,
+                childOptions);
+        }
+    }
+
+    private sealed class LineageObservedParentWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            var parentValue = await context.CallActivityAsync<int>(nameof(HistoryObservedParentActivity), input);
+            var childOptions = new ChildWorkflowTaskOptions(InstanceId: $"{context.InstanceId}-middle")
+                .WithHistoryPropagation(HistoryPropagationScope.Lineage);
+
+            return await context.CallChildWorkflowAsync<int>(
+                nameof(LineageObservedMiddleWorkflow),
+                parentValue,
+                childOptions);
+        }
+    }
+
+    private sealed class LineageObservedMiddleWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            var middleValue = await context.CallActivityAsync<int>(nameof(HistoryObservedMiddleActivity), input);
+            var childOptions = new ChildWorkflowTaskOptions(InstanceId: $"{context.InstanceId}-leaf")
+                .WithHistoryPropagation(HistoryPropagationScope.Lineage);
+
+            return await context.CallChildWorkflowAsync<int>(
+                nameof(HistoryObservedReceiverWorkflow),
+                middleValue,
+                childOptions);
+        }
+    }
+
+    private sealed class HistoryObservedReceiverWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            _ = context.GetPropagatedHistory();
+            await context.CreateTimer(TimeSpan.Zero);
+            return await context.CallActivityAsync<int>(nameof(HistoryObservedChildActivity), input);
+        }
+    }
+
+    private sealed class HistoryObservedParentActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input + 3);
+    }
+
+    private sealed class HistoryObservedMiddleActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input + 2);
+    }
+
+    private sealed class HistoryObservedChildActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input * 2);
+    }
+
+    private sealed class ParallelChildObservedParentWorkflow : Workflow<int, int[]>
+    {
+        public override async Task<int[]> RunAsync(WorkflowContext context, int input)
+        {
+            var tasks = Enumerable.Range(1, input)
+                .Select(value => context.CallChildWorkflowAsync<int>(
+                    nameof(ParallelChildObservedChildWorkflow),
+                    value * 10,
+                    new ChildWorkflowTaskOptions(InstanceId: $"{context.InstanceId}-child-{value}")))
+                .ToArray();
+
+            return await Task.WhenAll(tasks);
+        }
+    }
+
+    private sealed class ParallelChildObservedChildWorkflow : Workflow<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowContext context, int input) =>
+            context.CallActivityAsync<int>(nameof(ParallelChildObservedActivity), input);
+    }
+
+    private sealed class ParallelChildObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input);
+    }
+
+    private sealed class TerminateObservedWorkflow : Workflow<int, int>
+    {
+        public override async Task<int> RunAsync(WorkflowContext context, int input)
+        {
+            await context.CallActivityAsync<int>(nameof(TerminateObservedActivity), input);
+            await context.WaitForExternalEventAsync<string>("never");
+            return -1;
+        }
+    }
+
+    private sealed class TerminateObservedActivity : WorkflowActivity<int, int>
+    {
+        public override Task<int> RunAsync(WorkflowActivityContext context, int input) =>
+            Task.FromResult(input);
+    }
+}

--- a/test/Dapr.Workflow.Test/Client/WorkflowGrpcClientTests.cs
+++ b/test/Dapr.Workflow.Test/Client/WorkflowGrpcClientTests.cs
@@ -16,6 +16,7 @@ using Dapr.Workflow.Client;
 using Dapr.Common.Serialization;
 using Dapr.Workflow.Serialization;
 using Grpc.Core;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
@@ -89,6 +90,73 @@ public class WorkflowGrpcClientTests
         Assert.NotNull(capturedRequest);
         Assert.NotNull(capturedRequest!.ScheduledStartTimestamp);
         Assert.Equal(startAt, capturedRequest.ScheduledStartTimestamp.ToDateTimeOffset());
+    }
+
+    [Fact]
+    public async Task ScheduleNewWorkflowAsync_ShouldSetParentTraceContext_WhenActivityCurrentIsW3C()
+    {
+        var serializer = new StubSerializer { SerializeResult = "" };
+
+        CreateInstanceRequest? capturedRequest = null;
+
+        var grpcClientMock = CreateGrpcClientMock();
+        grpcClientMock
+            .Setup(x => x.StartInstanceAsync(It.IsAny<CreateInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Callback<CreateInstanceRequest, CallOptions>((r, _) => capturedRequest = r)
+            .Returns(CreateAsyncUnaryCall(new CreateInstanceResponse { InstanceId = "returned" }));
+
+        var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
+
+        var previous = Activity.Current;
+        using var activity = new Activity("parent");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.TraceStateString = "vendor=value";
+        activity.Start();
+
+        try
+        {
+            await client.ScheduleNewWorkflowAsync("MyWorkflow", input: null, options: new StartWorkflowOptions { InstanceId = "i" }, cancellationToken: TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+
+        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedRequest!.ParentTraceContext);
+        Assert.Equal(activity.Id, capturedRequest.ParentTraceContext.TraceParent);
+        Assert.Equal(activity.TraceStateString, capturedRequest.ParentTraceContext.TraceState);
+    }
+
+    [Fact]
+    public async Task ScheduleNewWorkflowAsync_ShouldNotSetParentTraceContext_WhenActivityCurrentIsNull()
+    {
+        var serializer = new StubSerializer { SerializeResult = "" };
+
+        CreateInstanceRequest? capturedRequest = null;
+
+        var grpcClientMock = CreateGrpcClientMock();
+        grpcClientMock
+            .Setup(x => x.StartInstanceAsync(It.IsAny<CreateInstanceRequest>(), It.IsAny<CallOptions>()))
+            .Callback<CreateInstanceRequest, CallOptions>((r, _) => capturedRequest = r)
+            .Returns(CreateAsyncUnaryCall(new CreateInstanceResponse { InstanceId = "returned" }));
+
+        var client = new WorkflowGrpcClient(grpcClientMock.Object, NullLogger<WorkflowGrpcClient>.Instance, serializer);
+
+        var previous = Activity.Current;
+        Activity.Current = null;
+
+        try
+        {
+            await client.ScheduleNewWorkflowAsync("MyWorkflow", input: null, options: new StartWorkflowOptions { InstanceId = "i" }, cancellationToken: TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            Activity.Current = previous;
+        }
+
+        Assert.NotNull(capturedRequest);
+        Assert.Null(capturedRequest!.ParentTraceContext);
     }
 
     [Fact]

--- a/test/Dapr.Workflow.Test/Worker/WorkflowTraceTests.cs
+++ b/test/Dapr.Workflow.Test/Worker/WorkflowTraceTests.cs
@@ -58,7 +58,8 @@ public class WorkflowTraceTests
         ActivitySource.AddActivityListener(listener);
 
         const string expectedTraceId = "0af7651916cd43dd8448eb211c80319c";
-        const string traceParent = $"00-{expectedTraceId}-b7ad6b7169203331-01";
+        const string expectedParentSpanId = "b7ad6b7169203331";
+        const string traceParent = $"00-{expectedTraceId}-{expectedParentSpanId}-01";
         var events = new[]
         {
             new HistoryEvent
@@ -76,6 +77,7 @@ public class WorkflowTraceTests
 
         Assert.NotNull(Activity.Current);
         Assert.Equal(expectedTraceId, Activity.Current.TraceId.ToHexString());
+        Assert.Equal(expectedParentSpanId, Activity.Current.ParentSpanId.ToHexString());
         Assert.Equal(string.Empty, Activity.Current.Source.Name);
         Assert.Equal(0, startedCount);
     }


### PR DESCRIPTION
# Description

With the generous assistant in pinpointing the issue of otel tracing in `Dapr.Workflows`, this PR applies a patch to make such tracing automatic as part of the outbound gRPC calls.

But because this has been a recurring ticket, it also expands the `Dapr.Testcontainers` implementation to add a Zipkin endpoint to pull the telemetry from the Dapr runtime and validate that the tracing encompasses the appropriate spans for more than a dozen of the common Workflow scenarios to ensure that not only does this patch work, but to also prevent future regression.

This only targets Workflows because it's the only part of the SDK that shares work with the runtime. All other packages either defer entirely to the runtime or simply don't need their own tracing (preferring that the developer bring their own and auto-register transport, for example).

Once support for [head-less workflows](https://github.com/dapr/dotnet-sdk/issues/1866) is implemented (as is planned for the 1.19 release), this will be expanded to accommodate that scenario as well.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1867

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
