### PR TITLE
Timezone accepted when scheduling jobs

### DIFF
--- a/src/Dapr.Jobs/CronExpressionBuilder.cs
+++ b/src/Dapr.Jobs/CronExpressionBuilder.cs
@@ -29,17 +29,24 @@ public sealed class CronExpressionBuilder
     private const string DayOfMonthRegexText = @"\*|(\*\/(([0-2]?\d)|(3[0-1])))|(((([0-2]?\d)|(3[0-1]))(-(([0-2]?\d)|(3[0-1])))?))";
     private const string MonthRegexText = @"(^(\*\/)?((0?\d)|(1[0-2]))$)|(^\*$)|(^((0?\d)|(1[0-2]))(-((0?\d)|(1[0-2]))?)$)|(^(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(?:-(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?(?:,(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(?:-(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?)*$)";
     private const string DayOfWeekRegexText = @"\*|(\*\/(0?[0-6])|(0?[0-6](-0?[0-6])?)|((,?(SUN|MON|TUE|WED|THU|FRI|SAT))+)|((SUN|MON|TUE|WED|THU|FRI|SAT)(-(SUN|MON|TUE|WED|THU|FRI|SAT))?))";
-    
-    private static readonly Regex cronExpressionRegex =
+
+    /// <summary>
+    /// The prefix used to associate an IANA timezone identifier with a Cron expression (e.g.
+    /// <c>CRON_TZ=Europe/Rome</c>), as supported by the Dapr Jobs runtime.
+    /// </summary>
+    private const string CronTimeZonePrefix = "CRON_TZ=";
+
+    private static readonly Regex CronExpressionRegex =
         new(
             $"{SecondsAndMinutesRegexText} {SecondsAndMinutesRegexText} {HoursRegexText} {DayOfMonthRegexText} {MonthRegexText} {DayOfWeekRegexText}", RegexOptions.Compiled);
-    
-    private string seconds = "*";
-    private string minutes = "*";
-    private string hours = "*";
-    private string dayOfMonth = "*";
-    private string month = "*";
-    private string dayOfWeek = "*";
+
+    private string _seconds = "*";
+    private string _minutes = "*";
+    private string _hours = "*";
+    private string _dayOfMonth = "*";
+    private string _month = "*";
+    private string _dayOfWeek = "*";
+    private string? _timeZone;
 
     /// <summary>
     /// Reflects an expression in which the developer specifies a series of numeric values and the period they're associated
@@ -64,16 +71,16 @@ public sealed class CronExpressionBuilder
         switch (period)
         {
             case OnCronPeriod.Second:
-                seconds = strValue;
+                _seconds = strValue;
                 break;
             case OnCronPeriod.Minute:
-                minutes = strValue;
+                _minutes = strValue;
                 break;
             case OnCronPeriod.Hour:
-                hours = strValue;
+                _hours = strValue;
                 break;
             case OnCronPeriod.DayOfMonth:
-                dayOfMonth = strValue;
+                _dayOfMonth = strValue;
                 break;
         }
 
@@ -86,7 +93,7 @@ public sealed class CronExpressionBuilder
     /// <param name="months">The months of the year to invoke the trigger on.</param>
     public CronExpressionBuilder On(params MonthOfYear[] months)
     {
-        month = string.Join(',', months.Distinct().OrderBy(a => a).Select(a => a.GetValueFromEnumMember()));
+        _month = string.Join(',', months.Distinct().OrderBy(a => a).Select(a => a.GetValueFromEnumMember()));
         return this;
     }
 
@@ -96,7 +103,7 @@ public sealed class CronExpressionBuilder
     /// <param name="days">The days of the week to invoke the trigger on.</param>
     public CronExpressionBuilder On(params DayOfWeek[] days)
     {
-        dayOfWeek = string.Join(',', days.Distinct().OrderBy(a => a).Select(a => a.GetValueFromEnumMember()));
+        _dayOfWeek = string.Join(',', days.Distinct().OrderBy(a => a).Select(a => a.GetValueFromEnumMember()));
         return this;
     }
 
