### PR TITLE
build: lift transitive SSH.NET above the GHSA-q939-rpr3-3284 vulnerable range

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,6 +59,10 @@
     <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.8" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="Testcontainers" Version="4.9.0" />
+    <!-- Transitive of Testcontainers; pinned directly until Testcontainers ships
+         a release depending on the patched line. SSH.NET <= 2025.1.0 carries
+         GHSA-q939-rpr3-3284 (high), which NU1903 promotes to a build error. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Dapr.Testcontainers/Dapr.Testcontainers.csproj
+++ b/src/Dapr.Testcontainers/Dapr.Testcontainers.csproj
@@ -10,6 +10,9 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Testcontainers" />
+        <!-- Direct reference solely to lift the transitive SSH.NET above the
+             GHSA-q939-rpr3-3284 vulnerable range. -->
+        <PackageReference Include="SSH.NET" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Testcontainers 4.9.0 depends on SSH.NET 2025.1.0, which is inside the vulnerable range of GHSA-q939-rpr3-3284 (high severity, ScpClient recursive download arbitrary file write). NuGet audit promotes that to error NU1903, which currently fails every job in CI, on master and on every open PR, since the advisory published.

Pin SSH.NET 2026.0.0 (the first patched version) centrally and reference it directly from Dapr.Testcontainers so the transitive edge resolves above the vulnerable range. The pin can be dropped once Testcontainers ships a release depending on the patched line.