### PR TITLE
Make Actors.Next runtime option defaults nullable and unset

### DIFF
--- a/src/Dapr.Actors.Next.Abstractions/Options/DaprActorsOptions.cs
+++ b/src/Dapr.Actors.Next.Abstractions/Options/DaprActorsOptions.cs
@@ -52,18 +52,21 @@ public sealed class DaprActorsOptions
 
     /// <summary>
     /// Gets or sets the idle timeout for actor activations.
+    /// <see langword="null"/> leaves the value unset so the Dapr runtime default applies.
     /// </summary>
-    public TimeSpan ActorIdleTimeout { get; set; } = TimeSpan.FromMinutes(60);
+    public TimeSpan? ActorIdleTimeout { get; set; }
 
     /// <summary>
     /// Gets or sets the timeout used when draining ongoing actor calls.
+    /// <see langword="null"/> leaves the value unset so the Dapr runtime default applies.
     /// </summary>
-    public TimeSpan DrainOngoingCallTimeout { get; private set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan? DrainOngoingCallTimeout { get; set; }
 
     /// <summary>
     /// Gets or sets the timeout used when draining rebalanced actors.
+    /// <see langword="null"/> leaves the value unset so the Dapr runtime default applies.
     /// </summary>
-    public TimeSpan DrainRebalancedActorsTimeout
+    public TimeSpan? DrainRebalancedActorsTimeout
     {
         get => DrainOngoingCallTimeout;
         set => DrainOngoingCallTimeout = value;
@@ -71,13 +74,15 @@ public sealed class DaprActorsOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether rebalanced actors drain in-flight calls.
+    /// <see langword="null"/> leaves the value unset so the Dapr runtime default applies.
     /// </summary>
-    public bool DrainRebalancedActors { get; set; } = true;
+    public bool? DrainRebalancedActors { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether reentrant actor calls are allowed.
+    /// <see langword="null"/> leaves the value unset so the Dapr runtime default applies.
     /// </summary>
-    public bool EnableReentrancy { get; set; }
+    public bool? EnableReentrancy { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the sidecar (gRPC) transport is used for actor state,
@@ -90,8 +95,9 @@ public sealed class DaprActorsOptions
 
     /// <summary>
     /// Gets or sets the maximum reentrant call depth when reentrancy is enabled.
+    /// <see langword="null"/> leaves the value unset so the Dapr runtime default applies.
     /// </summary>
-    public int MaxReentrantDepth { get; set; } = 32;
+    public int? MaxReentrantDepth { get; set; }
 
     internal void CopyFrom(DaprActorsOptions source)
     {

--- a/src/Dapr.Actors.Next.Abstractions/Options/DaprActorsOptionsValidator.cs
+++ b/src/Dapr.Actors.Next.Abstractions/Options/DaprActorsOptionsValidator.cs
@@ -26,10 +26,10 @@ public sealed class DaprActorsOptionsValidator : IValidateOptions<DaprActorsOpti
         List<string>? failures = null;
 
         AddFailureIf(options.DefaultContractVersion <= 0, "DefaultContractVersion must be greater than zero.", ref failures);
-        AddFailureIf(options.ActorIdleTimeout <= TimeSpan.Zero, "ActorIdleTimeout must be greater than zero.", ref failures);
-        AddFailureIf(options.DrainOngoingCallTimeout <= TimeSpan.Zero, "DrainOngoingCallTimeout must be greater than zero.", ref failures);
-        AddFailureIf(options.DrainRebalancedActorsTimeout <= TimeSpan.Zero, "DrainRebalancedActorsTimeout must be greater than zero.", ref failures);
-        AddFailureIf(options.MaxReentrantDepth <= 0, "MaxReentrantDepth must be greater than zero.", ref failures);
+        AddFailureIf(options.ActorIdleTimeout is { } globalIdleTimeout && globalIdleTimeout <= TimeSpan.Zero, "ActorIdleTimeout must be greater than zero.", ref failures);
+        AddFailureIf(options.DrainOngoingCallTimeout is { } globalDrainTimeout && globalDrainTimeout <= TimeSpan.Zero, "DrainOngoingCallTimeout must be greater than zero.", ref failures);
+        AddFailureIf(options.DrainRebalancedActorsTimeout is { } globalDrainRebalancedTimeout && globalDrainRebalancedTimeout <= TimeSpan.Zero, "DrainRebalancedActorsTimeout must be greater than zero.", ref failures);
+        AddFailureIf(options.MaxReentrantDepth is { } globalMaxDepth && globalMaxDepth <= 0, "MaxReentrantDepth must be greater than zero.", ref failures);
 
         foreach (var registration in options.Actors.Registrations)
         {

--- a/src/Dapr.Actors.Next.Core/Transport/DaprActorEventsTransport.cs
+++ b/src/Dapr.Actors.Next.Core/Transport/DaprActorEventsTransport.cs
@@ -240,17 +240,38 @@ public sealed class DaprActorEventsTransport : ISubscribeActorEventsTransport
                 return request;
             }
 
-            var entityConfig = new P.ActorEntityConfig
+            // Only assign fields the app configured; unset fields keep their
+            // Dapr runtime defaults.
+            var entityConfig = new P.ActorEntityConfig();
+
+            if (config.ActorIdleTimeout is { } idleTimeout)
             {
-                ActorIdleTimeout = Duration.FromTimeSpan(config.ActorIdleTimeout),
-                DrainOngoingCallTimeout = Duration.FromTimeSpan(config.DrainOngoingCallTimeout),
-                DrainRebalancedActors = config.DrainRebalancedActors,
-                Reentrancy = new P.ActorReentrancyConfig
+                entityConfig.ActorIdleTimeout = Duration.FromTimeSpan(idleTimeout);
+            }
+
+            if (config.DrainOngoingCallTimeout is { } drainTimeout)
+            {
+                entityConfig.DrainOngoingCallTimeout = Duration.FromTimeSpan(drainTimeout);
+            }
+
+            if (config.DrainRebalancedActors is { } drainRebalanced)
+            {
+                entityConfig.DrainRebalancedActors = drainRebalanced;
+            }
+
+            if (config.EnableReentrancy is not null || config.MaxReentrantDepth is not null)
+            {
+                var reentrancy = new P.ActorReentrancyConfig
                 {
-                    Enabled = config.EnableReentrancy,
-                    MaxStackDepth = config.MaxReentrantDepth,
-                },
-            };
+                    Enabled = config.EnableReentrancy ?? false,
+                };
+                if (config.MaxReentrantDepth is { } maxDepth)
+                {
+                    reentrancy.MaxStackDepth = maxDepth;
+                }
+                entityConfig.Reentrancy = reentrancy;
+            }
+
             entityConfig.Entities.Add(request.Entities);
             request.EntitiesConfig.Add(entityConfig);
             return request;

--- a/src/Dapr.Actors.Next.Core/Transport/SubscribeActorEventsResponse.cs
+++ b/src/Dapr.Actors.Next.Core/Transport/SubscribeActorEventsResponse.cs
@@ -66,10 +66,12 @@ public sealed record SubscribeActorEventsResponse(
 
 /// <summary>
 /// Runtime options advertised with the initial actor event stream registration.
+/// A <see langword="null"/> value leaves that field unset on the wire so the
+/// Dapr runtime default applies.
 /// </summary>
 public sealed record SubscribeActorEventsInitialConfig(
-    TimeSpan ActorIdleTimeout,
-    TimeSpan DrainOngoingCallTimeout,
-    bool DrainRebalancedActors,
-    bool EnableReentrancy,
-    int MaxReentrantDepth);
+    TimeSpan? ActorIdleTimeout,
+    TimeSpan? DrainOngoingCallTimeout,
+    bool? DrainRebalancedActors,
+    bool? EnableReentrancy,
+    int? MaxReentrantDepth);

--- a/test/Dapr.Actors.Next.Abstractions.Test/OptionsTests.cs
+++ b/test/Dapr.Actors.Next.Abstractions.Test/OptionsTests.cs
@@ -147,6 +147,21 @@ public sealed class OptionsTests
     }
 
     [MinimumDaprRuntimeFact("1.18")]
+    public void Options_DrainRebalancedActorsTimeout_AliasesDrainOngoingCallTimeout()
+    {
+        var options = new DaprActorsOptions();
+        Assert.Null(options.DrainOngoingCallTimeout);
+        Assert.Null(options.DrainRebalancedActorsTimeout);
+
+        options.DrainRebalancedActorsTimeout = TimeSpan.FromSeconds(7);
+        Assert.Equal(TimeSpan.FromSeconds(7), options.DrainOngoingCallTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(7), options.DrainRebalancedActorsTimeout);
+
+        options.DrainOngoingCallTimeout = null;
+        Assert.Null(options.DrainRebalancedActorsTimeout);
+    }
+
+    [MinimumDaprRuntimeFact("1.18")]
     public void TypeOptions_DrainRebalancedActorsTimeout_AliasesDrainOngoingCallTimeout()
     {
         var typeOptions = new DaprActorTypeOptions();

--- a/test/Dapr.Actors.Next.Core.Test/CoreRuntimeTests.cs
+++ b/test/Dapr.Actors.Next.Core.Test/CoreRuntimeTests.cs
@@ -117,11 +117,11 @@ public sealed class CoreRuntimeTests
 
         var config = advertisement.InitialConfig;
         Assert.NotNull(config);
-        Assert.Equal(TimeSpan.FromMinutes(60), config!.ActorIdleTimeout);
-        Assert.Equal(TimeSpan.FromSeconds(30), config.DrainOngoingCallTimeout);
-        Assert.True(config.DrainRebalancedActors);
-        Assert.False(config.EnableReentrancy);
-        Assert.Equal(32, config.MaxReentrantDepth);
+        Assert.Null(config!.ActorIdleTimeout);
+        Assert.Null(config.DrainOngoingCallTimeout);
+        Assert.Null(config.DrainRebalancedActors);
+        Assert.Null(config.EnableReentrancy);
+        Assert.Null(config.MaxReentrantDepth);
     }
 
     [MinimumDaprRuntimeFact("1.18")]
@@ -151,17 +151,17 @@ public sealed class CoreRuntimeTests
         var overridden = advertisements["Counter"].InitialConfig;
         Assert.NotNull(overridden);
         Assert.Equal(TimeSpan.FromMinutes(2), overridden!.ActorIdleTimeout);
-        Assert.Equal(TimeSpan.FromSeconds(30), overridden.DrainOngoingCallTimeout);
-        Assert.True(overridden.DrainRebalancedActors);
+        Assert.Null(overridden.DrainOngoingCallTimeout);
+        Assert.Null(overridden.DrainRebalancedActors);
         Assert.True(overridden.EnableReentrancy);
         Assert.Equal(8, overridden.MaxReentrantDepth);
 
         var inherited = advertisements["OtherCounter"].InitialConfig;
         Assert.NotNull(inherited);
         Assert.Equal(TimeSpan.FromMinutes(10), inherited!.ActorIdleTimeout);
-        Assert.Equal(TimeSpan.FromSeconds(30), inherited.DrainOngoingCallTimeout);
-        Assert.True(inherited.DrainRebalancedActors);
-        Assert.False(inherited.EnableReentrancy);
+        Assert.Null(inherited.DrainOngoingCallTimeout);
+        Assert.Null(inherited.DrainRebalancedActors);
+        Assert.Null(inherited.EnableReentrancy);
         Assert.Equal(8, inherited.MaxReentrantDepth);
     }
 
@@ -193,7 +193,7 @@ public sealed class CoreRuntimeTests
         Assert.Equal(TimeSpan.FromMinutes(1), merged!.ActorIdleTimeout);
         Assert.Equal(TimeSpan.FromSeconds(7), merged.DrainOngoingCallTimeout);
         Assert.False(merged.DrainRebalancedActors);
-        Assert.False(merged.EnableReentrancy);
+        Assert.Null(merged.EnableReentrancy);
         Assert.Equal(3, merged.MaxReentrantDepth);
     }
 

--- a/test/Dapr.Actors.Next.Core.Test/GeneratedActorEventsTransportTests.cs
+++ b/test/Dapr.Actors.Next.Core.Test/GeneratedActorEventsTransportTests.cs
@@ -117,6 +117,32 @@ public sealed class GeneratedActorEventsTransportTests
     }
 
     [MinimumDaprRuntimeFact("1.18")]
+    public async Task Transport_omits_unset_fields_in_initial_config()
+    {
+        var harness = new GeneratedActorEventsHarness();
+        var transport = new DaprActorEventsTransport(harness.Client);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await using var stream = await transport.OpenStreamAsync(cts.Token);
+        await stream.WriteAsync(SubscribeActorEventsResponse.RegisteredActors(
+            ["Sparse"],
+            new SubscribeActorEventsInitialConfig(
+                null,
+                TimeSpan.FromSeconds(5),
+                null,
+                null,
+                null)), cts.Token);
+        var initial = await harness.ReceiveAsync(cts.Token);
+
+        var entityConfig = Assert.Single(initial.InitialRequest.EntitiesConfig);
+        Assert.Equal(new[] { "Sparse" }, entityConfig.Entities.ToArray());
+        Assert.Null(entityConfig.ActorIdleTimeout);
+        Assert.Equal(5, entityConfig.DrainOngoingCallTimeout.Seconds);
+        Assert.False(entityConfig.HasDrainRebalancedActors);
+        Assert.Null(entityConfig.Reentrancy);
+    }
+
+    [MinimumDaprRuntimeFact("1.18")]
     public async Task Transport_maps_failures_and_non_invoke_callbacks()
     {
         var harness = new GeneratedActorEventsHarness();

--- a/test/Dapr.IntegrationTest.Actors.Next/RealSidecarActorTests.cs
+++ b/test/Dapr.IntegrationTest.Actors.Next/RealSidecarActorTests.cs
@@ -164,6 +164,7 @@ public sealed class RealSidecarActorTests : IAsyncLifetime
         builder.Services.AddDaprActors(options =>
         {
             options.DrainRebalancedActorsTimeout = TimeSpan.FromSeconds(1);
+            options.DrainRebalancedActors = true;
             options.EnableReentrancy = true;
             options.MaxReentrantDepth = 8;
         });


### PR DESCRIPTION
The app-wide DaprActorsOptions forced SDK-side defaults for every runtime option and sent them unconditionally on the actor event stream, so the Dapr runtime defaults could never apply. Most notably DrainOngoingCallTimeout was hard-coded to 30 seconds, which sits exactly at the daprd drain clamp boundary (80% of the 30 second dissemination timeout) and above the placement service's 8 second dissemination deadline, causing configured-looking values the app never chose.

Make ActorIdleTimeout, DrainOngoingCallTimeout (and its DrainRebalancedActorsTimeout alias), DrainRebalancedActors, EnableReentrancy, and MaxReentrantDepth nullable with no default. Null means unset: the field is omitted from the wire and the Dapr runtime default applies, matching the classic Dapr.Actors behaviour and the existing per-type DaprActorTypeOptions contract. This also drops the private setter on DrainOngoingCallTimeout, which previously made the alias the only way to set it.

The transport now assigns only configured fields on ActorEntityConfig (all proto fields are optional with explicit presence), and emits the reentrancy config only when reentrancy options are set. The validator skips unset values using the same pattern as the per-type rules. SubscribeActorEventsInitialConfig is widened to nullable accordingly; Actors.Next is not packable so there is no shipped API surface break