@@ -123,19 +130,19 @@ public sealed class CronExpressionBuilder
         switch (period)
         {
             case ThroughCronPeriod.Second:
-                seconds = stringValue;
+                _seconds = stringValue;
                 break;
             case ThroughCronPeriod.Minute:
-                minutes = stringValue;
+                _minutes = stringValue;
                 break;
             case ThroughCronPeriod.Hour:
-                hours = stringValue;
+                _hours = stringValue;
                 break;
             case ThroughCronPeriod.DayOfMonth:
-                dayOfMonth = stringValue;
+                _dayOfMonth = stringValue;
                 break;
             case ThroughCronPeriod.Month:
-                month = stringValue;
+                _month = stringValue;
                 break;
         }
 
@@ -159,7 +166,7 @@ public sealed class CronExpressionBuilder
             throw new ArgumentException("The From and To properties should not be equivalent");
         }
 
-        dayOfWeek = $"{from.GetValueFromEnumMember()}-{to.GetValueFromEnumMember()}";
+        _dayOfWeek = $"{from.GetValueFromEnumMember()}-{to.GetValueFromEnumMember()}";
         return this;
     }
 
@@ -180,7 +187,7 @@ public sealed class CronExpressionBuilder
             throw new ArgumentException("The From and To properties should not be equivalent");
         }
 
-        month = $"{from.GetValueFromEnumMember()}-{to.GetValueFromEnumMember()}";
+        _month = $"{from.GetValueFromEnumMember()}-{to.GetValueFromEnumMember()}";
         return this;
     }
 
@@ -194,22 +201,22 @@ public sealed class CronExpressionBuilder
         switch (period)
         {
             case CronPeriod.Second:
-                seconds = "*";
+                _seconds = "*";
                 break;
             case CronPeriod.Minute:
-                minutes = "*";
+                _minutes = "*";
                 break;
             case CronPeriod.Hour:
-                hours = "*";
+                _hours = "*";
                 break;
             case CronPeriod.DayOfMonth:
-                dayOfMonth = "*";
+                _dayOfMonth = "*";
                 break;
             case CronPeriod.Month:
-                month = "*";
+                _month = "*";
                 break;
             case CronPeriod.DayOfWeek:
-                dayOfWeek = "*";
+                _dayOfWeek = "*";
                 break;
         }
 
@@ -234,22 +241,22 @@ public sealed class CronExpressionBuilder
         switch (period)
         {
             case EveryCronPeriod.Second:
-                seconds = value;
+                _seconds = value;
                 break;
             case EveryCronPeriod.Minute:
-                minutes = value;
+                _minutes = value;
                 break;
             case EveryCronPeriod.Hour:
-                hours = value;
+                _hours = value;
                 break;
             case EveryCronPeriod.Month:
-                month = value;
+                _month = value;
                 break;
             case EveryCronPeriod.DayInMonth:
-                dayOfMonth = value;
+                _dayOfMonth = value;
                 break;
             case EveryCronPeriod.DayInWeek:
-                dayOfWeek = value;
+                _dayOfWeek = value;
                 break;
         }
 
@@ -257,17 +264,86 @@ public sealed class CronExpressionBuilder
     }
 
     /// <summary>
