### PR TITLE
Don't send binary grpc-trace-bin header on InvokeBinding calls

### DIFF
--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -349,6 +349,11 @@ internal class DaprClientGrpc : DaprClient
         }
 
         var options = CreateCallOptions(headers: null, cancellationToken);
+
+        // The sidecar forwards this call's metadata verbatim into the output binding component's metadata
+        // (e.g. Azure Blob/Service Bus properties), which must be valid UTF-8 text, so strip any binary
+        // ("-bin" suffixed) gRPC metadata such as grpc-trace-bin before it can be misrouted there.
+        RemoveBinaryMetadata(options.Headers);
         try
         {
             return await client.InvokeBindingAsync(envelope, options);
@@ -2306,6 +2311,17 @@ internal class DaprClientGrpc : DaprClient
         }
 
         return options;
+    }
+
+    private static void RemoveBinaryMetadata(Metadata headers)
+    {
+        for (var i = headers.Count - 1; i >= 0; i--)
+        {
+            if (headers[i].Key.EndsWith("-bin", StringComparison.OrdinalIgnoreCase))
+            {
+                headers.RemoveAt(i);
+            }
+        }
     }
 
     /// <summary>

--- a/test/Dapr.Client.Test/InvokeBindingApiTest.cs
+++ b/test/Dapr.Client.Test/InvokeBindingApiTest.cs
@@ -16,6 +16,7 @@ namespace Dapr.Client.Test;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -156,6 +157,37 @@ public class InvokeBindingApiTest
             });
     }
 
+
+    [Fact]
+    public async Task InvokeBindingAsync_DoesNotSendBinaryTraceContextHeader()
+    {
+        await using var client = TestClient.CreateForDaprClient();
+
+        var previousActivity = Activity.Current;
+        using var activity = new Activity("test-binding");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.Start();
+
+        try
+        {
+            var invokeRequest = new InvokeRequest() { RequestParameter = "Hello " };
+            var request = await client.CaptureGrpcRequestAsync(async daprClient =>
+            {
+                await daprClient.InvokeBindingAsync<InvokeRequest>("test", "create", invokeRequest);
+            });
+
+            request.Dismiss();
+
+            // The sidecar forwards this call's metadata verbatim into the output binding's component metadata,
+            // which must be valid UTF-8, so the binary grpc-trace-bin header must not be sent for InvokeBinding.
+            request.Request.Headers.Contains("grpc-trace-bin").ShouldBeFalse();
+            request.Request.Headers.Contains("traceparent").ShouldBeTrue();
+        }
+        finally
+        {
+            Activity.Current = previousActivity;
+        }
+    }
 
     [Fact]
     public async Task InvokeBindingAsync_WithCancelledToken()


### PR DESCRIPTION
Closes #1897

InvokeBindingAsync was sending the binary grpc-trace-bin header (added in #1858) on every call. The sidecar forwards a call's incoming metadata verbatim into the invoked binding component's metadata, and components like Azure Blob Storage and Service Bus require that metadata to be valid UTF-8 text. Since grpc-trace-bin's bytes come from the random trace/span ID, this caused intermittent failures - Blob request signing broke (403 AuthenticationFailed) and Service Bus rejected the message outright (
ot a valid UTF-8 string).

This strips any binary (-bin suffixed) gRPC metadata from the call options right before invoking InvokeBinding, so it can't be forwarded into binding component metadata regardless of source. 	raceparent/	racestate are still sent since they're plain text and don't cause this issue.

Root cause is really in the runtime (InvokeBinding shouldn't forward binary metadata into component metadata at all) - tracked in dapr/dapr#10387. This is a client-side mitigation so .NET SDK users aren't affected while that's being worked on.

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation