### PR TITLE
Do not send binary gRPC metadata on InvokeBinding calls

### DIFF
--- a/src/Dapr.Client/DaprClientGrpc.cs
+++ b/src/Dapr.Client/DaprClientGrpc.cs
@@ -349,6 +349,7 @@ internal class DaprClientGrpc : DaprClient
         }
 
         var options = CreateCallOptions(headers: null, cancellationToken);
+        RemoveBinaryMetadata(options.Headers);
         try
         {
             return await client.InvokeBindingAsync(envelope, options);
@@ -2306,6 +2307,28 @@ internal class DaprClientGrpc : DaprClient
         }
 
         return options;
+    }
+
+    /// <summary>
+    /// Removes binary gRPC metadata entries (keys ending in "-bin", such as grpc-trace-bin) because
+    /// the runtime copies InvokeBinding call metadata into string binding component metadata, where
+    /// raw bytes break components that require text values. Trace context still propagates via the
+    /// traceparent and tracestate headers.
+    /// </summary>
+    private static void RemoveBinaryMetadata(Metadata headers)
+    {
+        if (headers is null)
+        {
+            return;
+        }
+
+        for (var i = headers.Count - 1; i >= 0; i--)
+        {
+            if (headers[i].Key.EndsWith("-bin", StringComparison.OrdinalIgnoreCase))
+            {
+                headers.RemoveAt(i);
+            }
+        }
     }
 
     /// <summary>

--- a/test/Dapr.Client.Test/InvokeBindingApiTest.cs
+++ b/test/Dapr.Client.Test/InvokeBindingApiTest.cs
@@ -16,6 +16,7 @@ namespace Dapr.Client.Test;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -156,6 +157,36 @@ public class InvokeBindingApiTest
             });
     }
 
+    [Fact]
+    public async Task InvokeBindingAsync_StripsBinaryHeadersButKeepsTraceparent()
+    {
+        await using var client = TestClient.CreateForDaprClient();
+
+        var previousActivity = Activity.Current;
+        using var activity = new Activity("test-binding");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.Start();
+
+        try
+        {
+            var invokeRequest = new InvokeRequest() { RequestParameter = "Hello " };
+            var request = await client.CaptureGrpcRequestAsync(async daprClient =>
+            {
+                await daprClient.InvokeBindingAsync<InvokeRequest>("test", "create", invokeRequest);
+            });
+
+            request.Dismiss();
+
+            // The runtime copies InvokeBinding call metadata into string binding component metadata,
+            // which must be valid text, so binary (-bin) gRPC metadata must not be sent on this call.
+            request.Request.Headers.Any(h => h.Key.EndsWith("-bin", StringComparison.OrdinalIgnoreCase)).ShouldBeFalse();
+            request.Request.Headers.Contains("traceparent").ShouldBeTrue();
+        }
+        finally
+        {
+            Activity.Current = previousActivity;
+        }
+    }
 
     [Fact]
     public async Task InvokeBindingAsync_WithCancelledToken()


### PR DESCRIPTION
Strip -bin suffixed gRPC metadata from InvokeBinding call options before sending. Trace context still propagates via the traceparent and tracestate text headers, and all other APIs keep sending grpc-trace-bin. This is a client-side mitigation for runtimes without the fix from dapr/dapr#10387.

Fixes #1897