+    /// Associates an IANA timezone identifier with the Cron expression. The Dapr Jobs runtime uses this
+    /// to evaluate the schedule in the specified timezone (e.g. <c>Europe/Rome</c>).
+    /// </summary>
+    /// <param name="timeZoneId">The IANA timezone identifier to associate with the expression.</param>
+    /// <returns></returns>
+    public CronExpressionBuilder WithTimeZone(string timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            throw new ArgumentException("A timezone identifier must be provided.", nameof(timeZoneId));
+        }
+
+        this._timeZone = timeZoneId;
+        return this;
+    }
+
+    /// <summary>
+    /// Associates a <see cref="TimeZoneInfo"/> with the Cron expression. The Dapr Jobs runtime uses this
+    /// to evaluate the schedule in the specified timezone.
+    /// </summary>
+    /// <param name="timezone">The timezone to associate with the expression.</param>
+    /// <returns></returns>
+    public CronExpressionBuilder WithTimeZone(TimeZoneInfo timezone)
+    {
+        ArgumentNullException.ThrowIfNull(timezone);
+        this._timeZone = timezone.Id;
+        return this;
+    }
+
+    /// <summary>
+    /// The timezone associated with the Cron expression, if any. This is exposed so that consumers
+    /// (such as <see cref="Models.DaprJobSchedule"/>) can persist the value alongside the expression.
+    /// </summary>
+    internal string? TimeZone => _timeZone;
+
+    /// <summary>
+    /// Removes a leading <c>CRON_TZ=&lt;tz&gt;</c> segment from the expression, if present, and returns
+    /// the remaining Cron expression along with the extracted timezone identifier.
+    /// </summary>
+    /// <param name="expression">The expression to evaluate.</param>
+    /// <param name="timeZone">When this method returns, contains the extracted timezone identifier if a
+    /// <c>CRON_TZ=</c> prefix was present; otherwise <c>null</c>.</param>
+    /// <returns>The expression with any leading <c>CRON_TZ=</c> segment removed.</returns>
+    internal static string TryStripCronTimeZone(string expression, out string? timeZone)
+    {
+        timeZone = null;
+        if (!expression.StartsWith(CronTimeZonePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return expression;
+        }
+
+        var spaceIndex = expression.IndexOf(' ');
+        if (spaceIndex <= CronTimeZonePrefix.Length)
+        {
+            return expression;
+        }
+
+        timeZone = expression.Substring(CronTimeZonePrefix.Length, spaceIndex - CronTimeZonePrefix.Length);
+        return expression[(spaceIndex + 1)..];
+
+    }
+
+    /// <summary>
     /// Validates whether a given expression is valid Cron syntax.
     /// </summary>
     /// <param name="expression">The string to evaluate.</param>
     /// <returns>True if the expression is valid Cron syntax; false if not.</returns>
-    internal static bool IsCronExpression(string expression) => expression.Split(' ').Length == 6 && cronExpressionRegex.IsMatch(expression);
+    internal static bool IsCronExpression(string expression)
+    {
+        var stripped = TryStripCronTimeZone(expression, out _);
+        return stripped.Split(' ').Length == 6 && CronExpressionRegex.IsMatch(stripped);
+    }
 
     /// <summary>
     /// Builds the Cron expression.
     /// </summary>
     /// <returns></returns>
-    public override string ToString() => $"{seconds} {minutes} {hours} {dayOfMonth} {month} {dayOfWeek}";
+    public override string ToString() => string.IsNullOrEmpty(_timeZone)
+        ? $"{_seconds} {_minutes} {_hours} {_dayOfMonth} {_month} {_dayOfWeek}"
+        : $"{CronTimeZonePrefix}{_timeZone} {_seconds} {_minutes} {_hours} {_dayOfMonth} {_month} {_dayOfWeek}";
 }
 
 /// <summary>

--- a/src/Dapr.Jobs/Models/DaprJobSchedule.cs
+++ b/src/Dapr.Jobs/Models/DaprJobSchedule.cs
@@ -37,7 +37,15 @@ public sealed partial class DaprJobSchedule
     /// The value of the expression represented by the schedule.
     /// </summary>
     public string ExpressionValue { get; }
-    
+
+    /// <summary>
+    /// The IANA timezone identifier associated with the schedule, if any. This is populated when a
+    /// <c>CRON_TZ=&lt;tz&gt;</c> segment is provided as part of a Cron expression (either through
+    /// <see cref="FromExpression"/> or via <see cref="FromCronExpression"/> using a
+    /// <see cref="CronExpressionBuilder"/> configured with <see cref="CronExpressionBuilder.WithTimeZone(string)"/>).
+    /// </summary>
+    public string? TimeZone { get; }
+
     /// <summary>
     /// Initializes the value of <see cref="ExpressionValue"/> based on the provided value from each of the factory methods.
     /// </summary>
@@ -47,7 +55,11 @@ public sealed partial class DaprJobSchedule
     /// <param name="expressionValue">The value of the scheduling expression.</param>
     internal DaprJobSchedule(string expressionValue)
     {
+        // Persist any timezone embedded in the expression as a CRON_TZ=<tz> segment so that it's
+        // available on the schedule independently of the expression string itself.
+        CronExpressionBuilder.TryStripCronTimeZone(expressionValue, out var timeZone);
         ExpressionValue = expressionValue;
+        TimeZone = timeZone;
     }
 
     /// <summary>

--- a/test/Dapr.IntegrationTest.Jobs/JobSchedulingTests.cs
+++ b/test/Dapr.IntegrationTest.Jobs/JobSchedulingTests.cs
@@ -230,4 +230,114 @@ public sealed class JobSchedulingTests
         var finalCount = await invocationTcs.Task.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
         Assert.Equal(3, finalCount);
     }
+
+    [MinimumDaprRuntimeFact("1.16")]
+    public async Task ShouldScheduleJobWithCronTimeZoneFromExpression()
+    {
+        var componentsDir = TestDirectoryManager.CreateTestDirectory("jobs-component");
+        var jobName = $"cron-tz-expr-job-{Guid.NewGuid():N}";
+
+        await using var environment = await DaprTestEnvironment.CreateWithPooledNetworkAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await environment.StartAsync(TestContext.Current.CancellationToken);
+
+        var harness = new DaprHarnessBuilder(componentsDir)
+            .WithEnvironment(environment)
+            .BuildJobs();
+        await using var testApp = await DaprHarnessBuilder.ForHarness(harness)
+            .ConfigureServices(builder =>
+            {
+                builder.Services.AddDaprJobsClient(configure: (sp, clientBuilder) =>
+                {
+                    var config = sp.GetRequiredService<IConfiguration>();
+                    var grpcEndpoint = config["DAPR_GRPC_ENDPOINT"];
+                    var httpEndpoint = config["DAPR_HTTP_ENDPOINT"];
+
+                    if (!string.IsNullOrEmpty(grpcEndpoint))
+                        clientBuilder.UseGrpcEndpoint(grpcEndpoint);
+                    if (!string.IsNullOrEmpty(httpEndpoint))
+                        clientBuilder.UseHttpEndpoint(httpEndpoint);
+                });
+            })
+            .BuildAndStartAsync();
+
+        using var scope = testApp.CreateScope();
+        var daprJobsClient = scope.ServiceProvider.GetRequiredService<DaprJobsClient>();
+
+        // Use a cron expression that fires far in the future (midnight on January 1st) so the job
+        // doesn't trigger during the test — we're only validating that the timezone is persisted
+        // and echoed back by the runtime when the job is retrieved.
+        const string timeZoneId = "Europe/Rome";
+        var schedule = DaprJobSchedule.FromExpression($"CRON_TZ={timeZoneId} 0 0 0 1 1 *");
+        Assert.Equal(timeZoneId, schedule.TimeZone);
+
+        await daprJobsClient.ScheduleJobAsync(jobName, schedule, overwrite: true, cancellationToken: TestContext.Current.CancellationToken);
+
+        var jobDetails = await daprJobsClient.GetJobAsync(jobName, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(jobDetails);
+        Assert.Equal(timeZoneId, jobDetails.Schedule.TimeZone);
+        Assert.Contains($"CRON_TZ={timeZoneId}", jobDetails.Schedule.ExpressionValue);
+        Assert.True(jobDetails.Schedule.IsCronExpression);
+
+        await daprJobsClient.DeleteJobAsync(jobName, TestContext.Current.CancellationToken);
+    }
+
+    [MinimumDaprRuntimeFact("1.16")]
+    public async Task ShouldScheduleJobWithCronTimeZoneFromBuilder()
+    {
+        var componentsDir = TestDirectoryManager.CreateTestDirectory("jobs-component");
+        var jobName = $"cron-tz-builder-job-{Guid.NewGuid():N}";
+
+        await using var environment = await DaprTestEnvironment.CreateWithPooledNetworkAsync(cancellationToken: TestContext.Current.CancellationToken);
+        await environment.StartAsync(TestContext.Current.CancellationToken);
+
+        var harness = new DaprHarnessBuilder(componentsDir)
+            .WithEnvironment(environment)
+            .BuildJobs();
+        await using var testApp = await DaprHarnessBuilder.ForHarness(harness)
+            .ConfigureServices(builder =>
+            {
+                builder.Services.AddDaprJobsClient(configure: (sp, clientBuilder) =>
+                {
+                    var config = sp.GetRequiredService<IConfiguration>();
+                    var grpcEndpoint = config["DAPR_GRPC_ENDPOINT"];
+                    var httpEndpoint = config["DAPR_HTTP_ENDPOINT"];
+
+                    if (!string.IsNullOrEmpty(grpcEndpoint))
+                        clientBuilder.UseGrpcEndpoint(grpcEndpoint);
+                    if (!string.IsNullOrEmpty(httpEndpoint))
+                        clientBuilder.UseHttpEndpoint(httpEndpoint);
+                });
+            })
+            .BuildAndStartAsync();
+
+        using var scope = testApp.CreateScope();
+        var daprJobsClient = scope.ServiceProvider.GetRequiredService<DaprJobsClient>();
+
+        // Use a cron expression that fires far in the future (midnight on January 1st) so the job
+        // doesn't trigger during the test — we're only validating that the timezone configured via
+        // the fluent builder is persisted and echoed back by the runtime when the job is retrieved.
+        const string timeZoneId = "Europe/Rome";
+        var cronSchedule = new CronExpressionBuilder()
+            .On(OnCronPeriod.Second, 0)
+            .On(OnCronPeriod.Minute, 0)
+            .On(OnCronPeriod.Hour, 0)
+            .On(OnCronPeriod.DayOfMonth, 1)
+            .On(MonthOfYear.January)
+            .WithTimeZone(timeZoneId);
+
+        var schedule = DaprJobSchedule.FromCronExpression(cronSchedule);
+        Assert.Equal(timeZoneId, schedule.TimeZone);
+
+        await daprJobsClient.ScheduleJobAsync(jobName, schedule, overwrite: true, cancellationToken: TestContext.Current.CancellationToken);
+
+        var jobDetails = await daprJobsClient.GetJobAsync(jobName, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(jobDetails);
+        Assert.Equal(timeZoneId, jobDetails.Schedule.TimeZone);
+        Assert.Contains($"CRON_TZ={timeZoneId}", jobDetails.Schedule.ExpressionValue);
+        Assert.True(jobDetails.Schedule.IsCronExpression);
+
+        await daprJobsClient.DeleteJobAsync(jobName, TestContext.Current.CancellationToken);
+    }
 }

--- a/test/Dapr.Jobs.Test/CronExpressionBuilderTests.cs
+++ b/test/Dapr.Jobs.Test/CronExpressionBuilderTests.cs
@@ -377,9 +377,92 @@ public sealed class CronExpressionBuilderTests
     [InlineData("00-59 0-59 00-23 1-31 JAN-DEC SUN-SAT", true)]
     [InlineData("0-59 0-59 0-23 1-31 1-12 0-6", true)]
     [InlineData("*/1 2,4,5 * 2-9 JAN,FEB,DEC MON-WED", true)]
+    [InlineData("CRON_TZ=Europe/Rome 0 */5 * * * *", true)]
+    [InlineData("CRON_TZ=America/New_York 30 15 6 */4 JAN,APR,AUG WED-FRI", true)]
+    [InlineData("CRON_TZ=Asia/Kolkata 0 0 0 * * *", true)]
+    [InlineData("CRON_TZ=UTC * * * * * *", true)]
+    [InlineData("cron_tz=Europe/Rome 0 */5 * * * *", true)]
+    [InlineData("CRON_TZ=Europe/Rome 0 */5 * * *", false)]
+    [InlineData("CRON_TZ=Europe/Rome", false)]
+    [InlineData("CRON_TZ= 0 */5 * * * *", false)]
     public void ValidateCronExpression(string cronValue, bool isValid)
     {
         var result = CronExpressionBuilder.IsCronExpression(cronValue);
         Assert.Equal(result, isValid);
+    }
+
+    [Fact]
+    public void WithTimeZone_PrependsCronTzSegment()
+    {
+        var builder = new CronExpressionBuilder()
+            .Every(EveryCronPeriod.Minute, 5)
+            .WithTimeZone("Europe/Rome");
+
+        var result = builder.ToString();
+        Assert.Equal("CRON_TZ=Europe/Rome * */5 * * * *", result);
+    }
+
+    [Fact]
+    public void WithoutTimeZone_OmitsCronTzSegment()
+    {
+        var builder = new CronExpressionBuilder()
+            .Every(EveryCronPeriod.Minute, 5);
+
+        var result = builder.ToString();
+        Assert.Equal("* */5 * * * *", result);
+    }
+
+    [Fact]
+    public void WithTimeZone_PersistsTimeZoneProperty()
+    {
+        var builder = new CronExpressionBuilder()
+            .WithTimeZone("Europe/Rome");
+
+        Assert.Equal("Europe/Rome", builder.TimeZone);
+    }
+
+    [Fact]
+    public void WithTimeZone_FromTimeZoneInfo_PersistsId()
+    {
+        var builder = new CronExpressionBuilder()
+            .WithTimeZone(TimeZoneInfo.Utc);
+
+        Assert.Equal(TimeZoneInfo.Utc.Id, builder.TimeZone);
+        Assert.Equal($"CRON_TZ={TimeZoneInfo.Utc.Id} * * * * * *", builder.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WithTimeZone_ThrowsWhenIdentifierIsMissing(string timeZoneId)
+    {
+        Assert.Throws<ArgumentException>(() => new CronExpressionBuilder().WithTimeZone(timeZoneId));
+    }
+
+    [Fact]
+    public void WithTimeZone_ThrowsWhenTimeZoneInfoIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CronExpressionBuilder().WithTimeZone((TimeZoneInfo)null!));
+    }
+
+    [Fact]
+    public void TryStripCronTimeZone_ExtractsTimezoneAndRemainingExpression()
+    {
+        var remaining = CronExpressionBuilder.TryStripCronTimeZone(
+            "CRON_TZ=Europe/Rome 0 */5 * * * *", out var timeZone);
+
+        Assert.Equal("Europe/Rome", timeZone);
+        Assert.Equal("0 */5 * * * *", remaining);
+    }
+
+    [Fact]
+    public void TryStripCronTimeZone_ReturnsExpressionWhenNoTimezonePresent()
+    {
+        const string expression = "0 */5 * * * *";
+        var remaining = CronExpressionBuilder.TryStripCronTimeZone(expression, out var timeZone);
+
+        Assert.Null(timeZone);
+        Assert.Equal(expression, remaining);
     }
 }

--- a/test/Dapr.Jobs.Test/DaprJobsGrpcClientTests.cs
+++ b/test/Dapr.Jobs.Test/DaprJobsGrpcClientTests.cs
@@ -182,4 +182,17 @@ public sealed class DaprJobsGrpcClientTests
         Assert.Null(jobDetails.DueTime);
         Assert.Equal(jobDetails.Schedule.ExpressionValue, schedule.ExpressionValue);
     }
+
+    [Fact]
+    public void ShouldDeserialize_CronTzExpression_PersistsTimezone()
+    {
+        const string scheduleText = "CRON_TZ=Europe/Rome 0 */5 * * * *";
+        var response = new GetJobResponse { Job = new Job { Name = "test", Schedule = scheduleText } };
+
+        var jobDetails = DaprJobsGrpcClient.DeserializeJobResponse(response);
+
+        Assert.Equal(scheduleText, jobDetails.Schedule.ExpressionValue);
+        Assert.Equal("Europe/Rome", jobDetails.Schedule.TimeZone);
+        Assert.True(jobDetails.Schedule.IsCronExpression);
+    }
 }

--- a/test/Dapr.Jobs.Test/Models/DaprJobScheduleTests.cs
+++ b/test/Dapr.Jobs.Test/Models/DaprJobScheduleTests.cs
@@ -177,4 +177,79 @@ public sealed class DaprJobScheduleTests
         Assert.False(schedule.IsPointInTimeExpression);
         Assert.False(schedule.IsDurationExpression);
     }
+
+    [Fact]
+    public void FromExpression_PersistsTimezoneFromCronTzExpression()
+    {
+        const string expression = "CRON_TZ=Europe/Rome 0 */5 * * * *";
+        var schedule = DaprJobSchedule.FromExpression(expression);
+
+        Assert.Equal(expression, schedule.ExpressionValue);
+        Assert.Equal("Europe/Rome", schedule.TimeZone);
+        Assert.True(schedule.IsCronExpression);
+        Assert.False(schedule.IsPrefixedPeriodExpression);
+        Assert.False(schedule.IsPointInTimeExpression);
+        Assert.False(schedule.IsDurationExpression);
+    }
+
+    [Theory]
+    [InlineData("CRON_TZ=Europe/Rome 0 */5 * * * *")]
+    [InlineData("CRON_TZ=America/New_York 30 15 6 */4 JAN,APR,AUG WED-FRI")]
+    [InlineData("CRON_TZ=UTC * * * * * *")]
+    [InlineData("cron_tz=Asia/Kolkata 0 0 0 * * *")]
+    public void FromExpression_CronTzExpressionsAreCronExpressions(string expression)
+    {
+        var schedule = DaprJobSchedule.FromExpression(expression);
+        Assert.True(schedule.IsCronExpression);
+        Assert.NotNull(schedule.TimeZone);
+    }
+
+    [Fact]
+    public void FromExpression_WithoutTimezoneHasNullTimeZone()
+    {
+        var schedule = DaprJobSchedule.FromExpression("0 */5 * * * *");
+        Assert.Null(schedule.TimeZone);
+    }
+
+    [Fact]
+    public void FromCronExpression_PersistsTimezoneFromBuilder()
+    {
+        var builder = new CronExpressionBuilder()
+            .Every(EveryCronPeriod.Minute, 5)
+            .WithTimeZone("Europe/Rome");
+
+        var schedule = DaprJobSchedule.FromCronExpression(builder);
+
+        Assert.Equal("CRON_TZ=Europe/Rome * */5 * * * *", schedule.ExpressionValue);
+        Assert.Equal("Europe/Rome", schedule.TimeZone);
+        Assert.True(schedule.IsCronExpression);
+    }
+
+    [Fact]
+    public void FromCronExpression_WithoutTimezoneHasNullTimeZone()
+    {
+        var builder = new CronExpressionBuilder()
+            .Every(EveryCronPeriod.Minute, 5);
+
+        var schedule = DaprJobSchedule.FromCronExpression(builder);
+
+        Assert.Equal("* */5 * * * *", schedule.ExpressionValue);
+        Assert.Null(schedule.TimeZone);
+    }
+
+    [Fact]
+    public void PrefixedAndDurationAndPointInTimeSchedulesHaveNullTimeZone()
+    {
+        Assert.Null(DaprJobSchedule.Weekly.TimeZone);
+        Assert.Null(DaprJobSchedule.FromDuration(TimeSpan.FromHours(2)).TimeZone);
+        Assert.Null(DaprJobSchedule.FromDateTime(DateTimeOffset.UtcNow.AddDays(2)).TimeZone);
+    }
+
+    [Fact]
+    public void InternalConstructor_ParsesTimezoneFromExpression()
+    {
+        var schedule = new DaprJobSchedule("CRON_TZ=Europe/Rome 0 */5 * * * *");
+        Assert.Equal("Europe/Rome", schedule.TimeZone);
+        Assert.Equal("CRON_TZ=Europe/Rome 0 */5 * * * *", schedule.ExpressionValue);
+    }
 }


### PR DESCRIPTION
# Description

Users can provide the timezone in which the job should be scheduled via either the builder, the `DaprJobScheduler` or when passing in a raw Cron expression and it will be passed through to the runtime now.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #1883

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Created/updated tests
* [ ] Extended the documentation
